### PR TITLE
Fix a closed I/O stream error in `run_tests_testingfarm.py`

### DIFF
--- a/tests/run_tests_testingfarm.py
+++ b/tests/run_tests_testingfarm.py
@@ -133,9 +133,9 @@ def main():
 
         logger.info("Test execution completed!")
 
-    # Log final output locations
-    logger.info(f"Results written to: {output_results}")
-    logger.info(f"Test files in: {output_files}")
+        # Log final output locations
+        logger.info(f"Results written to: {output_results}")
+        logger.info(f"Test files in: {output_files}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Description:

The problem is that the code does
```python
def setup_logging():
    debug_log_fobj = gzip.open("atex_debug.log.gz", "wt")
    return debug_log_fobj

with contextlib.ExitStack() as stack:
    debug_log_fobj = setup_logging()
    stack.enter_context(contextlib.closing(debug_log_fobj))
    logger.info(...)

logger.info(...)
```
which means it closes the gzip file object when the `ExitStack` finishes, causing any `logger.*` calls outside of it to fail with ie.
```
     --- Logging error ---
    Traceback (most recent call last):
      File "/usr/lib64/python3.14/logging/__init__.py", line 1154, in emit
        stream.write(msg + self.terminator)
        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
    ValueError: I/O operation on closed file.
    Call stack:
      File "/__w/content/content/tests/run_tests_testingfarm.py", line 142, in <module>
        main()
      File "/__w/content/content/tests/run_tests_testingfarm.py", line 137, in main
        logger.info(f"Results written to: {output_results}")
    Message: 'Results written to: results-centos-stream-10-x86_64.json.xz'
    Arguments: ()
```
as visible in Github CI, the "Run tests on Testing Farm" step.

#### Rationale:

Fix it by moving the extra logger calls into the context.
