### PR TITLE
Drop unneeded sudo in bash remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_all
 
-readarray -t users_with_empty_pass < <(sudo awk -F: '!$2 {print $1}' /etc/shadow)
+readarray -t users_with_empty_pass < <(awk -F: '!$2 {print $1}' /etc/shadow)
 
 for user_with_empty_pass in "${users_with_empty_pass[@]}"
 do


### PR DESCRIPTION
#### Description:

- Cleanup bash remediation code

#### Rationale:

- Drop unneeded sudo in remediation. THe remediation is assumed to be executed in privileged mode