### PR TITLE
[Ubuntu 22.04] Add missing stigid@ubuntu2204 references: File Permissions and Ownership (UBTU-22-231000 to 232999)

### DIFF
--- a/linux_os/guide/auditing/file_permissions_auditd/file_ownership_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_ownership_audit_binaries/rule.yml
@@ -38,6 +38,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000256-GPOS-00097,SRG-OS-000257-GPOS-00098
+    stigid@ubuntu2204: UBTU-22-232110
 
 ocil: |-
     Verify it by running the following command:

--- a/linux_os/guide/auditing/file_permissions_auditd/file_permissions_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_permissions_audit_binaries/rule.yml
@@ -38,6 +38,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000256-GPOS-00097,SRG-OS-000257-GPOS-00098
+    stigid@ubuntu2204: UBTU-22-232035
 
 ocil: |-
     Verify it by running the following command:

--- a/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/rule.yml
@@ -37,3 +37,6 @@ template:
             - /var/log/journal/
         recursive: 'true'
         gid_or_name: 'systemd-journal'
+references:
+    stigid@ubuntu2204: UBTU-22-232085
+

--- a/linux_os/guide/system/logging/journald/dir_owner_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/dir_owner_system_journal/rule.yml
@@ -37,3 +37,6 @@ template:
             - /var/log/journal/
         recursive: 'true'
         uid_or_name: '0'
+references:
+    stigid@ubuntu2204: UBTU-22-232080
+

--- a/linux_os/guide/system/logging/journald/dir_permissions_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/dir_permissions_system_journal/rule.yml
@@ -37,3 +37,6 @@ template:
             - /var/log/journal/
         recursive: 'true'
         filemode: '2750'
+references:
+    stigid@ubuntu2204: UBTU-22-232027
+

--- a/linux_os/guide/system/logging/journald/file_groupowner_journalctl/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_groupowner_journalctl/rule.yml
@@ -30,3 +30,6 @@ template:
     vars:
         filepath: /usr/bin/journalctl
         gid_or_name: '0'
+references:
+    stigid@ubuntu2204: UBTU-22-232105
+

--- a/linux_os/guide/system/logging/journald/file_groupowner_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_groupowner_system_journal/rule.yml
@@ -45,6 +45,7 @@ fixtext: |
 
 references:
     srg: SRG-APP-000118-CTR-000240
+    stigid@ubuntu2204: UBTU-22-232095
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/journal/.*/system.journal", group="systemd-journal") }}}'
 

--- a/linux_os/guide/system/logging/journald/file_owner_journalctl/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_owner_journalctl/rule.yml
@@ -30,3 +30,6 @@ template:
     vars:
         filepath: /usr/bin/journalctl
         uid_or_name: '0'
+references:
+    stigid@ubuntu2204: UBTU-22-232100
+

--- a/linux_os/guide/system/logging/journald/file_owner_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_owner_system_journal/rule.yml
@@ -44,6 +44,7 @@ fixtext: |
 
 references:
     srg: SRG-APP-000118-CTR-000240
+    stigid@ubuntu2204: UBTU-22-232090
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/journal/.*/system.journal", owner="root") }}}'
 

--- a/linux_os/guide/system/logging/journald/file_permissions_journalctl/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_permissions_journalctl/rule.yml
@@ -28,3 +28,6 @@ template:
     vars:
         filepath: /usr/bin/journalctl
         filemode: '0740'
+references:
+    stigid@ubuntu2204: UBTU-22-232140
+

--- a/linux_os/guide/system/logging/journald/file_permissions_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_permissions_system_journal/rule.yml
@@ -42,6 +42,7 @@ fixtext: |
 
 references:
     srg: SRG-APP-000118-CTR-000240
+    stigid@ubuntu2204: UBTU-22-232027
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/journal/.*/system.journal", perms="-rw-r-----") }}}'
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
@@ -51,6 +51,7 @@ references:
     stigid@ol8: OL08-00-010190
     stigid@sle12: SLES-12-010460
     stigid@sle15: SLES-15-010300
+    stigid@ubuntu2204: UBTU-22-232145
 
 ocil_clause: 'any world-writable directories are missing the sticky bit'
 

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -39,6 +39,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000205-GPOS-00083
     stigid@sle15: SLES-15-010340
+    stigid@ubuntu2204: UBTU-22-232026
 
 ocil_clause: 'not all log files have permission 640 or stricter'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084,SRG-APP-000118-CTR-000240
     stigid@ol8: OL08-00-010260
+    stigid@ubuntu2204: UBTU-22-232125
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log", group=gid) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/rule.yml
@@ -16,6 +16,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000206-GPOS-00084
+    stigid@ubuntu2204: UBTU-22-232135
 
 {{%- if product in ['ubuntu2404'] %}}
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/syslog", group="adm|root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084,SRG-APP-000118-CTR-000240
     stigid@ol8: OL08-00-010250
+    stigid@ubuntu2204: UBTU-22-232120
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/rule.yml
@@ -18,6 +18,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000206-GPOS-00084
+    stigid@ubuntu2204: UBTU-22-232130
 
 {{%- if product in ['ubuntu2404'] %}}
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/syslog", owner="syslog|root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084,SRG-APP-000118-CTR-000240
     stigid@ol8: OL08-00-010240
