### PR TITLE
Update OL9 ccn profile to use cis_default value

### DIFF
--- a/controls/ccn_ol9.yml
+++ b/controls/ccn_ol9.yml
@@ -624,9 +624,9 @@ controls:
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
           - sshd_enable_warning_banner_net
-          - login_banner_text=default
-          - motd_banner_text=default
-          - remote_login_banner_text=default
+          - login_banner_text=cis_default
+          - motd_banner_text=cis_default
+          - remote_login_banner_text=cis_default
 
     - id: A.11.SEC-OL5
       title: Network Acess to the System is Controlled


### PR DESCRIPTION
#### Description:

Update the value of login_banner_text, motd_banner_text and remote_login_banner_text variable to cis_default

#### Rationale:

Update OL9 CCN profile