### PR TITLE
Fix ansible roles dependencies

### DIFF
--- a/utils/ansible_galaxy_meta_template.yml
+++ b/utils/ansible_galaxy_meta_template.yml
@@ -16,6 +16,8 @@ galaxy_info:
 
   @GALAXY_TAGS@
 
-dependencies:
+collections:
   - community.general
   - ansible.posix
+
+dependencies: []


### PR DESCRIPTION
#### Description:

- Fix ansible roles dependencies

#### Rationale

- The roles in this case are actually collections. Another way to make this work would be to list explicitly the roles required, for example:

```
dependencies:
  - role: community.general.ini_file
  - role: ansible.posix.firewalld
  - role: ansible.posix.mount
  - role: ansible.posix.sysctl
  - role: ansible.posix.seboolean
```