+    stigid@ubuntu2204: UBTU-22-232025
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log", perms="drwxr-xr-x") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_syslog/rule.yml
@@ -13,6 +13,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000206-GPOS-00084
+    stigid@ubuntu2204: UBTU-22-232030
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/syslog", perms="-rw-r-----") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
@@ -42,6 +42,7 @@ references:
     stigid@ol8: OL08-00-010351
     stigid@sle12: SLES-12-010876
     stigid@sle15: SLES-15-010356
+    stigid@ubuntu2204: UBTU-22-232065
 
 ocil_clause: any system-wide shared library directory is returned and is not group-owned by a required system account
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_groupownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_groupownership_binary_dirs/rule.yml
@@ -33,6 +33,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000258-GPOS-00099
+    stigid@ubuntu2204: UBTU-22-232045
 
 ocil_clause: 'any of these directories are not owned by root group'
  

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_binary_dirs/rule.yml
@@ -24,6 +24,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000258-GPOS-00099
+    stigid@ubuntu2204: UBTU-22-232040
 
 ocil_clause: 'any system executables directories are found to not be owned by root'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
@@ -41,6 +41,7 @@ references:
     stigid@ol8: OL08-00-010341
     stigid@sle12: SLES-12-010874
     stigid@sle15: SLES-15-010354
+    stigid@ubuntu2204: UBTU-22-232060
 
 ocil_clause: any system-wide shared library directory is not owned by root
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_binary_dirs/rule.yml
@@ -29,6 +29,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000258-GPOS-00099
+    stigid@ubuntu2204: UBTU-22-232010
 
 ocil_clause: 'any of these files are group-writable or world-writable'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
@@ -52,6 +52,7 @@ references:
     stigid@ol8: OL08-00-010320
     stigid@sle12: SLES-12-010882
     stigid@sle15: SLES-15-010361
+    stigid@ubuntu2204: UBTU-22-232055
 
 ocil_clause: 'any system commands are returned and is not group-owned by a required system account'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
@@ -47,6 +47,7 @@ references:
     stigid@ol8: OL08-00-010310
     stigid@sle12: SLES-12-010879
     stigid@sle15: SLES-15-010359
+    stigid@ubuntu2204: UBTU-22-232050
 
 ocil_clause: 'any system commands are found to not be owned by root'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -47,6 +47,7 @@ references:
     stigid@ol8: OL08-00-010340
     stigid@sle12: SLES-12-010873
     stigid@sle15: SLES-15-010353
+    stigid@ubuntu2204: UBTU-22-232070
 
 ocil_clause: 'any system wide shared library file is not owned by root'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/rule.yml
@@ -47,6 +47,7 @@ references:
     stigid@ol8: OL08-00-010300
     stigid@sle12: SLES-12-010878
     stigid@sle15: SLES-15-010358
+    stigid@ubuntu2204: UBTU-22-232015
 
 ocil_clause: any system commands are found to be group-writable or world-writable
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -47,6 +47,7 @@ references:
     stigid@ol8: OL08-00-010330
     stigid@sle12: SLES-12-010871
     stigid@sle15: SLES-15-010351
+    stigid@ubuntu2204: UBTU-22-232020
 
 ocil_clause: any system-wide shared library file is found to be group-writable or world-writable
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -49,6 +49,7 @@ references:
     stigid@ol8: OL08-00-010350
     stigid@sle12: SLES-12-010875
     stigid@sle15: SLES-15-010355
+    stigid@ubuntu2204: UBTU-22-232075
 
 ocil_clause: any system wide shared library file is returned and is not group-owned by root{{{ gid_description }}}
 

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -85,6 +85,7 @@ references:
     stigid@ol8: OL08-00-010030
     stigid@sle12: SLES-12-010450
     stigid@sle15: SLES-15-010330
+    stigid@ubuntu2204: UBTU-22-231010
 
 ocil_clause: 'partitions do not have a type of crypto_LUKS'
 


### PR DESCRIPTION
## Problem

The ComplianceAsCode Ubuntu 22.04 STIG profile cannot map OpenSCAP scan results to DISA STIG checklist items in STIG Viewer. CKL exports have blank **Rule ID** fields for Ubuntu 22.04 rules.

**Root cause:** Rule.yml files are missing `stigid@ubuntu2204:` entries. Rules have `stigid@ol8`, `stigid@sle12`, and `stigid@sle15` — but `stigid@ubuntu2204` was never added.

## Solution

Add `stigid@ubuntu2204: UBTU-22-XXXXXX` to 31 rule.yml files for DISA Ubuntu 22.04 STIG V2R7 **File Permissions and Ownership** controls (UBTU-22-231000 to 232999).

All UBTU-22 IDs sourced from `controls/stig_ubuntu2204.yml`.

## Series

Part of a series adding `stigid@ubuntu2204` across all V2R7 categories:
- Auditing — 96 rules ([#14463](https://github.com/ComplianceAsCode/content/pull/14463))
- Password Policy — 24 rules ([#14464](https://github.com/ComplianceAsCode/content/pull/14464))
- Account Management — 21 rules ([#14465](https://github.com/ComplianceAsCode/content/pull/14465))
- **File Permissions and Ownership** (this PR) — 31 rules
- Networking, Software, System Config, GNOME, Kernel Modules — remaining PRs