### PR TITLE
Update rule for OL09-00-002370 and OL08-00-040284

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -342,7 +342,7 @@ controls:
           - medium
       title: OL 9 must disable the use of user namespaces.
       rules:
-          - sysctl_user_max_user_namespaces
+          - sysctl_user_max_user_namespaces_no_remediation
       status: automated
 
     - id: OL09-00-002385

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -1158,7 +1158,7 @@ selections:
     - sysctl_kernel_kptr_restrict
 
     # OL08-00-040284
-    - sysctl_user_max_user_namespaces
+    - sysctl_user_max_user_namespaces_no_remediation
 
     # OL08-00-040285
     - sysctl_net_ipv4_conf_all_rp_filter


### PR DESCRIPTION
#### Description:

Replace rule sysctl_user_max_user_namespaces with sysctl_user_max_user_namespaces_no_remediation in OL STIG

#### Rationale:

Let users remediate this rule manually
