### PR TITLE
Enable cap_net_admin to allow firewall rule tests to run

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -534,6 +534,7 @@ class PodmanTestEnv(ContainerTestEnv):
                       "--cap-add=cap_sys_chroot",
                     #   "--privileged",
                       "--network", "slirp4netns:mtu=1500",
+                      "--cap-add=cap_net_admin",
                       "--publish", "{}".format(self.internal_ssh_port), "--detach", image_name,
                       "/usr/sbin/sshd", "-p", "{}".format(self.internal_ssh_port), "-D"]
         try:


### PR DESCRIPTION
#### Description:

- Enable net_admin to allow firewall rule tests to run

#### Rationale:

- Before enable that cap, testing xccdf_org.ssgproject.content_rule_set_nftables_table will get error even we ssh into container as root

```
+ echo 'Remediating rule 1/1: '\''xccdf_org.ssgproject.content_rule_set_nftables_table'\'''
Remediating rule 1/1: 'xccdf_org.ssgproject.content_rule_set_nftables_table'
+ dpkg-query --show '--showformat=${db:Status-Status}' nftables
+ grep -q '^installed$'
+ var_nftables_family=inet
+ var_nftables_table=filter
+ nft list table inet filter
Operation not permitted (you must be root)
netlink: Error: cache initialization failed: Operation not permitted
+ nft create table inet filter
Error: Could not process rule: Operation not permitted
create table inet filter
^^^^^^^^^^^^^^^^^^^^^^^^^
```