### PR TITLE
[Ubuntu 22.04] Add missing stigid@ubuntu2204 references: Networking and Firewall (UBTU-22-251000 to 254099)

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -94,6 +94,7 @@ references:
     stigid@ol8: OL08-00-030740
     stigid@sle12: SLES-12-030300
     stigid@sle15: SLES-15-010400
+    stigid@ubuntu2204: UBTU-22-252010
 
 ocil_clause: '"maxpoll" has not been set to the value of "{{{ xccdf_value("var_time_service_set_maxpoll") }}}", is commented out, or is missing'
 

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
@@ -21,6 +21,7 @@ platform: package[chrony]
 
 references:
     srg: SRG-OS-000356-GPOS-00144
+    stigid@ubuntu2204: UBTU-22-252015
 
 ocil_clause: ''
 

--- a/linux_os/guide/services/sssd/package_sssd_installed/rule.yml
+++ b/linux_os/guide/services/sssd/package_sssd_installed/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: CM-6(a)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     srg: SRG-OS-000375-GPOS-00160
+    stigid@ubuntu2204: UBTU-22-254010
 
 
 ocil_clause: 'the package is not installed'

--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -28,6 +28,7 @@ references:
     nist: CM-6(a),IA-5(10)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     srg: SRG-OS-000375-GPOS-00160
+    stigid@ubuntu2204: UBTU-22-254015
 
 ocil_clause: 'the service is not enabled'
 

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/rule.yml
@@ -32,3 +32,6 @@ fixtext: |-
         certificate_verification = ca_cert,ocsp
         ca_cert = /etc/ssl/certs/ca-certificates.crt
     </pre>
+references:
+    stigid@ubuntu2204: UBTU-22-254020
+

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/rule.yml
@@ -36,6 +36,7 @@ references:
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     srg: SRG-OS-000375-GPOS-00160,SRG-OS-000376-GPOS-00161,SRG-OS-000377-GPOS-00162
     stigid@ol7: OL07-00-041002
+    stigid@ubuntu2204: UBTU-22-254020
 
 ocil_clause: 'it does not exist or ''pam'' is not added to the ''services'' option under the ''sssd'' section'
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -47,6 +47,7 @@ references:
     pcidss: Req-8.3
     srg: SRG-OS-000375-GPOS-00160,SRG-OS-000105-GPOS-00052,SRG-OS-000106-GPOS-00053,SRG-OS-000107-GPOS-00054,SRG-OS-000108-GPOS-00055
     stigid@ol8: OL08-00-020250
+    stigid@ubuntu2204: UBTU-22-254020
 
 ocil_clause: 'smart cards are not enabled in SSSD'
 

--- a/linux_os/guide/services/sssd/sssd_enable_user_cert/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_user_cert/rule.yml
@@ -19,3 +19,6 @@ rationale: |-
 severity: medium
 
 platform: package[sssd]
+references:
+    stigid@ubuntu2204: UBTU-22-254030
+

--- a/linux_os/guide/system/accounts/accounts-pam/package_nss_sss_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_nss_sss_installed/rule.yml
@@ -16,3 +16,6 @@ template:
     vars:
         pkgname: libnss-sss
         pkgname@ubuntu2404: libnss-sss
+references:
+    stigid@ubuntu2204: UBTU-22-254010
+

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_sss_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_sss_installed/rule.yml
@@ -16,3 +16,6 @@ template:
     vars:
         pkgname: libpam-sss
         pkgname@ubuntu2404: libpam-sss
+references:
+    stigid@ubuntu2204: UBTU-22-254010
+

--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/rule.yml
@@ -25,6 +25,7 @@ references:
     srg: SRG-OS-000359-GPOS-00146
     stigid@sle12: SLES-12-030310
     stigid@sle15: SLES-15-010410
+    stigid@ubuntu2204: UBTU-22-252020
 
 ocil_clause: 'the system real-time clock is not configured to use UTC as its time base'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000420-GPOS-00186,SRG-OS-000142-GPOS-00071
     stigid@sle12: SLES-12-030350
     stigid@sle15: SLES-15-010310
+    stigid@ubuntu2204: UBTU-22-253010
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.tcp_syncookies", value="1") }}}
 

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -23,3 +23,6 @@ fixtext: |-
     <pre>$ sudo ufw enable</pre>
 
 platform: system_with_kernel and package[ufw]
+references:
+    stigid@ubuntu2204: UBTU-22-251015
+

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -14,6 +14,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2204: UBTU-22-251010
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -12,6 +12,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2204: UBTU-22-251020
 
 ocil_clause: 'the service is not enabled'
 

--- a/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
@@ -44,6 +44,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000096-GPOS-00050
+    stigid@ubuntu2204: UBTU-22-251030
 
 ocil_clause: 'unauthorized network services can be accessed from the network'
 

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
@@ -40,6 +40,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000420-GPOS-00186
+    stigid@ubuntu2204: UBTU-22-251025
 
 ocil_clause: 'network interface not rate-limit'
 


### PR DESCRIPTION
## Problem

The ComplianceAsCode Ubuntu 22.04 STIG profile cannot map OpenSCAP scan results to DISA STIG checklist items in STIG Viewer. CKL exports have blank **Rule ID** fields for Ubuntu 22.04 rules.

**Root cause:** Rule.yml files are missing `stigid@ubuntu2204:` entries. Rules have `stigid@ol8`, `stigid@sle12`, and `stigid@sle15` — but `stigid@ubuntu2204` was never added.

## Solution

Add `stigid@ubuntu2204: UBTU-22-XXXXXX` to 17 rule.yml files for DISA Ubuntu 22.04 STIG V2R7 **Networking and Firewall** controls (UBTU-22-251000 to 254099).

All UBTU-22 IDs sourced from `controls/stig_ubuntu2204.yml`.

## Series

Part of a series adding `stigid@ubuntu2204` across all V2R7 categories:
- Auditing — 96 rules ([#14463](https://github.com/ComplianceAsCode/content/pull/14463))
- Password Policy — 24 rules ([#14464](https://github.com/ComplianceAsCode/content/pull/14464))
- Account Management — 21 rules ([#14465](https://github.com/ComplianceAsCode/content/pull/14465))
- File Permissions and Ownership — 31 rules ([#14466](https://github.com/ComplianceAsCode/content/pull/14466))
- **Networking and Firewall** (this PR) — 17 rules
- Software, System Config, GNOME, Kernel Modules — remaining PRs