### PR TITLE
Enforce sha512 and minimum rounds in Ubuntu 22.04 STIG

### DIFF
--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -886,7 +886,9 @@ controls:
       levels:
           - medium
       rules:
-          - set_password_hashing_algorithm_systemauth
+          - var_password_pam_unix_rounds=100000
+          - set_password_hashing_algorithm_auth_stig
+          - accounts_password_pam_unix_rounds_password_auth
       status: automated
 
     - id: UBTU-22-611060

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
@@ -6,7 +6,7 @@
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'sufficient', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
 {{% elif product in ["debian12", "debian13"] %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', '\[success=1 default=ignore\]', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
-{{% elif product in ["ubuntu2404"] %}}
+{{% elif product in ["ubuntu2204", "ubuntu2404"] %}}
 config_file="/usr/share/pam-configs/cac_unix"
 {{{ bash_pam_unix_enable() }}}
 sed -i -E '/^Password:/,/^[^[:space:]]/ {

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if product in ["sle12", "sle15", "debian12", "debian13", 'ubuntu2404'] %}}
+{{% if product in ["sle12", "sle15", "debian12", "debian13", 'ubuntu2204', 'ubuntu2404'] %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/password-auth" %}}
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_password_auth_pam_unix_rounds" version="1">
     <ind:filepath operation="pattern match">^{{{ pam_passwd_file_path }}}$</ind:filepath>
-    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
+    {{% if product in ["debian12", "debian13", 'ubuntu2204', 'ubuntu2404'] %}}
     <ind:pattern operation="pattern match">^\s*password\s+.*\s+pam_unix\.so[^#]*rounds=([0-9]*).*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so[^#]*rounds=([0-9]*).*$</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 
 title: 'Set number of Password Hashing Rounds - password-auth'
 
-{{% if product in ["sle12", "sle15", "debian12", "debian13", 'ubuntu2404'] %}}
+{{% if product in ["sle12", "sle15", "debian12", "debian13", 'ubuntu2204', 'ubuntu2404'] %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/password-auth" %}}
@@ -15,7 +15,7 @@ description: |-
     <br /><br />
     In file <tt>{{{ pam_passwd_file_path }}}</tt> append <tt>rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</tt>
     to the <tt>pam_unix.so</tt> entry, as shown below:
-    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
+    {{% if product in ["debian12", "debian13", 'ubuntu2204', 'ubuntu2404'] %}}
     <pre>password [success=1 default=ignore] pam_unix.so <i>...existing_options...</i> rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so <i>...existing_options...</i> rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
@@ -49,7 +49,7 @@ ocil: |-
     To verify the number of rounds for the password hashing algorithm is configured, run the following command:
     <pre>$ sudo grep rounds {{{ pam_passwd_file_path }}}</pre>
     The output should show the following match:
-    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
+    {{% if product in ["debian12", "debian13", 'ubuntu2204', 'ubuntu2404'] %}}
     <pre>password [success=1 default=ignore] pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
@@ -62,7 +62,7 @@ fixtext: |-
 
     Add or modify the following line in "{{{ pam_passwd_file_path }}}" and set "rounds" to {{{ xccdf_value("var_password_pam_unix_rounds") }}}.
     For example:
-    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
+    {{% if product in ["debian12", "debian13", 'ubuntu2204', 'ubuntu2404'] %}}
     password [success=1 default=ignore] pam_unix.so sha512 rounds=5000
     {{% else %}}
     password sufficient pam_unix.so sha512 rounds=5000


### PR DESCRIPTION
#### Description:

- Enforce sha512 and minimum rounds (100000) in Ubuntu 22.04 STIG

#### Rationale:

- Aligns with new requirements in STIG V2R7 rule UBTU-22-611055 (Ubuntu 22.04 LTS must store only encrypted representations of passwords).

