### PR TITLE
Make sure not to run ansible procedure in check mode

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/ansible/shared.yml
@@ -42,6 +42,7 @@
     enabled: true
     daemon_reload: true
     masked: false
+  when: not ansible_check_mode
 
 - name: "{{{ rule_title }}} - Ensure AIDE Service Timer is Enabled"
   ansible.builtin.systemd:
@@ -50,3 +51,4 @@
     enabled: true
     daemon_reload: true
     masked: false
+  when: not ansible_check_mode


### PR DESCRIPTION
#### Description:

- Minor patch in ansible remediation for aide_periodic_checking_systemd_timer

#### Rationale:

- Make sure that ansible remediation proc in aide_periodic_checking_systemd_timer is not executed in check_mode