### PR TITLE
sysctl_kernel_core_pattern_empty_string: align with template

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
@@ -4,9 +4,16 @@
 # complexity = low
 # disruption = medium
 
+- name: "{{{ rule_title }}} - Set fact for sysctl paths"
+  ansible.builtin.set_fact:
+    sysctl_paths:
+      - "/etc/sysctl.d/"
+      - "/run/sysctl.d/"
+      - "/usr/local/lib/sysctl.d/"
+
 - name: "{{{ rule_title }}} - Find all files that contain kernel.core_pattern"
   ansible.builtin.shell:
-    cmd: find -L /etc/sysctl.conf /etc/sysctl.d/ /run/sysctl.d/ -type f -name '*.conf' | xargs grep -HP '^\s*kernel.core_pattern\s*=\s*.*$'
+    cmd: find -L {{ sysctl_paths | join(" ") }} -type f -name '*.conf' | xargs grep -HP '^\s*kernel.core_pattern\s*=\s*.*$'
   register: find_all_values
   check_mode: false
   changed_when: false
@@ -14,7 +21,7 @@
 
 - name: "{{{ rule_title }}} - Find all files that set kernel.core_pattern to correct value"
   ansible.builtin.shell:
-    cmd: find -L /etc/sysctl.conf /etc/sysctl.d/ /run/sysctl.d/ -type f -name '*.conf' | xargs grep -HP '^\s*kernel.core_pattern\s*=\s*$'
+    cmd: find -L {{ sysctl_paths | join(" ") }} -type f -name '*.conf' | xargs grep -HP '^\s*kernel.core_pattern\s*=\s*$'
   register: find_correct_value
   check_mode: false
   changed_when: false
@@ -23,15 +30,23 @@
 - name: "{{{ rule_title }}} - Comment out any occurrences of kernel.core_pattern from config files"
   ansible.builtin.replace:
     path: '{{ item | split(":") | first }}'
-    regexp: ^[\s]*kernel.core_pattern
+    regexp: '^[\s]*kernel.core_pattern'
     replace: '#kernel.core_pattern'
   loop: '{{ find_all_values.stdout_lines }}'
   when: find_correct_value.stdout_lines | length == 0 or find_all_values.stdout_lines | length > find_correct_value.stdout_lines | length
 
+- name: "{{{ rule_title }}} - Comment out any occurrences of kernel.core_pattern from /etc/sysctl.conf"
+  ansible.builtin.replace:
+    path: "{{ item }}"
+    regexp: '^[\s]*kernel.core_pattern'
+    replace: '#kernel.core_pattern'
+  with_fileglob:
+    - "/etc/sysctl.conf"
+
 - name: "{{{ rule_title }}} - Ensure sysctl kernel.core_pattern is set to empty"
   ansible.posix.sysctl:
-    name: kernel.core_pattern
-    value: ' ' # ansible sysctl module doesn't allow empty string, a space string is allowed and has the same semantics as sysctl will ignore spaces
-    sysctl_file: "/etc/sysctl.conf"
+    name: "kernel.core_pattern"
+    value: ' '  # ansible sysctl module doesn't allow empty string, a space string is allowed and has the same semantics as sysctl will ignore spaces
+    sysctl_file: "/etc/sysctl.d/kernel_core_pattern.conf"
     state: present
-    reload: true
+    reload: yes

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
@@ -5,49 +5,39 @@
 # disruption = medium
 
 # Comment out any occurrences of kernel.core_pattern from /etc/sysctl.d/*.conf files
-for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf; do
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf; do
+
+  # skip systemd-sysctl symlink (/etc/sysctl.d/99-sysctl.conf -> /etc/sysctl.conf)
+  if [[ "$(readlink -f "$f")" == "/etc/sysctl.conf" ]]; then continue; fi
 
   matching_list=$(grep -P '^(?!#).*[\s]*kernel.core_pattern.*$' $f | uniq )
   if ! test -z "$matching_list"; then
     while IFS= read -r entry; do
       escaped_entry=$(sed -e 's|/|\\/|g' <<< "$entry")
       # comment out "kernel.core_pattern" matches to preserve user data
-      sed -i "s/^${escaped_entry}$/# &/g" $f
+      sed -i --follow-symlinks "s/^${escaped_entry}$/# &/g" $f
     done <<< "$matching_list"
   fi
 done
 
 #
+# Set sysctl config file which to save the desired value
+#
+
+SYSCONFIG_FILE='/etc/sysctl.d/kernel_core_pattern.conf'
+
+#
 # Set runtime for kernel.core_pattern
 #
-/sbin/sysctl -q -n -w kernel.core_pattern=""
+if {{{ bash_not_bootc_build() }}} ; then
+    /sbin/sysctl -q -n -w kernel.core_pattern=""
+fi
 
 #
 # If kernel.core_pattern present in /etc/sysctl.conf, change value to empty
 #	else, add "kernel.core_pattern =" to /etc/sysctl.conf
 #
