### PR TITLE
Add rules for disabling nfs to Ubuntu 22.04 STIG

### DIFF
--- a/components/nfs-common.yml
+++ b/components/nfs-common.yml
@@ -1,0 +1,5 @@
+name: nfs-common
+packages:
+- nfs-common
+rules:
+- package_nfs-common_removed

--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -143,6 +143,15 @@ controls:
           - package_telnetd_removed
       status: automated
 
+    - id: UBTU-22-215040
+      title: Ubuntu 22.04 LTS must not have the "nfs-kernel-server" package installed.
+      levels:
+          - medium
+      rules:
+          - package_nfs-common_removed
+          - package_nfs-kernel-server_removed
+      status: automated
+
     - id: UBTU-22-231010
       title: Ubuntu 22.04 LTS must implement cryptographic mechanisms to prevent unauthorized disclosure
           and modification of all information that requires protection at rest.

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-common_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-common_removed/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Uninstall nfs-common Package'
+
+description: |-
+    {{{ describe_package_remove(package="nfs-common") }}}
+
+rationale: |-
+    If the system does not export NFS shares or act as an NFS client, it is
+    recommended that these services be removed to reduce the remote attack
+    surface.
+
+severity: low
+
+{{{ complete_ocil_entry_package(package="nfs-common") }}}
+
+fixtext: '{{{ fixtext_package_removed("nfs-common") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: nfs-common


### PR DESCRIPTION
#### Description:

Add rules for disabling nfs to Ubuntu 22.04 STIG

#### Rationale:

Aligns with STIG V2R7 rule UBTU-22-215040
(Ubuntu 22.04 LTS must not have the nfs-kernel-server package installed).
