### PR TITLE
Remove aes192-ctr

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
@@ -1,5 +1,5 @@
 {{%- if product == 'ubuntu2204' %}}
-{{%- set sshd_approved_ciphers = "aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com" %}}
+{{%- set sshd_approved_ciphers = "aes256-ctr,aes256-gcm@openssh.com,aes128-ctr,aes128-gcm@openssh.com" %}}
 {{%- else %}}
 {{%- set sshd_approved_ciphers = "aes256-ctr,aes192-ctr,aes128-ctr" %}}
 {{%- endif %}}


### PR DESCRIPTION
#### Description:

- Remove aes192-ctr for ubuntu2204 stig

#### Rationale:

- UBTU-22-255050 in stig ubuntu2204 v2r7 removes aes192-ctr

`Ciphers aes256-ctr,aes256-gcm@openssh.com,aes128-ctr,aes128-gcm@openssh.com`