### PR TITLE
Specify custom CaC content path to changed actions in OSCAL Sync workflow

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -75,6 +75,8 @@ jobs:
         if: ${{ env.SKIP == 'false' }}
         uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
         id: changed-files
+        with:
+          path: "cac-content"
       - name: Detect updates in changed files
         if: ${{ env.SKIP == 'false' }}
         run: |


### PR DESCRIPTION
#### Description:
- Specify custom CaC content path to changed actions
  - We are using a custom path here for the checkout action "cac-content". So the changed actions needs to point to that place specifically.


https://github.com/ComplianceAsCode/content/blob/91d894b3801ec08bb25661dc09fd0260ee9d4016/.github/workflows/sync-cac-oscal.yml#L22-L26


#### Rationale:

- Attempt to fix: https://github.com/ComplianceAsCode/content/actions/runs/21436817820/job/61729477540

#### Review Hints:

- This is only triggered whenever it is pushed to master, so I don't know how to test it.