### PR TITLE
Add tftp package definition for sle platforms

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 {{% if 'ubuntu' in product %}}
 {{% set package_name = "tftpd-hpa" %}}
+{{% elif 'sle' in product %}}
+{{% set package_name = "tftp" %}}
 {{% else %}}
 {{% set package_name = "tftp-server" %}}
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Set package name to tftp for sle platforms

#### Rationale:

- To be used by rule package_tftp-server_removed