### PR TITLE
Bump version of development branch to 0.1.81

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(SSGCommon)
 # Define Version values
 set(SSG_MAJOR_VERSION 0)
 set(SSG_MINOR_VERSION 1)
-set(SSG_PATCH_VERSION 80)
+set(SSG_PATCH_VERSION 81)
 set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}")
 
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")


### PR DESCRIPTION
#### Description:

- Bump version of development branch to 0.1.81
- The stabilization has been created and we need to update the dev branch.
