### PR TITLE
[Ubuntu 22.04] Bump STIG profile metadata from V2R3 to V2R7

### DIFF
--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -2,7 +2,7 @@
 policy: Canonical Ubuntu 22.04 LTS Security Technical Implementation Guide (STIG)
 title: Canonical Ubuntu 22.04 LTS Security Technical Implementation Guide (STIG)
 id: stig_ubuntu2204
-version: V2R3
+version: V2R7
 source: https://www.cyber.mil/stigs/downloads/
 
 levels:

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -2,7 +2,7 @@
 documentation_complete: true
 
 metadata:
-    version: V2R3
+    version: V2R7
     SMEs:
         - mpurg
         - dodys
@@ -11,11 +11,11 @@ metadata:
 
 reference: https://www.cyber.mil/stigs/downloads
 
-title: 'Canonical Ubuntu 22.04 LTS Security Technical Implementation Guide (STIG) V2R3'
+title: 'Canonical Ubuntu 22.04 LTS Security Technical Implementation Guide (STIG) V2R7'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for Canonical Ubuntu 22.04 LTS V2R3.
+    DISA STIG for Canonical Ubuntu 22.04 LTS V2R7.
 
 selections:
     - stig_ubuntu2204:all


### PR DESCRIPTION
## Summary

PRs [#14427](https://github.com/ComplianceAsCode/content/pull/14427), [#14418](https://github.com/ComplianceAsCode/content/pull/14418), [#14415](https://github.com/ComplianceAsCode/content/pull/14415), [#14416](https://github.com/ComplianceAsCode/content/pull/14416), and [#14433](https://github.com/ComplianceAsCode/content/pull/14433) merged V2R7 STIG rules for Ubuntu 22.04 LTS but the version metadata fields were not updated. This causes a mismatch where:

- STIG Viewer imports report **V2R3** in the header
- Auditors performing ATO reviews see **V2R3** in scan reports
- The actual content reflects **V2R7** rules

## Changes

| File | Change |
|------|--------|
| `controls/stig_ubuntu2204.yml` | `version: V2R3` → `version: V2R7` |
| `products/ubuntu2204/profiles/stig.profile` | `version`, `title`, and description strings V2R3 → V2R7 |

## Testing

This is a metadata-only change with no functional impact on rule evaluation. No build or test infrastructure required to verify correctness — the change is a string substitution aligning version labels to match the content already merged.

## References

- DISA Ubuntu 22.04 STIG V2R7: https://www.cyber.mil/stigs/downloads/