### PR TITLE
Update OL9 STIG profile

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -1858,6 +1858,8 @@ controls:
       title: OL 9 SSH server configuration file must be group-owned by root.
       rules:
           - file_groupowner_sshd_config
+          - directory_groupowner_sshd_config_d
+          - file_groupowner_sshd_drop_in_config
       status: automated
 
     - id: OL09-00-002508
@@ -1866,6 +1868,8 @@ controls:
       title: OL 9 SSH server configuration file must be owned by root.
       rules:
           - file_owner_sshd_config
+          - directory_owner_sshd_config_d
+          - file_owner_sshd_drop_in_config
       status: automated
 
     - id: OL09-00-002509
@@ -1874,6 +1878,8 @@ controls:
       title: OL 9 SSH server configuration file must have mode 0600 or less permissive.
       rules:
           - file_permissions_sshd_config
+          - directory_permissions_sshd_config_d
+          - file_permissions_sshd_drop_in_config
       status: automated
 
     - id: OL09-00-002502
@@ -3257,7 +3263,7 @@ controls:
       title: OL 9 must allow only the information system security manager (ISSM) (or individuals or roles
           appointed by the ISSM) to select which auditable events are to be audited.
       rules:
-          - file_permissions_etc_audit_rulesd
+          - file_permissions_audit_configuration
       status: automated
 
     - id: OL09-00-000810


### PR DESCRIPTION
#### Description:

STIG ID - OL09-00-000805
Replace file_permissions_etc_audit_rulesd with file_permissions_audit_configuration

STIG ID - OL09-00-002507
Add rules file_groupowner_sshd_drop_in_config and directory_groupowner_sshd_config_d

STIG ID - OL09-00-002508
Add rules directory_owner_sshd_config_d and file_owner_sshd_drop_in_config

STIG ID - OL09-00-002509
Add rules directory_permissions_sshd_config_d and file_permissions_sshd_drop_in_config

#### Rationale:

Get better alignment with OL9 STIG DISA standard