### PR TITLE
Record Testing Farm usage via ATEX using Testing Farm `tags`

### DIFF
--- a/.github/workflows/atex-test.yaml
+++ b/.github/workflows/atex-test.yaml
@@ -149,6 +149,8 @@ jobs:
         env:
           TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
           CS_MAJOR: ${{ matrix.centos_stream_major }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          ACTOR: ${{ github.actor }}
         run: |
           python3 tests/run_tests_testingfarm.py \
             --contest-dir contest \
@@ -157,7 +159,9 @@ jobs:
             --compose "CentOS-Stream-${CS_MAJOR}" \
             --arch x86_64 \
             --os-major-version "${CS_MAJOR}" \
-            --timeout ${{ env.TEST_TIMEOUT }}
+            --timeout ${{ env.TEST_TIMEOUT }} \
+            --tag github_actor=$ACTOR \
+            --tag github_repo=$REPO_URL
 
       - name: Upload test results
         if: always()

--- a/tests/run_tests_testingfarm.py
+++ b/tests/run_tests_testingfarm.py
@@ -20,6 +20,11 @@ from atex.fmf import FMFTests
 logger = logging.getLogger("ATEX")
 
 
+def kv_pair(keyval):
+    if "=" not in keyval:
+        raise argparse.ArgumentTypeError(f"expected KEY=VALUE, got: {keyval}")
+    return keyval.split("=", 1)
+
 def parse_args():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Run tests on Testing Farm using atex")
@@ -33,6 +38,7 @@ def parse_args():
     parser.add_argument("--timeout", type=int, default=120, help="Timeout in minutes")
     parser.add_argument("--max-remotes", type=int, default=10, help="Maximum number of parallel test executions")
     parser.add_argument("--reruns", type=int, default=1, help="Number of test reruns on failure")
+    parser.add_argument("--tag", type=kv_pair, default=[], action="append", help="Additional tag(s) to store in TF Request")
     return parser.parse_args()
 
 
@@ -116,6 +122,7 @@ def main():
             arch=args.arch,
             max_retries=2,
             timeout=args.timeout,
+            tags=dict(args.tag),
         )
 
         # Setup Contest orchestrator


### PR DESCRIPTION
#### Description:

This encodes additional metadata using a generic JSON object called `tags` in the Testing Farm API: https://api.testing-farm.io/docs#operation/request_a_new_test_v0_1_requests_post

#### Rationale:

With Packit-based Testing Farm usage, we had at least rough idea of who is running the test by git repo URL, ie.
```
https://github.com/ggbecker/content
https://github.com/vojtapolasek/content
https://github.com/ComplianceAsCode/content
...
```
but with ATEX, we only get
```
https://github.com/RHSecurityCompliance/atex-reserve
```
because it simply reserves systems from TF, and only then runs tests on them.

This PR adds additional metadata to reserve "requests" (which is what TF calls jobs, basically) to help us at least approximate who is pushing too frequently / using too much of TF resources.

#### Review Hints:
This might need to be a blind review since I can't change the workflow and test it in the same PR.