### PR TITLE
Patch ansible remediation for postfix_network_listening_disabled rule

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
@@ -4,9 +4,4 @@
 # complexity = low
 # disruption = low
 {{{ ansible_instantiate_variables("var_postfix_inet_interfaces") }}}
-
-- name: "Gather list of packages"
-  ansible.builtin.package_facts:
-    manager: auto
-
-{{{ ansible_lineinfile(msg='Make changes to Postfix configuration file', path='/etc/postfix/main.cf', regex='^inet_interfaces\s*=\s.*', insensitive='false', new_line='inet_interfaces = {{ var_postfix_inet_interfaces }}', create='no', state='present', insert_after='^inet_interfaces\s*=\s.*', when='"postfix" in ansible_facts.packages', rule_title=rule_title) }}}
+{{{ ansible_only_lineinfile(msg='Make changes to Postfix configuration file', path='/etc/postfix/main.cf', line_regex='^inet_interfaces\s*=\s*.*$', new_line='inet_interfaces = {{ var_postfix_inet_interfaces }}', create='no', block=True, rule_title=rule_title) }}}


### PR DESCRIPTION
#### Description:

- Fix ansible remediation for postfix_network_listening_disabled rule

#### Rationale:

- Make sure that the /etc/postfix/main.cf configuration contain only one file with desired config

#### Fixes

- Fixes issue on applying ansible remediation when configuration contains inet_interfaces=all
