### PR TITLE
Add a check for postquantum GPG key to RHEL 9 content

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -40,13 +40,18 @@
 
 {{% endif %}}
 
-{{% if "rhel" in families and major_version_ordinal >= 10 %}}
+{{% if "rhel" in families and major_version_ordinal >= 9 %}}
+{{% if major_version_ordinal >= 10 %}}
+{{% set pqc_min_version = "10.1" %}}
+{{% else %}}
+{{% set pqc_min_version = "9.7" %}}
+{{% endif %}}
 - name: "{{{ rule_title }}}: Set Fact - Valid fingerprints (without PQC)"
   ansible.builtin.set_fact:
     gpg_valid_fingerprints:
     - "{{{ release_key_fingerprint }}}"
     - "{{{ auxiliary_key_fingerprint }}}"
-  when: ansible_distribution_version is version('10.1', '<')
+  when: ansible_distribution_version is version('{{{ pqc_min_version }}}', '<')
 
 - name: "{{{ rule_title }}}: Set Fact - Valid fingerprints (with PQC)"
   ansible.builtin.set_fact:
@@ -54,7 +59,7 @@
     - "{{{ release_key_fingerprint }}}"
     - "{{{ auxiliary_key_fingerprint }}}"
     - "{{{ pqc_key_fingerprint }}}"
-  when: ansible_distribution_version is version('10.1', '>=')
+  when: ansible_distribution_version is version('{{{ pqc_min_version }}}', '>=')
 {{% else %}}
 - name: "{{{ rule_title }}}: Set Fact - Valid fingerprints"
   ansible.builtin.set_fact:

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -2,7 +2,7 @@
 # The two fingerprints below are retrieved from https://access.redhat.com/security/team/key
 readonly REDHAT_RELEASE_FINGERPRINT="{{{ release_key_fingerprint }}}"
 readonly REDHAT_AUXILIARY_FINGERPRINT="{{{ auxiliary_key_fingerprint }}}"
-{{% if "rhel" in families  and major_version_ordinal >= 10 %}}
+{{% if "rhel" in families  and major_version_ordinal >= 9 %}}
 readonly REDHAT_PQC_FINGERPRINT="{{{ pqc_key_fingerprint }}}"
 {{% endif %}}
 
@@ -26,8 +26,13 @@ then
   if [ "${GPG_RESULT}" -eq "0" ]
   then
   # If $REDHAT_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
-{{% if "rhel" in families  and major_version_ordinal >= 10 %}}
-    if {{{ bash_os_linux_conditional("rhel", expected_ver="10.1", op=">=") | trim }}}
+{{% if "rhel" in families  and major_version_ordinal >= 9 %}}
+{{% if major_version_ordinal >= 10 %}}
+{{% set pqc_min_version = "10.1" %}}
+{{% else %}}
+{{% set pqc_min_version = "9.7" %}}
+{{% endif %}}
+    if {{{ bash_os_linux_conditional("rhel", expected_ver=pqc_min_version, op=">=") | trim }}}
     then
       echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}|${REDHAT_PQC_FINGERPRINT}" || rpm --import "${REDHAT_RELEASE_KEY}"
     else

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -12,11 +12,16 @@
         test_ref="test_redhat_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
           <criterion comment="package gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}} is installed"
           test_ref="test_redhat_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
-{{% if "rhel" in families  and major_version_ordinal >= 10 %}}
-          <criteria comment="If RHEL is 10.1 or newer then PQC key must be installed" operator="OR">
-            <criterion comment="RHEL is older than 10.1" test_ref="test_{{{ rule_id }}}_rhel_is_10_1_or_newer" negate="true" />
-            <criteria comment="RHEL is 10.1 or newer AND PQC is installed" operator="AND">
-              <criterion comment="RHEL is 10.1 or newer" test_ref="test_{{{ rule_id }}}_rhel_is_10_1_or_newer" />
+{{% if "rhel" in families  and major_version_ordinal >= 9 %}}
+{{% if major_version_ordinal >= 10 %}}
+{{% set pqc_min_version = "10.1" %}}
+{{% else %}}
+{{% set pqc_min_version = "9.7" %}}
+{{% endif %}}
+          <criteria comment="If RHEL is {{{ pqc_min_version }}} or newer then PQC key must be installed" operator="OR">
+            <criterion comment="RHEL is older than {{{ pqc_min_version }}}" test_ref="test_{{{ rule_id }}}_rhel_pqc_version_check" negate="true" />
+            <criteria comment="RHEL is {{{ pqc_min_version }}} or newer AND PQC is installed" operator="AND">
+              <criterion comment="RHEL is {{{ pqc_min_version }}} or newer" test_ref="test_{{{ rule_id }}}_rhel_pqc_version_check" />
               <criterion comment="package gpg-pubkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}} is installed" test_ref="test_redhat_package_gpgkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}}_installed" />
             </criteria>
           </criteria>
