### PR TITLE
Add test file to incorrect_owner test in file_owner template

### DIFF
--- a/shared/templates/file_owner/tests/incorrect_owner.fail.sh
+++ b/shared/templates/file_owner/tests/incorrect_owner.fail.sh
@@ -20,6 +20,7 @@ id "{{{ own }}}" &>/dev/null || useradd {{{ own }}}
 if [ ! -d {{{ path }}} ]; then
     mkdir -p {{{ path }}}
 fi
+touch "{{{ path }}}"/cac_file_owner_test_file
 {{% if FILE_REGEX %}}
 find -P {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown testuser_123 {} \;
 {{% elif RECURSIVE %}}


### PR DESCRIPTION
#### Description:

This line was added to `incorrect_owner.fail.sh ` test

`touch "{{{ path }}}"/cac_file_owner_test_file `

It  check if the path exist but not if at least one file exist, this solution was taken from the test `correct_owner.pass.sh` in the same rule.

#### Rationale:

The test incorrect_owner.fail.sh fail in the initial stage when no file is present in /etc/ssh/sshd_config.d/
