### PR TITLE
Bump retention days to 3 for ATEX

### DIFF
--- a/.github/workflows/atex-build.yaml
+++ b/.github/workflows/atex-build.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  ARTIFACT_RETENTION_DAYS: 1
+  ARTIFACT_RETENTION_DAYS: 3
 
 permissions:
   contents: read

--- a/.github/workflows/atex-test.yaml
+++ b/.github/workflows/atex-test.yaml
@@ -10,7 +10,7 @@ env:
   ATEX_REPO: RHSecurityCompliance/atex-results-testing-farm
   ATEX_HTML_REPO: RHSecurityCompliance/atex-html
   CONTEST_REPO: RHSecurityCompliance/contest
-  ARTIFACT_RETENTION_DAYS: 1
+  ARTIFACT_RETENTION_DAYS: 3
   TEST_TIMEOUT: 1440 # 24 hours
   # CentOS Stream versions to test (space-separated for shell loops)
   # NOTE: Keep in sync with matrix.centos_stream_major in the test job


### PR DESCRIPTION

#### Description:

Bump retention days to 3 for ATEX

#### Rationale:

Just in case we need to do tries after outage we don't have to rebuild

