### PR TITLE
Removing "not osbuild" from fips subpolicy rule

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/rule.yml
@@ -49,4 +49,4 @@ warnings:
     - general: |-
         This rule does not have a remediation.
 
-platform: system_with_kernel and not osbuild
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/fips/fips_custom_stig_sub_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_custom_stig_sub_policy/rule.yml
@@ -25,4 +25,4 @@ ocil: |-
     mac@SSH=HMAC-SHA2-512 HMAC-SHA2-256
     </pre>
 
-platform: system_with_kernel and not osbuild
+platform: system_with_kernel


### PR DESCRIPTION
#### Description:

- it should be possible to apply  `fips_crypto_subpolicy` and `fips_custom_stig_sub_policy` rules during the OSBuild time
- therefore these rules should not contain `not osbuild` restriction

#### Rationale:

- Fixes #13877
- Fixes failing `/hardening/image-builder/stig` in daily productization

#### Review Hints:
- Passed custom productization pipeline. Tested with
  - `/hardening/image-builder/stig`
  - rhel-8.10, rhel-9.7, rhel-10.1
  - x86_64
