### PR TITLE
Fix sshd param_conflict_directory.fail.sh tests

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -164,7 +164,7 @@ value: :code:`Setting={{ varname1 }}`
 {{%- set line_regex = prefix_regex + "{{ \"" + parameter + "\"| regex_escape }}" + separator_regex -%}}
 {{%- set find_when = dir_exists + ".stat.isdir is defined and " + dir_exists + ".stat.isdir" -%}}
 {{%- set lineinfile_items = "{{ " + dir_parameter + ".files }}" -%}}
-{{%- set lineinfile_when = dir_parameter + ".matched | bool" -%}}
+{{%- set lineinfile_when = dir_parameter + ".matched > 0" -%}}
 {{%- set new_line = parameter + separator + value -%}}
 - name: {{{ rule_title }}} - Check if the parameter {{{ parameter }}} is configured
   ansible.builtin.find:


### PR DESCRIPTION
#### Description:

Adjust lineinfile_when in `ansible_set_config_file_dir` seems that old way would get confused during tests and not remediate correctly.

#### Rationale:

Fixes issues with sshd exposed in #14343

#### Review Hints:
Run some Automatus tests for the effected rules.

```
./automatus.py rule --datastream ../build/ssg-rhel9-ds.xml --libvirt qemu:///system automatus_RHEL-9.8 --remediate-using ansible sshd_rekey_limit --scenarios param_conflict_directory.fail.sh
```

and 

```
 ./automatus.py rule --datastream ../build/ssg-rhel9-ds.xml --libvirt qemu:///system automatus_RHEL-9.8 --remediate-using ansible sshd_set_max_auth_tries --scenarios param_conflict_directory.fail.sh 
 ```
