### PR TITLE
Add rules to Ubuntu 22.04 STIG to align with V2R7

### DIFF
--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -14,6 +14,14 @@ reference_type: stigid
 product: ubuntu2204
 
 controls:
+    - id: UBTU-22-211000
+      title: Ubuntu 22.04 LTS must be a vendor-supported release.
+      levels:
+          - high
+      rules:
+          - installed_OS_is_vendor_supported
+      status: automated
+
     - id: UBTU-22-211015
       title: Ubuntu 22.04 LTS must disable the x86 Ctrl-Alt-Delete key sequence.
       levels:
@@ -472,6 +480,42 @@ controls:
           - medium
       rules:
           - sysctl_net_ipv4_tcp_syncookies
+      status: automated
+
+    - id: UBTU-22-254010
+      title: Ubuntu 22.04 LTS must have the "SSSD" package installed.
+      levels:
+          - medium
+      rules:
+          - package_nss_sss_installed
+          - package_pam_sss_installed
+          - package_sssd_installed
+      status: automated
+
+    - id: UBTU-22-254015
+      title: Ubuntu 22.04 LTS must use the "SSSD" package for multifactor authentication services.
+      levels:
+          - medium
+      rules:
+          - service_sssd_enabled
+      status: automated
+
+    - id: UBTU-22-254020
+      title: Ubuntu 22.04 LTS must ensure SSSD performs certificate path validation, including revocation checking, against a trusted anchor for PKI-based authentication.
+      levels:
+          - medium
+      rules:
+          - sssd_enable_pam_services
+          - sssd_enable_smartcards
+          - sssd_certification_path_trust_anchor
+      status: automated
+
+    - id: UBTU-22-254030
+      title: Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication.
+      levels:
+          - medium
+      rules:
+          - sssd_enable_user_cert
       status: automated
 
     - id: UBTU-22-255010
@@ -1600,6 +1644,14 @@ controls:
           - medium
       rules:
           - audit_rules_sudoers
+      status: automated
+
+    - id: UBTU-22-654224
+      title: The operating system must restrict privilege elevation to authorized personnel.
+      levels:
+          - medium
+      rules:
+          - sudo_restrict_privilege_elevation_to_authorized
       status: automated
 
     - id: UBTU-22-654225

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -16,6 +16,7 @@
       <extend_definition comment="Installed OS is SLE16" definition_ref="installed_OS_is_sle16" />
       <extend_definition comment="Installed OS is SLE Micro 5" definition_ref="installed_OS_is_slmicro5" />
       <extend_definition comment="Installed OS is SLE Micro 6" definition_ref="installed_OS_is_slmicro6" />
+      <extend_definition comment="Installed OS is Ubuntu 22.04" definition_ref="installed_OS_is_ubuntu2204" />
       <extend_definition comment="Installed OS is Ubuntu 24.04" definition_ref="installed_OS_is_ubuntu2404" />
     </criteria>
   </definition>


### PR DESCRIPTION
#### Description:

Add these rules to Ubuntu 22.04 STIG control file:
- UBTU-22-211000: Ubuntu 22.04 LTS must be a vendor-supported release.
- UBTU-22-254010: Ubuntu 22.04 LTS must have the "SSSD" package installed.
- UBTU-22-254015: Ubuntu 22.04 LTS must use the "SSSD" package for multifactor authentication services.
- UBTU-22-254020: Ubuntu 22.04 LTS must ensure SSSD performs certificate path validation, including revocation checking, against a trusted anchor for PKI-based authentication.
- UBTU-22-254030: Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication.
- UBTU-22-654224: The operating system must restrict privilege elevation to authorized personnel.


#### Rationale:

Aligns with STIG V2R7