-# Test if the config_file is a symbolic link. If so, use --follow-symlinks with sed.
-# Otherwise, regular sed command will do.
-sed_command=('sed' '-i')
-if test -L "/etc/sysctl.conf"; then
-    sed_command+=('--follow-symlinks')
-fi
 
-# Strip any search characters in the key arg so that the key can be replaced without
-# adding any search characters to the config file.
-stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "^kernel.core_pattern")
+sed -i --follow-symlinks "/^kernel.core_pattern/d" /etc/sysctl.conf
 
-# shellcheck disable=SC2059
-printf -v formatted_output "%s=" "$stripped_key"
-
-# If the key exists, change it. Otherwise, add it to the config_file.
-# We search for the key string followed by a word boundary (matched by \>),
-# so if we search for 'setting', 'setting2' won't match.
-if LC_ALL=C grep -q -m 1 -i -e "^kernel.core_pattern\\>" "/etc/sysctl.conf"; then
-    escaped_formatted_output=$(sed -e 's|/|\\/|g' <<< "$formatted_output")
-    "${sed_command[@]}" "s/^kernel.core_pattern\\>.*/$escaped_formatted_output/gi" "/etc/sysctl.conf"
-else
-    # \n is precaution for case where file ends without trailing newline
-
-    printf '%s\n' "$formatted_output" >> "/etc/sysctl.conf"
-fi
+{{{ bash_replace_or_append('${SYSCONFIG_FILE}', '^kernel.core_pattern', '', cce_identifiers=cce_identifiers) }}}

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/oval/shared.xml
@@ -37,155 +37,68 @@
   </unix:sysctl_state>
 
 </def-group>
