### PR TITLE
Add package rsync name definition for rsync package for sle16

### DIFF
--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -41,6 +41,7 @@ template:
         packagename@ol7: rsync
         packagename@sle12: rsync
         packagename@sle15: rsync
+        packagename@sle16: rsync
         packagename@slmicro5: rsync
         packagename@openeuler2203: rsync
         servicename@ubuntu2404: rsync


### PR DESCRIPTION
#### Description:

- Make sure rsync package rsync disabled is relevant for sle16

#### Rationale:

- Add package rsync name definition for rsync package for sle16
