### PR TITLE
Disable SHA1 for RPM in RHEL 9 CIS

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_custom_crypto_policy_cis/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_custom_crypto_policy_cis/rule.yml
@@ -49,6 +49,11 @@ title: Implement Custom Crypto Policy Modules for CIS Benchmark
         "key": "mac",
         "value": "-*-128*"
     },
+    {
+        "module_name": "NO-RPMSHA1",
+        "key": "hash@rpm",
+        "value": "-SHA1"
+    },
 ] %}}
 {{% elif product == "rhel10" or product == "fedora" %}}
 {{% set base_policy = "DEFAULT" %}}


### PR DESCRIPTION
The DEFAULT crypto policy on RHEL 9.7 adds SHA1 to `hash@rpm` policy, which we can see in `/etc/crypto-policies/state/CURRENT.pol`. Using SHA1 isn't compliant with CIS requirement 1.6.3 "Ensure system wide crypto policy disables sha1 hash and signature support". In this commit we will introduce a new custom crypto policy submodule that will disable SHA1 in `hash@rpm` policy.

Resolves: https://issues.redhat.com/browse/RHEL-138448

### Review hints

Harden a RHEL 9 system with this profile. Then run

1. `update-crypto-policies --show` and verify the output contains `NO-RPMSHA1`
2. `grep SHA1 /etc/crypto-policies/state/CURRENT.pol`
3. 
