### PR TITLE
[Ubuntu 22.04] Add missing stigid@ubuntu2204 references: Software and Packages (UBTU-22-214000 to 215099)

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
@@ -13,3 +13,4 @@ severity: unknown
 
 references:
     srg: SRG-OS-000366-GPOS-00153
+    stigid@ubuntu2204: UBTU-22-214010

--- a/linux_os/guide/services/deprecated/package_telnetd_removed/rule.yml
+++ b/linux_os/guide/services/deprecated/package_telnetd_removed/rule.yml
@@ -23,6 +23,7 @@ references:
     iso27001-2013: A.11.2.6,A.12.1.2,A.12.5.1,A.12.6.2,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.2,A.14.2.3,A.14.2.4,A.6.2.1,A.6.2.2,A.9.1.2
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
+    stigid@ubuntu2204: UBTU-22-215035
 
 template:
     name: package_removed

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-common_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-common_removed/rule.yml
@@ -20,3 +20,6 @@ template:
     name: package_removed
     vars:
         pkgname: nfs-common
+references:
+    stigid@ubuntu2204: UBTU-22-215040
+

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-kernel-server_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-kernel-server_removed/rule.yml
@@ -20,3 +20,6 @@ template:
     name: package_removed
     vars:
         pkgname: nfs-kernel-server
+references:
+    stigid@ubuntu2204: UBTU-22-215040
+

--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -30,6 +30,7 @@ references:
     ospp: FMT_SMF_EXT.1
     pcidss: Req-10.4
     srg: SRG-OS-000355-GPOS-00143
+    stigid@ubuntu2204: UBTU-22-215015
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/services/ntp/package_ntp_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_ntp_removed/rule.yml
@@ -18,3 +18,6 @@ template:
     name: package_removed
     vars:
         pkgname: ntp
+references:
+    stigid@ubuntu2204: UBTU-22-215025
+

--- a/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
@@ -27,3 +27,6 @@ template:
     vars:
         pkgname: systemd-timesyncd
 {{%- endif %}}
+references:
+    stigid@ubuntu2204: UBTU-22-215020
+

--- a/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
@@ -35,6 +35,7 @@ references:
     srg: SRG-OS-000095-GPOS-00049
     stigid@ol7: OL07-00-020000
     stigid@ol8: OL08-00-040010
+    stigid@ubuntu2204: UBTU-22-215030
 
 {{{ complete_ocil_entry_package(package="rsh-server") }}}
 

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000480-GPOS-00225
+    stigid@ubuntu2204: UBTU-22-215010
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -48,6 +48,7 @@ references:
     stigid@ol8: OL08-00-010440
     stigid@sle12: SLES-12-010570
     stigid@sle15: SLES-15-010560
+    stigid@ubuntu2204: UBTU-22-214015
 
 ocil_clause: |-
     {{%- if 'sle' in product or 'slmicro' in product %}}


### PR DESCRIPTION
## Problem

The ComplianceAsCode Ubuntu 22.04 STIG profile cannot map OpenSCAP scan results to DISA STIG checklist items in STIG Viewer. CKL exports have blank **Rule ID** fields for Ubuntu 22.04 rules.

**Root cause:** Rule.yml files are missing `stigid@ubuntu2204:` entries. Rules have `stigid@ol8`, `stigid@sle12`, and `stigid@sle15` — but `stigid@ubuntu2204` was never added.

## Solution

Add `stigid@ubuntu2204: UBTU-22-XXXXXX` to 10 rule.yml files for DISA Ubuntu 22.04 STIG V2R7 **Software and Packages** controls (UBTU-22-214000 to 215099).

All UBTU-22 IDs sourced from `controls/stig_ubuntu2204.yml`.

## Series

Part of a series adding `stigid@ubuntu2204` across all V2R7 categories:
- Auditing — 96 rules ([#14463](https://github.com/ComplianceAsCode/content/pull/14463))
- Password Policy — 24 rules ([#14464](https://github.com/ComplianceAsCode/content/pull/14464))
- Account Management — 21 rules ([#14465](https://github.com/ComplianceAsCode/content/pull/14465))
- File Permissions and Ownership — 31 rules ([#14466](https://github.com/ComplianceAsCode/content/pull/14466))
- Networking and Firewall — 17 rules ([#14467](https://github.com/ComplianceAsCode/content/pull/14467))
- **Software and Packages** (this PR) — 10 rules
- System Config, GNOME, Kernel Modules — remaining PRs