### PR TITLE
Fix incorrect sudo rules selections in RHEL 9 CIS

### DIFF
--- a/products/rhel9/controls/cis_rhel9.yml
+++ b/products/rhel9/controls/cis_rhel9.yml
@@ -1738,7 +1738,7 @@ controls:
           - l2_workstation
       status: automated
       rules:
-          - sudo_require_authentication
+          - sudo_remove_nopasswd
 
     - id: 5.2.5
       title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
@@ -1747,7 +1747,7 @@ controls:
           - l1_workstation
       status: automated
       rules:
-          - sudo_require_reauthentication
+          - sudo_remove_no_authenticate
 
     - id: 5.2.6
       title: Ensure sudo authentication timeout is configured correctly (Automated)
@@ -1757,6 +1757,7 @@ controls:
       status: automated
       rules:
           - sudo_require_reauthentication
+          - var_sudo_timestamp_timeout=15_minutes
 
     - id: 5.2.7
       title: Ensure access to the su command is restricted (Automated)

--- a/tests/data/profile_stability/rhel9/cis.profile
+++ b/tests/data/profile_stability/rhel9/cis.profile
@@ -368,7 +368,8 @@ sshd_set_max_sessions
 sshd_set_maxstartups
 sudo_add_use_pty
 sudo_custom_logfile
-sudo_require_authentication
+sudo_remove_no_authenticate
+sudo_remove_nopasswd
 sudo_require_reauthentication
 sysctl_kernel_randomize_va_space
 sysctl_kernel_yama_ptrace_scope
@@ -454,6 +455,7 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces
 xwindows_runlevel_target

--- a/tests/data/profile_stability/rhel9/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_server_l1.profile
@@ -265,6 +265,7 @@ sshd_set_max_sessions
 sshd_set_maxstartups
 sudo_add_use_pty
 sudo_custom_logfile
+sudo_remove_no_authenticate
 sudo_require_reauthentication
 sysctl_kernel_randomize_va_space
 sysctl_kernel_yama_ptrace_scope
@@ -339,5 +340,6 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
@@ -259,6 +259,7 @@ sshd_set_max_sessions
 sshd_set_maxstartups
 sudo_add_use_pty
 sudo_custom_logfile
+sudo_remove_no_authenticate
 sudo_require_reauthentication
 sysctl_kernel_randomize_va_space
 sysctl_kernel_yama_ptrace_scope
@@ -333,4 +334,5 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_user_initialization_files_regex=all_dotfiles

--- a/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
@@ -364,7 +364,8 @@ sshd_set_max_sessions
 sshd_set_maxstartups
 sudo_add_use_pty
 sudo_custom_logfile
-sudo_require_authentication
+sudo_remove_no_authenticate
+sudo_remove_nopasswd
 sudo_require_reauthentication
 sysctl_kernel_randomize_va_space
 sysctl_kernel_yama_ptrace_scope
@@ -450,4 +451,5 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_user_initialization_files_regex=all_dotfiles


### PR DESCRIPTION
Fix incorrect selections in RHEL 9 CIS profiles in requirements for `sudo` configuration. Specifically, requirements 5.2.4, 5.2.5, 5.2.6 in RHEL 9 CIS v2.0.0. The current rule selections don't align with the text in these requirements. Also, these requirements are the same as in RHEL 8 CIS v4.0.0 and RHEL 10 CIS v1.0.1 so the selections in the RHEL 9 control file should also be the same as in RHEL 8 and RHEL 10 control files.

Related to: https://issues.redhat.com/browse/RHEL-59133

