### PR TITLE
Add github token to download artifacts from different workflow

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -74,6 +74,7 @@ jobs:
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
             name: pr-artifacts-${{ github.event.workflow_run.head_sha }}
             path: pr_artifacts
             run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION


#### Description:
- Add github token to download artifacts from different workflow.
  - From https://docs.github.com/en/actions/tutorials/store-and-share-data#downloading-artifacts-during-a-workflow-run If you want to download artifacts from a different workflow or workflow run, you need to supply a token and run identifier. See Download Artifacts from other Workflow Runs or Repositories in the documentation for the download-artifact action.

#### Rationale:

- Fixes https://github.com/ComplianceAsCode/content/actions/runs/21523411965/job/62020566817
