### PR TITLE
SLE16 Make sure for permissions_local_var_log file_permissions template 

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -63,6 +63,7 @@ template:
         filepath: /var/log/
         recursive@sle12: 'true'
         recursive@sle15: 'true'
+        recursive@sle16: 'true'
         recursive@slmicro5: 'true'
         recursive@slmicro6: 'true'
         recursive@ubuntu2204: 'true'


### PR DESCRIPTION

#### Description:

- Fix permissions_local_var_log for sle16 file_permissions template

#### Rationale:

- set recursive for sle16 wtmp,btmp and lastlog not needed: sle16 uses pam_lastlog2.so (which writes in /var/lib/)
