### PR TITLE
Remove useless authsucc

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml
@@ -57,7 +57,7 @@
   <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-      <value>^\s*auth\s+(requisite|required)\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+      <value>^\s*auth\s+(requisite|required)\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
@@ -7,7 +7,6 @@ Priority: 0
 Auth-Type: Primary
 Auth:
     [default=die]                   pam_faillock.so authfail
-    sufficient                      pam_faillock.so authsucc
 EOF
 
 cat << EOF > /usr/share/pam-configs/tmp_faillock_notify

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct_pamd.pass.sh
@@ -8,7 +8,6 @@ Priority: 0
 Auth-Type: Primary
 Auth:
     [default=die]                   pam_faillock.so authfail silent
-    sufficient                      pam_faillock.so authsucc silent
 EOF
 
 cat << EOF > /usr/share/pam-configs/tmp_faillock_notify

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -856,7 +856,6 @@ Priority: 0
 Auth-Type: Primary
 Auth:
     [default=die]                   pam_faillock.so authfail
-    sufficient                      pam_faillock.so authsucc
 EOF
 fi
 


### PR DESCRIPTION
#### Description:

- Delete authsucc

#### Rationale:

- authsucc line is never reached, if faillock authfail line succeed then pam stack jump over, if not, die.