### PR TITLE
Fix keys in audit rules

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_etc_cron_d/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_etc_cron_d/rule.yml
@@ -41,5 +41,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/cron.d/
-        key@ol8: cronjobs
-        key: actions
+        key: cronjobs

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_hosts/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_hosts/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/hosts'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/hosts") }}}
+    {{{ describe_audit_rules_watch("/etc/hosts", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -28,3 +28,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/hosts
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_issue/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_issue/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/issue'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/issue") }}}
+    {{{ describe_audit_rules_watch("/etc/issue", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -28,3 +28,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/issue
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_issue_net/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_issue_net/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/issue.net'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/issue.net") }}}
+    {{{ describe_audit_rules_watch("/etc/issue.net", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -28,3 +28,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/issue.net
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_networkmanager_system_connections/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_networkmanager_system_connections/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/NetworkManager/system-connections/'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/NetworkManager/system-connections/") }}}
+    {{{ describe_audit_rules_watch("/etc/NetworkManager/system-connections/", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -28,3 +28,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/NetworkManager/system-connections/
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_sysconfig_network/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_etc_sysconfig_network/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/sysconfig/network'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/sysconfig/network") }}}
+    {{{ describe_audit_rules_watch("/etc/sysconfig/network", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -29,3 +29,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/sysconfig/network
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_hostname_file/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_hostname_file/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/hostname'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/hostname", "audit_rules_networkconfig_modification_hostname_file") }}}
+    {{{ describe_audit_rules_watch("/etc/hostname", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -29,3 +29,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/hostname
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_network_scripts/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_network_scripts/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/sysconfig/network-scripts'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/sysconfig/network-scripts", "audit_rules_networkconfig_modification_network_scripts") }}}
+    {{{ describe_audit_rules_watch("/etc/sysconfig/network-scripts", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -30,3 +30,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/sysconfig/network-scripts
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_networkmanager/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification_networkmanager/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Record Events that Modify the System''s Network Environment - /etc/NetworkManager/'
 
 description: |-
-    {{{ describe_audit_rules_watch("/etc/NetworkManager", "audit_rules_networkconfig_modification_networkmanager") }}}
+    {{{ describe_audit_rules_watch("/etc/NetworkManager", "system-locale") }}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -29,3 +29,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/NetworkManager
+        key: system-locale

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
@@ -58,3 +58,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /etc/passwd
+        key: audit_rules_usergroup_modification

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_var_log_journal/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_var_log_journal/rule.yml
@@ -42,3 +42,4 @@ template:
     name: audit_rules_watch
     vars:
         path: /var/log/journal/
+        key: systemd_journal


### PR DESCRIPTION
Fix inconsistent or missing keys in rules using the `audit_rules_watch` template. Align keys used in the rule description with keys used in remediations. This doesn't affect OVAL checks because the template OVAL doesn't check for audit rule keys.

Resolves: https://issues.redhat.com/browse/RHEL-141394
