### PR TITLE
Set rpm crypto only if rpm scope exists

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_custom_crypto_policy_cis/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_custom_crypto_policy_cis/rule.yml
@@ -52,7 +52,8 @@ title: Implement Custom Crypto Policy Modules for CIS Benchmark
     {
         "module_name": "NO-RPMSHA1",
         "key": "hash@rpm",
-        "value": "-SHA1"
+        "value": "-SHA1",
+        "scope": "rpm-sequoia"
     },
 ] %}}
 {{% elif product == "rhel10" or product == "fedora" %}}

--- a/shared/templates/crypto_sub_policies/ansible.template
+++ b/shared/templates/crypto_sub_policies/ansible.template
@@ -4,7 +4,18 @@
 # complexity = low
 # disruption = low
 
+-   name: "{{{ rule_title }}} - Set the base crypto policy"
+    ansible.builtin.set_fact:
+        expected_crypto_policy: "{{{ BASE_POLICY }}}"
+
 {{% for sub_policy in SUB_POLICIES %}}
+{{% if "scope" in sub_policy %}}
+-   name: "{{{ rule_title }}} - Check That /etc/crypto-policies/back-ends/{{{ sub_policy.scope }}}.config Exists"
+    ansible.builtin.stat:
+        path: /etc/crypto-policies/back-ends/{{{ sub_policy.scope }}}.config
+    register: crypto_{{{ sub_policy.scope | replace("-", "_") }}}_scope
+{{% endif %}}
+
 -   name: "{{{ rule_title }}} - Create custom crypto policy module {{{ sub_policy.module_name }}}"
     ansible.builtin.lineinfile:
         path: /etc/crypto-policies/policies/modules/{{{ sub_policy.module_name }}}.pmod
@@ -14,6 +25,16 @@
         line: {{{ sub_policy.key }}} = {{{ sub_policy.value }}}
         create: true
         regexp: "{{{ sub_policy.key }}}"
+{{% if "scope" in sub_policy %}}
+    when: crypto_{{{ sub_policy.scope | replace("-", "_") }}}_scope.stat.exists
+{{% endif %}}
+
+-   name: "{{{ rule_title }}} - Update the expected policy"
+    ansible.builtin.set_fact:
+        expected_crypto_policy: "{{ expected_crypto_policy + ':{{{ sub_policy.module_name }}}' }}"
+{{% if "scope" in sub_policy %}}
+    when: crypto_{{{ sub_policy.scope | replace("-", "_") }}}_scope.stat.exists
+{{% endif %}}
 {{% endfor %}}
 
 -   name: "{{{ rule_title }}} - Check current crypto policy"
@@ -24,5 +45,5 @@
     check_mode: false
 
 -   name: "{{{ rule_title }}} - Update crypto-policies"
-    ansible.builtin.command: update-crypto-policies --set {{{ BASE_POLICY }}}:{{{ CONFIGURE_CRYPTO_POLICY_MODULES }}}
-    when: current_crypto_policy.stdout.strip() != "{{{ BASE_POLICY }}}:{{{ CONFIGURE_CRYPTO_POLICY_MODULES }}}"
+    ansible.builtin.command: update-crypto-policies --set {{ expected_crypto_policy }}
+    when: current_crypto_policy.stdout.strip() != expected_crypto_policy

--- a/shared/templates/crypto_sub_policies/bash.template
+++ b/shared/templates/crypto_sub_policies/bash.template
@@ -4,12 +4,22 @@
 # complexity = low
 # disruption = low
 
-{{% for sub_policy in SUB_POLICIES %}}
-{{{ bash_file_contents("/etc/crypto-policies/policies/modules/" ~ sub_policy.module_name ~ ".pmod", sub_policy.key ~ " = " ~ sub_policy.value) }}}
-{{% endfor %}}
+expected_crypto_policy="{{{ BASE_POLICY }}}"
+
+{{% for sub_policy in SUB_POLICIES -%}}
+{{% if "scope" in sub_policy %}}
+# this module is applicable only if {{{ sub_policy.scope }}} scope is available in crypto-policies
+if [[ -f /etc/crypto-policies/back-ends/{{{ sub_policy.scope }}}.config ]] ; then
+{{%- endif %}}
+expected_crypto_policy="${expected_crypto_policy}:{{{ sub_policy.module_name }}}"
+{{{ bash_file_contents("/etc/crypto-policies/policies/modules/" ~ sub_policy.module_name ~ ".pmod", sub_policy.key ~ " = " ~ sub_policy.value) | trim }}}
+{{% if "scope" in sub_policy -%}}
+fi
+{{% endif %}}
+{{%- endfor %}}
 
 current_crypto_policy=$(update-crypto-policies --show)
-expected_crypto_policy="{{{ BASE_POLICY }}}:{{{ CONFIGURE_CRYPTO_POLICY_MODULES }}}"
+
 if [[ "$current_crypto_policy" != "$expected_crypto_policy" ]] ; then
     update-crypto-policies --set "$expected_crypto_policy"
 fi