@@ -64,7 +69,7 @@
     <linux:version>{{{ aux_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
-{{% if "rhel" in families  and major_version_ordinal >= 10 %}}
+{{% if "rhel" in families  and major_version_ordinal >= 9 %}}
   <!-- Test for Red Hat post quantum cryptography key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
   id="test_redhat_package_gpgkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}}_installed" version="1"
@@ -93,20 +98,25 @@
   </linux:rpminfo_state>
   {{%- endif %}}
 
-{{% if "rhel" in families and major_version_ordinal >= 10 %}}
-  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is greater than or equal 10.1" id="test_{{{ rule_id }}}_rhel_is_10_1_or_newer" version="1">
-    <ind:object object_ref="obj_{{{ rule_id }}}_rhel_is_10_1_or_newer" />
-    <ind:state state_ref="state_{{{ rule_id }}}_rhel_is_10_1_or_newer" />
+{{% if "rhel" in families and major_version_ordinal >= 9 %}}
+{{% if major_version_ordinal >= 10 %}}
+{{% set pqc_min_version = "10.1" %}}
+{{% else %}}
+{{% set pqc_min_version = "9.7" %}}
+{{% endif %}}
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is greater than or equal {{{ pqc_min_version }}}" id="test_{{{ rule_id }}}_rhel_pqc_version_check" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_rhel_pqc_version_check" />
+    <ind:state state_ref="state_{{{ rule_id }}}_rhel_pqc_version_check" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_rhel_is_10_1_or_newer" version="1">
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_rhel_pqc_version_check" version="1">
     <ind:filepath>/etc/os-release</ind:filepath>
     <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?([\w.]+)[&quot;&apos;]?$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_rhel_is_10_1_or_newer" version="1">
-    <ind:subexpression operation="greater than or equal" datatype="version">10.1</ind:subexpression>
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_rhel_pqc_version_check" version="1">
+    <ind:subexpression operation="greater than or equal" datatype="version">{{{ pqc_min_version }}}</ind:subexpression>
   </ind:textfilecontent54_state>
 {{% endif %}}
 

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -36,9 +36,12 @@ pkg_release: "4ae0493b"
 pkg_version: "fd431d51"
 aux_pkg_release: "6229229e"
 aux_pkg_version: "5a6340b3"
+pqc_pkg_release: "68e6a1f3"
+pqc_pkg_version: "05707a62"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "7E4624258C406535D56D6F135054E4A45A6340B3"
+pqc_key_fingerprint: "FCD355B305707A62DA143AB6E422397E50FE8467A2A95343D246D6276AFEDF8F"
 
 cpes_root: "../../shared/applicability"
 cpes:

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -59,6 +59,9 @@ pkg_manager_config_file: /etc/dnf/dnf.conf
 pkg_release: 4ae0493b
 pkg_system: rpm
 pkg_version: fd431d51
+pqc_key_fingerprint: "FCD355B305707A62DA143AB6E422397E50FE8467A2A95343D246D6276AFEDF8F"
+pqc_pkg_release: "68e6a1f3"
+pqc_pkg_version: "05707a62"
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common


### PR DESCRIPTION
#### Description:

Add a check for PQC on RHEL 9.

Extracted from https://github.com/ComplianceAsCode/content/pull/14462.

Currently **does not work**.

TODO:
- on RHEL 9.7 the key is shipped in a separate file `/etc/pki/rpm-gpg/RPM-GPG-KEY-PQC-redhat-release` whereas on RHEL 10.1 the key is a part of the common file `/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release`
- on RHEL 9.7 using the PQC signatures is optional and there is an entirely separate copy of RPM with PQ support that is not installed by default. IOW the users need to opt-in to use the key.
- on RHEL 9.7 the `sq` command that we use in our RHEL 10 remediation to get the fingerprint isn't available

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
