### PR TITLE
[Ubuntu 22.04] Add missing stigid@ubuntu2204 references: GNOME Display Manager (UBTU-22-271000 to 271099)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -52,6 +52,7 @@ references:
     stigid@ol8: OL08-00-010049
     stigid@sle12: SLES-12-010040
     stigid@sle15: SLES-15-010080
+    stigid@ubuntu2204: UBTU-22-271010
 
 ocil_clause: 'it is not'
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
@@ -56,6 +56,7 @@ references:
     stigid@ol8: OL08-00-010050
     stigid@sle12: SLES-12-010050
     stigid@sle15: SLES-15-010090
+    stigid@ubuntu2204: UBTU-22-271015
 
 ocil_clause: 'it does not'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -48,6 +48,7 @@ references:
     stigid@ol8: OL08-00-020060
     stigid@sle12: SLES-12-010080
     stigid@sle15: SLES-15-010120
+    stigid@ubuntu2204: UBTU-22-271025
 
 ocil_clause: 'idle-delay is set to 0 or a value greater than {{{ xccdf_value("inactivity_timeout_value") }}}'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol7: OL07-00-010110
     stigid@ol8: OL08-00-020031
+    stigid@ubuntu2204: UBTU-22-271025
 
 ocil_clause: 'the screensaver lock delay is missing, or is set to a value greater than {{{ xccdf_value("var_screensaver_lock_delay") }}}'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -55,6 +55,7 @@ references:
     stigid@ol8: OL08-00-020030,OL08-00-020082
     stigid@sle12: SLES-12-010060
     stigid@sle15: SLES-15-010100
+    stigid@ubuntu2204: UBTU-22-271020
 
 
 ocil_clause: 'screensaver locking is not enabled and/or has not been set or configured correctly'

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020231
     stigid@ol8: OL08-00-040171
+    stigid@ubuntu2204: UBTU-22-271030
 
 ocil_clause: 'GNOME3 is configured to reboot when Ctrl-Alt-Del is pressed'
 


### PR DESCRIPTION
## Problem

The ComplianceAsCode Ubuntu 22.04 STIG profile cannot map OpenSCAP scan results to DISA STIG checklist items in STIG Viewer. CKL exports have blank **Rule ID** fields for Ubuntu 22.04 rules.

**Root cause:** Rule.yml files are missing `stigid@ubuntu2204:` entries.

## Solution

Add `stigid@ubuntu2204: UBTU-22-XXXXXX` to 6 rule.yml files for DISA Ubuntu 22.04 STIG V2R7 **GNOME Display Manager** controls (UBTU-22-271000 to 271099).

All UBTU-22 IDs sourced from `controls/stig_ubuntu2204.yml`.

## Series

Part of a series — all 9 PRs: #14463 (Auditing), #14464 (Password Policy), #14465 (Account Mgmt), #14466 (File Perms), #14467 (Networking), #14468 (Software), #14469 (System Config), **this PR** (GNOME), and Kernel Modules.