--- a/shared/templates/crypto_sub_policies/oval.template
+++ b/shared/templates/crypto_sub_policies/oval.template
@@ -3,8 +3,18 @@
         {{{ oval_metadata("Ensure that the custom crypto policy module is configured", rule_title=rule_title) }}}
         <criteria operator="AND" comment="Ensure that all of the correct lines are in the file.">
         {{% for sub_policy in SUB_POLICIES %}}
-            <criterion comment="Check that {{{ sub_policy.key }}} is configured in {{{ sub_policy.module_name }}}.pmod"
+            {{% if "scope" in sub_policy %}}
+                <criteria operator="OR" comment="If {{{ sub_policy.scope }}} scope is available then {{{ sub_policy.key }}} must be configured in {{{ sub_policy.module_name }}}.pmod">
+                    <criterion comment="Check that {{{ sub_policy.scope }}} scope is not available" negate="true" test_ref="test_{{{ rule_id }}}_{{{ sub_policy.scope }}}" />
+                    <criteria operator="AND" comment="Check that {{{ sub_policy.scope }}} scope is available AND {{{ sub_policy.key }}} is configured in {{{ sub_policy.module_name }}}.pmod">
+                        <criterion comment="Check that {{{ sub_policy.scope }}} scope is available" test_ref="test_{{{ rule_id }}}_{{{ sub_policy.scope }}}" />
+                        <criterion comment="Check that {{{ sub_policy.key }}} is configured in {{{ sub_policy.module_name }}}.pmod" test_ref="test_{{{ rule_id }}}_{{{ sub_policy.module_name }}}"/>
+                    </criteria>
+                </criteria>
+            {{% else %}}
+                <criterion comment="Check that {{{ sub_policy.key }}} is configured in {{{ sub_policy.module_name }}}.pmod"
                        test_ref="test_{{{ rule_id }}}_{{{ sub_policy.module_name }}}"/>
+            {{% endif %}}
         {{% endfor %}}
         </criteria>
     </definition>
@@ -21,5 +31,14 @@
             <ind:pattern operation="pattern match">^{{{ sub_policy.key }}} = {{{ sub_policy.value | escape_regex }}}$</ind:pattern>
             <ind:instance datatype="int">1</ind:instance>
         </ind:textfilecontent54_object>
+        {{% if "scope" in sub_policy %}}
+            <unix:file_test comment="Check that {{{ sub_policy.scope }}} scope is available" id="test_{{{ rule_id }}}_{{{ sub_policy.scope }}}" check="all" check_existence="all_exist" version="1">
+                <unix:object object_ref="object_{{{ rule_id }}}_{{{ sub_policy.scope }}}" />
+            </unix:file_test>
+
+            <unix:file_object comment="/etc/crypto-policies/back-ends/{{{ sub_policy.scope }}}.config" id="object_{{{ rule_id }}}_{{{ sub_policy.scope }}}" version="1">
+                <unix:filepath>/etc/crypto-policies/back-ends/{{{ sub_policy.scope }}}.config</unix:filepath>
+            </unix:file_object>
+        {{% endif %}}
         {{% endfor %}}
 </def-group>

--- a/shared/templates/crypto_sub_policies/template.py
+++ b/shared/templates/crypto_sub_policies/template.py
@@ -1,3 +1,0 @@
-def preprocess(data, lang):
-    data["configure_crypto_policy_modules"] = ":".join([sub_policy["module_name"] for sub_policy in data["sub_policies"]])
-    return data


### PR DESCRIPTION
#### Description:
Setting a crypto policy for RPM is possible only if the crypto-policies package provides the `rpm-sequoia` scope. This scope is new in RHEL 9.7 and doesn't exist in older minor versions of RHEL 9. If the `rpm-sequoia` scope isn't present in crypto-policies, the `update-crypto-policies` command fails to set the `NO-RPMSHA1` custom crypto policy module. That causes multiple problems, namely termination of the profile Ansible Playbook for CIS profiles.

We will fix the problem by first checking if the `rpm-sequoia` scope exists and we will define the `NO-RPMSHA1` custom crypto policy module only if the scope exists.

Addressing:
```
{"changed": true, "cmd": ["update-crypto-policies", "--set", "DEFAULT:NO-SHA1:NO-SSHCBC:NO-SSHWEAKCIPHERS:NO-SSHWEAKMACS:NO-WEAKMAC:NO-RPMSHA1"], "delta": "0:00:00.070451", "end": "2026-02-16 19:47:56.444333", "msg": "non-zero return code", "rc": 1, "start": "2026-02-16 19:47:56.373882", "stderr": "ScopeUnknownError: Unknown scope rpm\nErrors found in policy, first one: \nunknown scope rpm", "stderr_lines": ["ScopeUnknownError: Unknown scope rpm", "Errors found in policy, first one: ", "unknown scope rpm"], "stdout": "", "stdout_lines": []}
```

#### Rationale:

Resolves: https://issues.redhat.com/browse/OPENSCAP-6615

#### Review Hints:

Run contest test `/hardening/host-os/ansible/cis_server_l1` at least on RHEL 9.6 and RHEL 9.7, ideally on all RHEL versions.
