### PR TITLE
Add audit rules for cron dirs to Ubuntu 22.04 STIG

### DIFF
--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -1260,6 +1260,15 @@ controls:
           - audit_rules_privileged_commands_crontab
       status: automated
 
+    - id: UBTU-22-654041
+      title: Ubuntu 22.04 LTS must audit any script or executable called by cron as root or by any privileged user.
+      levels:
+          - medium
+      rules:
+          - audit_rules_etc_cron_d
+          - audit_rules_var_spool_cron
+      status: automated
+
     - id: UBTU-22-654045
       title: Ubuntu 22.04 LTS must generate audit records for successful/unsuccessful attempts to use
           the fdisk command.


### PR DESCRIPTION
#### Description:

Add audit rules for cron dirs to Ubuntu 22.04 STIG

#### Rationale:

Aligns with UBTU-22-654041
(Ubuntu 22.04 LTS must audit any script or executable called by cron as root or by any privileged user)

#### Tests:
(KVM)
```
$ python3 "tests/automatus.py" rule         --libvirt qemu:///system "sec-jammy-amd64"         --datastream "build/ssg-ubuntu2204-ds.xml"         --remove-fips-certified         --remediate-using "bash"         --profile "stig"         --dontclean   
      "audit_rules_etc_cron_d"                                                                                              
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - xccdf_org.ssgproject.content_rule_audit_rules_etc_cron_d
INFO - Script auditctl_wrong_rule_without_key.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script rules_not_there.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_correct_without_key.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_correct.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_remove_all_rules.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_correct.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_wrong_rule_without_key.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_remove_all_rules.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_correct_without_key.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_correct_extra_permission.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_wrong_rule.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_correct_extra_permission.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_wrong_rule.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK

$ python3 "tests/automatus.py" rule         --libvirt qemu:///system "sec-jammy-amd64"         --datastream "build/ssg-ubuntu2204-ds.xml"         --remove-fips-certified         --remediate-using "bash"         --profile "stig"         --dontclean   
      "audit_rules_var_spool_cron"                                                                                          
Setting console output to log level INFO                      
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - xccdf_org.ssgproject.content_rule_audit_rules_var_spool_cron
INFO - Script augenrules_correct.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_correct_extra_permission.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_correct_extra_permission.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_wrong_rule_without_key.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script rules_not_there.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_correct_without_key.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_correct_without_key.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_wrong_rule.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_wrong_rule.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_remove_all_rules.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_correct.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script augenrules_wrong_rule_without_key.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
INFO - Script auditctl_remove_all_rules.fail.sh using profile xccdf_org.ssgproject.content_profile_stig OK
```