### PR TITLE
Enable sle16 remeditaions in grub2_enable_selinux

### DIFF
--- a/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_fedora,multi_platform_ol,SUSE Linux Enterprise 15,multi_platform_almalinux
+# platform = SUSE Linux Enterprise 15,SUSE Linux Enterprise 16,multi_platform_almalinux,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/bash/shared.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_fedora,multi_platform_ol,SUSE Linux Enterprise 15,multi_platform_almalinux
+# platform = SUSE Linux Enterprise 15,SUSE Linux Enterprise 16,multi_platform_almalinux,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv
 
 sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
 sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*


### PR DESCRIPTION
#### Description:

- Enable bash and ansible remediation for sle16 in grub2_enable_selinux rule


#### Rationale:

- Enable sle16 platform for ansible and bash remediation scripts in grub2_enable_selinux rule
