### PR TITLE
Update `run_tests_testingfarm.py` logging for ATEX 0.15

### DIFF
--- a/.github/workflows/atex-test.yaml
+++ b/.github/workflows/atex-test.yaml
@@ -99,7 +99,7 @@ jobs:
           # Restore permissions from the saved file created during build
           CONTENT_DIR="content-centos-stream${{ matrix.centos_stream_major }}"
           PERMS_FILE="${CONTENT_DIR}/file-permissions.txt"
-          
+
           if [ -f "${PERMS_FILE}" ]; then
             echo "=== Restoring file permissions from ${PERMS_FILE} ==="
             cd "${CONTENT_DIR}"
@@ -143,7 +143,7 @@ jobs:
       - name: Install test dependencies
         run: |
           dnf -y install python3-pip rsync
-          pip install fmf atex==0.13
+          pip install fmf atex==0.15
 
       - name: Run tests on Testing Farm
         env:
@@ -171,7 +171,7 @@ jobs:
           path: |
             results-centos-stream-${{ matrix.centos_stream_major }}-x86_64.json.xz
             files-centos-stream-${{ matrix.centos_stream_major }}-x86_64/
-            atex_debug.log.gz
+            atex_debug.log.xz
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
   upload:
@@ -190,7 +190,7 @@ jobs:
         if: always()
         run: |
           dnf -y install python3-pip git rsync
-          pip install fmf atex==0.13
+          pip install fmf atex==0.15
 
       - name: Checkout ATEX results repository
         if: always()


### PR DESCRIPTION
#### Description:

ATEX 0.15 has changed the way logging works - it now uses a more standard `logging`-module-native approach with different subsystems using different loggers, so instead of one `atex` logger, there is `atex.provisioner.testingfarm`, `atex.orchestrator.adhoc`, etc.

It also re-categorized what "debug", "info" and "warning" means within the context of each subsystem, whereas previously, the importance was based on using Orchestrator only (like we do here) - messages that should have been `info()` for a Provisioner were `debug()`.

That's not true anymore, so we need to filter out unrelated `info()` we don't care about, hence the `OrchestratorLogFilter` - a `logging`-native solution to the problem.

Similarly, I figured we don't need the long logger names in the output, hence the different format for console vs debug log.

#### Rationale:

While the logging changes are the most visible part, the real benefit is a much [more reliable support for **test reboots**](https://github.com/RHSecurityCompliance/atex/commit/69eaa20a4a6c61db3e7894e91d96538f9f2ce1aa), which are now two-way (test waits for disconnect from ATEX) and, in my testing, reduced a ~3% rerun rate due to EOF disconnects, down to **0%**.

Fortunately, this support is free here (no extra code needed beyond upgrading ATEX version, hence this PR), but a test suite change is mandatory (https://github.com/RHSecurityCompliance/contest/pull/534) along with RH-internal productization repo MR#5, with **all three needing to be merged at the same time**.

(This is due to us using latest Contest `main` here in the ATEX workflow, unversioned.)

#### Review Hints:

The changes in this PR passed for me: https://github.com/comps/scap-content/actions/runs/21679753722

I even downloaded the artifacts and verified `atex_debug.log.xz` works as expected - contains FULL debug output, at approx. 250KB of compressed log size. The console output also correctly shows just the orchestration, not low-level provisioning details.

Please contact me when this is ready for immediate merging, to coordinate with the repositories mentioned above.