### PR TITLE
Fix remediation in rule logind_session_timeout

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/bash/shared.sh
@@ -5,6 +5,7 @@
 {{% if product in ["rhel9", "rhel10", "sle15", "sle16"] %}}
 # create drop-in in the /etc/systemd/logind.conf.d/ directory
 {{% set logind_conf_file = "/etc/systemd/logind.conf.d/oscap-idle-sessions.conf" %}}
+mkdir -p "/etc/systemd/logind.conf.d/"
 {{% else %}}
 {{% set logind_conf_file = "/etc/systemd/logind.conf" %}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/tests/dir_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/tests/dir_missing.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+{{% if product in ["rhel9", "rhel10", "sle15", "sle16"] %}}
+rm -rf "/etc/systemd/logind.conf.d/"
+{{% endif %}}


### PR DESCRIPTION
The bash remediation failed if the /etc/systemd/logind.conf.d/ directory didn't exist. This change makes sure this directory exists. Also, add a simple test scenario that covers this situation.

Fixes: https://github.com/ComplianceAsCode/content/issues/14388

