### PR TITLE
Adding platform applicability to fips rules

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/rule.yml
@@ -49,3 +49,4 @@ warnings:
     - general: |-
         This rule does not have a remediation.
 
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/fips_custom_stig_sub_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_custom_stig_sub_policy/rule.yml
@@ -24,3 +24,5 @@ ocil: |-
     cipher@SSH=AES-256-GCM AES-256-CTR AES-128-GCM AES-128-CTR
     mac@SSH=HMAC-SHA2-512 HMAC-SHA2-256
     </pre>
+
+platform: system_with_kernel and not osbuild


### PR DESCRIPTION
#### Description:

- This PR adds platform applicability to `fips_crypto_subpolicy` and `fips_custom_stig_sub_policy` rules

#### Rationale:

- FIPS crypto policies require kernel-level access and containers don't have kernel packages

- Fixes #13877

#### Review Hints:

- use `atex` to reserve testing farm and `autocontest` to run tests, that are mentioned in the issue
