### PR TITLE
Fix Jinja filter in Ansible task in mount_option template

### DIFF
--- a/shared/templates/mount_option/ansible.template
+++ b/shared/templates/mount_option/ansible.template
@@ -41,7 +41,7 @@
   set_fact:
     mount_info: "{{ mount_info|default({})|combine({item.0: item.1}) }}"
   with_together:
-    - "{{ device_name.stdout_lines[0].split() | list | lower }}"
+    - "{{ device_name.stdout_lines[0].split() | map('lower') | list }}"
     - "{{ device_name.stdout_lines[1].split() | list }}"
   when:
     - device_name.stdout is defined and device_name.stdout_lines is defined


### PR DESCRIPTION
The Jinja filter `lower` produces a string, not a list, but the rest of the code assumes that the result is a list. The correct approach is to use the `map` function to apply `lower` on each element of the given list separately.

Fixes: https://github.com/ComplianceAsCode/content/issues/14259


