### PR TITLE
SLE16 set filemode parameter for file_permissions rules

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -57,3 +57,4 @@ template:
         filemode@ubuntu2404: '0640'
         filemode@sle12: '0640'
         filemode@sle15: '0640'
+        filemode@sle16: '0640'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -69,5 +69,6 @@ template:
         filemode@debian13: '0640'
         filemode@sle12: '0640'
         filemode@sle15: '0640'
+        filemode@sle16: '0640'
         filemode@ubuntu2204: '0640'
         filemode@ubuntu2404: '0640'


### PR DESCRIPTION
#### Description:

- SLE16 set filemode parameter for file_permissions_etc_shadow and file_permissions_backup_etc_shadow
- 
#### Rationale:

- Make sure file_permissions_etc_shadow and file_permissions_backup_etc_shadow rules bash remediation works