### PR TITLE
[Ubuntu 22.04] Add missing stigid@ubuntu2204 references: Kernel Modules (UBTU-22-291000 to 291099)

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -63,6 +63,7 @@ references:
     stigid@ol8: OL08-00-040110
     stigid@sle12: SLES-12-030450
     stigid@sle15: SLES-15-010380
+    stigid@ubuntu2204: UBTU-22-291015
 
 ocil_clause: 'a wireless interface is configured and has not been documented and approved by the Information System Security Officer (ISSO)'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
@@ -45,6 +45,7 @@ references:
     stigid@ol8: OL08-00-040080
     stigid@sle12: SLES-12-010580
     stigid@sle15: SLES-15-010480
+    stigid@ubuntu2204: UBTU-22-291010
 
 {{{ complete_ocil_entry_module_disable(module="usb-storage") }}}
 


### PR DESCRIPTION
## Problem

The ComplianceAsCode Ubuntu 22.04 STIG profile cannot map OpenSCAP scan results to DISA STIG checklist items in STIG Viewer. CKL exports have blank **Rule ID** fields for Ubuntu 22.04 rules.

**Root cause:** Rule.yml files are missing `stigid@ubuntu2204:` entries.

## Solution

Add `stigid@ubuntu2204: UBTU-22-XXXXXX` to 2 rule.yml files for DISA Ubuntu 22.04 STIG V2R7 **Kernel Modules** controls (UBTU-22-291000 to 291099):
- `kernel_module_usb-storage_disabled` → UBTU-22-291010
- `wireless_disable_interfaces` → UBTU-22-291015

All UBTU-22 IDs sourced from `controls/stig_ubuntu2204.yml`.

## Series

Final PR in a series — all 9: #14463 (Auditing, 96 rules), #14464 (Password Policy, 24), #14465 (Account Mgmt, 21), #14466 (File Perms, 31), #14467 (Networking, 17), #14468 (Software, 10), #14469 (System Config, 9), #14470 (GNOME, 6), **this PR** (Kernel Modules, 2). Total: 230 rule.yml files.