### PR TITLE
Fix SELinux ansible variable name conflict

### DIFF
--- a/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
@@ -7,7 +7,7 @@
 - name: "{{{ rule_title }}} - Check current SELinux state"
   ansible.builtin.command:
     cmd: getenforce
-  register: selinux_state
+  register: current_selinux_state
   check_mode: false
   changed_when: false
 
@@ -19,4 +19,4 @@
     state: touch
     access_time: preserve
     modification_time: preserve
-  when: selinux_state.stdout | lower != "permissive"
+  when: current_selinux_state.stdout | lower != "permissive"

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: "{{{ rule_title }}} - Check current SELinux state"
   ansible.builtin.command:
     cmd: getenforce
-  register: selinux_state
+  register: current_selinux_state
   check_mode: false
   changed_when: false
 
@@ -20,4 +20,4 @@
     state: touch
     access_time: preserve
     modification_time: preserve
-  when: selinux_state.stdout | lower != var_selinux_state
+  when: current_selinux_state.stdout | lower != var_selinux_state


### PR DESCRIPTION
#### Description:

The ansible remediation for both selinux_not_disabled and selinux_state rules were using 'selinux_state' as the registered variable name for the output of the 'getenforce' command. This created a naming conflict with the 'selinux_state' boolean control (which comes from the rule id) variable used in the when conditions to determine if a rule should be applied.

When roles are generated, the 'Check current SELinux state' task includes a when condition with 'selinux_state | bool' (coming from the rule id), but this creates a circular dependency since that same task is supposed to register 'selinux_state'.
As a result, the task gets skipped, the variable never gets registered, and subsequent tasks that depend on checking the current SELinux state fail or are skipped.

This fix renames the registered variable from 'selinux_state' to 'current_selinux_state' in both ansible remediation files to avoid the naming conflict.

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes #14344 