### PR TITLE
Update RHEL 9 STIG version in profile for V2R7

### DIFF
--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -2,7 +2,7 @@
 documentation_complete: true
 
 metadata:
-    version: V2R6
+    version: V2R7
     SMEs:
         - mab879
         - ggbecker
@@ -13,7 +13,7 @@ title: 'DISA STIG for Red Hat Enterprise Linux 9'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for Red Hat Enterprise Linux 9 V2R6.
+    DISA STIG for Red Hat Enterprise Linux 9 V2R7.
 
     In addition to being applicable to Red Hat Enterprise Linux 9, this
     configuration baseline is applicable to the operating system tier of

--- a/products/rhel9/profiles/stig_gui.profile
+++ b/products/rhel9/profiles/stig_gui.profile
@@ -2,7 +2,7 @@
 documentation_complete: true
 
 metadata:
-    version: V2R6
+    version: V2R7
     SMEs:
         - mab879
         - ggbecker
@@ -13,7 +13,7 @@ title: 'DISA STIG with GUI for Red Hat Enterprise Linux 9'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for Red Hat Enterprise Linux 9 V2R6.
+    DISA STIG for Red Hat Enterprise Linux 9 V2R7.
 
     In addition to being applicable to Red Hat Enterprise Linux 9, this
     configuration baseline is applicable to the operating system tier of


### PR DESCRIPTION
#### Description:

Update RHEL 9 STIG version in profile for V2R7

#### Rationale:

Keep things up-to-date.
