### PR TITLE
[stabilization] Fix a broken link

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
@@ -11,9 +11,7 @@ title: 'Disable XDMCP in GDM'
 {{% endif %}}
 
 description: |-
-    XDMCP is an unencrypted protocol, and therefore, presents a security risk, see e.g.
-    {{{ weblink("https://help.gnome.org/admin/gdm/stable/security.html.en_GB#xdmcpsecurity", "XDMCP Gnome docs") }}}.
-
+    XDMCP is an unencrypted protocol, and therefore, presents a security risk.
     To disable XDMCP support in Gnome, set <code>Enable</code> to <code>false</code> under the <code>[xdmcp]</code> configuration section in <code>{{{ gdm_conf_path }}}</code>. For example:
     <pre>
     [xdmcp]


### PR DESCRIPTION
I can't find the original content that the link pointed to. I think the content wasn't so important, so I will remove it.


This PR is a backport of https://github.com/ComplianceAsCode/content/pull/14455 to the stabilization branch.