+
 <def-group>
   <definition class="compliance" id="sysctl_kernel_core_pattern_empty_string_static" version="3">
     {{{ oval_metadata("The kernel 'kernel.core_pattern' parameter should be set to an empty string in the system configuration.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <criteria operator="OR">
-        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /etc/sysctl.conf"
-                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static"/>
-        <!-- see sysctl.d(5) -->
-        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /etc/sysctl.d/*.conf"
-                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static_etc_sysctld"/>
-        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /run/sysctl.d/*.conf"
-                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static_run_sysctld"/>
+    <criteria operator="OR">
+      <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in sysctl files not managed by packages"
+                 test_ref="test_sysctl_kernel_core_pattern_empty_string_static_user"/>
+      <criteria operator="AND">
+        <criterion comment="kernel static parameter kernel.core_pattern missing in sysctl files not managed by packages"
+                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static_user_missing"/>
+        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in sysctl files managed by packages"
+                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static_pkg_correct"/>
       </criteria>
-      <criterion comment="Check that kernel_core_pattern is defined in only one file" test_ref="test_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static" version="1"
+  <!-- Test: user files have correct value -->
+  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_user" version="1"
                               check="all" check_existence="all_exist"
                               comment="kernel.core_pattern static configuration" state_operator="OR">
-    <ind:object object_ref="object_static_sysctl_sysctl_kernel_core_pattern_empty_string"/>
+    <ind:object object_ref="object_static_user_sysctl_kernel_core_pattern_empty_string"/>
     <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_etc_sysctld" version="1" check="all"
-                          comment="kernel.core_pattern static configuration in /etc/sysctl.d/*.conf" state_operator="OR">
-    <ind:object object_ref="object_static_etc_sysctld_sysctl_kernel_core_pattern_empty_string"/>
-    <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
-
+  <!-- Test: user files are missing (none_exist) -->
+  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_user_missing" version="1"
+                              check="all" check_existence="none_exist"
+                              comment="kernel.core_pattern static configuration" state_operator="AND">
+    <ind:object object_ref="object_static_user_sysctl_kernel_core_pattern_empty_string"/>
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_run_sysctld" version="1" check="all"
-                          comment="kernel.core_pattern static configuration in /run/sysctl.d/*.conf" state_operator="OR">
-    <ind:object object_ref="object_static_run_sysctld_sysctl_kernel_core_pattern_empty_string"/>
+  <!-- Test: package-managed files have correct value -->
+  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_pkg_correct" version="2"
+                              check="all" check_existence="all_exist"
+                              comment="kernel.core_pattern static configuration in /usr/lib/sysctl.d/*.conf" state_operator="OR">
+    <ind:object object_ref="object_static_usr_lib_sysctld_sysctl_kernel_core_pattern_empty_string"/>
     <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
-
   </ind:textfilecontent54_test>
-{{% if target_oval_version >= [5, 11] %}}
-  <ind:variable_test check="all" check_existence="all_exist" comment="Check that only one file contains kernel_core_pattern"
-  id="test_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" version="1">
-    <ind:object object_ref="object_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
-    <ind:state state_ref="state_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
-  </ind:variable_test>
 
-  <ind:variable_object id="object_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" version="1">
-    <ind:var_ref>local_var_sysctl_kernel_core_pattern_empty_string_counter</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_state id="state_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" version="1">
-    <ind:value operation="equals" datatype="int">1</ind:value>
-  </ind:variable_state>
-
-  <local_variable comment="Count unique sysctls" datatype="int" id="local_var_sysctl_kernel_core_pattern_empty_string_counter" version="1">
-    <count>
-      <unique>
-        <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls" item_field="filepath" />
-      </unique>
-    </count>
-  </local_variable>
-
-  <ind:textfilecontent54_object id="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls" version="1">
+  <!-- User files: union of etc + run + usr/local/lib -->
+  <ind:textfilecontent54_object id="object_static_user_sysctl_kernel_core_pattern_empty_string" version="1">
     <set>
-      <object_reference>object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered</object_reference>
-      <filter action="exclude">state_sysctl_kernel_core_pattern_empty_string_filepath_is_symlink</filter>
+      <object_reference>object_static_etc_lib_sysctls_sysctl_kernel_core_pattern_empty_string</object_reference>
+      <object_reference>object_static_run_usr_local_sysctls_sysctl_kernel_core_pattern_empty_string</object_reference>
     </set>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_sysctl_kernel_core_pattern_empty_string_filepath_is_symlink" version="1">
-    <ind:filepath operation="equals" var_check="at least one" var_ref="local_var_sysctl_kernel_core_pattern_empty_string_safe_symlinks" datatype="string" />
-  </ind:textfilecontent54_state>
-
-  <!-- <no symlink handling> -->
-  <!-- We craft a variable with blank string to combine with the symlink paths found.
-       This ultimately avoids referencing a variable with "no values",
-       we reference a variable with a blank string -->
-  <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_sysctl_kernel_core_pattern_empty_string_safe_symlinks" version="1">
-    <unique>
-      <object_component object_ref="var_object_symlink_sysctl_kernel_core_pattern_empty_string" item_field="value" />
-    </unique>
-  </local_variable>
-
-  <ind:variable_object id="var_object_symlink_sysctl_kernel_core_pattern_empty_string" comment="combine the blank string with symlink paths found" version="1">
-    <set>
-      <object_reference>var_obj_symlink_sysctl_kernel_core_pattern_empty_string</object_reference>
-      <object_reference>var_obj_blank_sysctl_kernel_core_pattern_empty_string</object_reference>
-    </set>
-  </ind:variable_object>
-
-  <ind:variable_object id="var_obj_blank_sysctl_kernel_core_pattern_empty_string" comment="variable object of the blank string" version="1">
-    <ind:var_ref>local_var_blank_path_sysctl_kernel_core_pattern_empty_string</ind:var_ref>
-  </ind:variable_object>
-
-  <local_variable comment="Blank string" datatype="string" id="local_var_blank_path_sysctl_kernel_core_pattern_empty_string" version="1">
-    <literal_component datatype="string"></literal_component>
-  </local_variable>
-
-  <ind:variable_object id="var_obj_symlink_sysctl_kernel_core_pattern_empty_string" comment="variable object of the symlinks found" version="1">
-    <ind:var_ref>local_var_symlinks_sysctl_kernel_core_pattern_empty_string</ind:var_ref>
-  </ind:variable_object>
-  <!-- </no symlink handling> -->
-
-  <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_symlinks_sysctl_kernel_core_pattern_empty_string" version="1">
-    <unique>
-      <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_symlinks" item_field="filepath" />
-    </unique>
-  </local_variable>
-
-  <!-- "pattern match" doesn't seem to work with symlink_object, not sure if a bug or not.
-       Workaround by querying for all conf files found -->
-  <unix:symlink_object comment="Symlinks referencing files in default dirs" id="object_sysctl_kernel_core_pattern_empty_string_symlinks" version="1">
-    <unix:filepath operation="equals" var_ref="local_var_conf_files_sysctl_kernel_core_pattern_empty_string" />
-    <filter action="exclude">state_symlink_points_outside_usual_dirs_sysctl_kernel_core_pattern_empty_string</filter>
-  </unix:symlink_object>
-
-  <!-- The state matches symlinks that don't point to the default dirs, i.e. paths that are not:
-       ^/etc/sysctl.conf$
-       ^/etc/sysctl.d/.*$
-       ^/run/sysctl.d/.*$
-       ^/usr/lib/sysctl.d/.*$ -->
-  <unix:symlink_state comment="State that matches symlinks referencing files not in the default dirs" id="state_symlink_points_outside_usual_dirs_sysctl_kernel_core_pattern_empty_string" version="1">
-    <unix:canonical_path operation="pattern match">^(?!(\/etc\/sysctl\.conf$|(\/etc|\/run|\/usr\/lib)\/sysctl\.d\/)).*$</unix:canonical_path>
-  </unix:symlink_state>
-{{% endif %}}
-  <local_variable comment="List of conf files" datatype="string" id="local_var_conf_files_sysctl_kernel_core_pattern_empty_string" version="1">
-    <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered" item_field="filepath" />
-  </local_variable>
-
-  <!-- Avoid directly referencing a possibly empty collection, one empty collection will cause the
-       variable to have no value even when there are valid objects. -->
-  <ind:textfilecontent54_object id="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered" version="1">
-    <set>
-      <object_reference>object_static_etc_sysctls_sysctl_kernel_core_pattern_empty_string</object_reference>
-      <object_reference>object_static_run_usr_sysctls_sysctl_kernel_core_pattern_empty_string</object_reference>
-    </set>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_object id="object_static_etc_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
+  <ind:textfilecontent54_object id="object_static_etc_lib_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
     <set>
       <object_reference>object_static_sysctl_sysctl_kernel_core_pattern_empty_string</object_reference>
       <object_reference>object_static_etc_sysctld_sysctl_kernel_core_pattern_empty_string</object_reference>
     </set>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_run_usr_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
+  <ind:textfilecontent54_object id="object_static_run_usr_local_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
     <set>
+      <object_reference>object_static_usr_local_lib_sysctld_sysctl_kernel_core_pattern_empty_string</object_reference>
       <object_reference>object_static_run_sysctld_sysctl_kernel_core_pattern_empty_string</object_reference>
     </set>
   </ind:textfilecontent54_object>
 
+  <!-- Individual directory objects -->
   <ind:textfilecontent54_object id="object_static_sysctl_sysctl_kernel_core_pattern_empty_string" version="1">
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
     <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
@@ -205,6 +118,23 @@
     <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_usr_local_lib_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
+    <ind:path>/usr/local/lib/sysctl.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Package-managed files: /usr/lib/sysctl.d/ -->
+  <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
+    <ind:path>/usr/lib/sysctl.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- State: subexpression must be empty string -->
   <ind:textfilecontent54_state id="state_static_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
     <ind:subexpression operation="equals" datatype="string"></ind:subexpression>
   </ind:textfilecontent54_state>


### PR DESCRIPTION
#### Description:

- Align the custom Bash, Ansible, and OVAL implementations of `sysctl_kernel_core_pattern_empty_string` with the patterns used by the `sysctl` template (as seen in the sibling rule `sysctl_kernel_core_pattern`). The rule cannot use the template directly because the sysctl template does not support empty string values without significant reengineering.

- **Bash**: Add bootc/container guard (`bash_not_bootc_build`) around `sysctl -w` call, add `/usr/local/lib/sysctl.d/` to the comment-out loop, add `--follow-symlinks` to sed, add systemd-sysctl symlink skip, write to `/etc/sysctl.d/kernel_core_pattern.conf` instead of `/etc/sysctl.conf`, use `bash_replace_or_append` macro with CCE identifiers.

- **Ansible**: Add `set_fact` for `sysctl_paths` including `/usr/local/lib/sysctl.d/`, add task to comment out entries from `/etc/sysctl.conf`, write to `/etc/sysctl.d/kernel_core_pattern.conf` instead of `/etc/sysctl.conf`.

- **OVAL**: Rewrite static check to use the template's OR-based structure (user files correct OR user files missing AND package-managed files correct), add `/usr/local/lib/sysctl.d/` and `/usr/lib/sysctl.d/` directory checks, drop custom "defined_in_one_file" and symlink handling checks.

#### Rationale:

- The custom Bash remediation called `sysctl -w` directly without the `bash_not_bootc_build()` guard, causing remediation failures in container/bootc build environments. Aligning the implementation with the template also brings consistency in directory coverage and config file handling.

- Fixes #14373

#### Review Hints:

- Affected products: rhel9, rhel10. Build with: `./build_product --datastream-only rhel10`

- Automatus tests all pass (7 scenarios × 2 remediation types = 14/14 on rhel10):
  ```
  ./tests/automatus.py rule --libvirt qemu:///system rhel10 --datastream build/ssg-rhel10-ds.xml sysctl_kernel_core_pattern_empty_string
  ./tests/automatus.py rule --libvirt qemu:///system rhel10 --datastream build/ssg-rhel10-ds.xml --remediate-using ansible sysctl_kernel_core_pattern_empty_string
  ```

- The rendered OVAL closely mirrors the template-generated OVAL for `sysctl_kernel_core_pattern`, except it uses `[[:blank:]]` instead of `[\s]` in regex patterns (to avoid a cross-newline matching issue) and checks for an empty string value instead of `|/bin/false`.

- Review all changes together — they form a single cohesive update.
