### PR TITLE
[SSH] Remove hmac-ripemd160 from sshd_strong_macs default and cis_sle12 selectors

### DIFF
--- a/linux_os/guide/services/ssh/sshd_strong_macs.var
+++ b/linux_os/guide/services/ssh/sshd_strong_macs.var
@@ -11,11 +11,11 @@ operator: equals
 interactive: false
 
 options:
-    default: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
+    default: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_rhel8: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
     cis_rhel9: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
     cis_rhel10: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
-    cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
+    cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_tencentos4: hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com
     cis_ubuntu2204: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256


### PR DESCRIPTION
## Summary

`hmac-ripemd160` was removed from OpenSSH in version 7.6 (released October 2017). Any deployment that uses the `default` or `cis_sle12` selector for `var_sshd_strong_macs` will fail `sshd` validation on restart, because the daemon rejects unrecognized MAC algorithm names with a fatal error.

## Root cause

The `default` and `cis_sle12` selectors in `sshd_strong_macs.var` still include `hmac-ripemd160` in their explicit allow-lists. All modern profile selectors already exclude it:

| Selector | Has hmac-ripemd160? |
|----------|---------------------|
| `default` | ✅ Yes — **broken** |
| `cis_sle12` | ✅ Yes — **broken** |
| `cis_sle15` | ❌ No — correct |
| `cis_ubuntu2204` | ❌ No — correct |
| `cis_ubuntu2404` | ❌ No — correct |
| `stig_rhel9` | ❌ No — correct |
| `stig_ol9` | ❌ No — correct |
| `cis_debian12` | ❌ No — correct |

Note: `cis_rhel8/9/10` use OpenSSH minus-prefix subtraction syntax (`MACs -hmac-md5,...`) and are not affected.

## Changes

One file, two lines:

- `default:` — removed trailing `,hmac-ripemd160`
- `cis_sle12:` — removed trailing `,hmac-ripemd160` (as noted by maintainer in #14363)

## Testing

On any system with OpenSSH 7.6+, applying the `default` or `cis_sle12` selector and restarting sshd will fail with:

```
/etc/ssh/sshd_config line N: Bad MAC algorithm 'hmac-ripemd160'.
```

After this fix, sshd restarts cleanly.

Fixes #14363