### PR TITLE
[stabilization] Check for PQC GPG key only on RHEL 10.1 and newer

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -40,13 +40,27 @@
 
 {{% endif %}}
 
+{{% if "rhel" in families and major_version_ordinal >= 10 %}}
+- name: "{{{ rule_title }}}: Set Fact - Valid fingerprints (without PQC)"
+  ansible.builtin.set_fact:
+    gpg_valid_fingerprints:
+    - "{{{ release_key_fingerprint }}}"
+    - "{{{ auxiliary_key_fingerprint }}}"
+  when: ansible_distribution_version is version('10.1', '<')
+
+- name: "{{{ rule_title }}}: Set Fact - Valid fingerprints (with PQC)"
+  ansible.builtin.set_fact:
+    gpg_valid_fingerprints:
+    - "{{{ release_key_fingerprint }}}"
+    - "{{{ auxiliary_key_fingerprint }}}"
+    - "{{{ pqc_key_fingerprint }}}"
+  when: ansible_distribution_version is version('10.1', '>=')
+{{% else %}}
 - name: "{{{ rule_title }}}: Set Fact - Valid fingerprints"
   ansible.builtin.set_fact:
     gpg_valid_fingerprints:
     - "{{{ release_key_fingerprint }}}"
     - "{{{ auxiliary_key_fingerprint }}}"
-{{% if "rhel" in families  and major_version_ordinal >= 10 %}}
-    - "{{{ pqc_key_fingerprint }}}"
 {{% endif %}}
 
 - name: "{{{ rule_title }}}: Import RedHat GPG key"

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -25,13 +25,16 @@ then
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then
+  # If $REDHAT_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
 {{% if "rhel" in families  and major_version_ordinal >= 10 %}}
-    echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}|${REDHAT_PQC_FINGERPRINT}" || {
+    if {{{ bash_os_linux_conditional("rhel", expected_ver="10.1", op=">=") | trim }}}
+    then
+      echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}|${REDHAT_PQC_FINGERPRINT}" || rpm --import "${REDHAT_RELEASE_KEY}"
+    else
+      echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || rpm --import "${REDHAT_RELEASE_KEY}"
+    fi
 {{% else %}}
-    echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || {
+    echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || rpm --import "${REDHAT_RELEASE_KEY}"
 {{% endif %}}
-      # If $REDHAT_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
-      rpm --import "${REDHAT_RELEASE_KEY}"
-    }
   fi
 fi

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -13,8 +13,13 @@
           <criterion comment="package gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}} is installed"
           test_ref="test_redhat_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
 {{% if "rhel" in families  and major_version_ordinal >= 10 %}}
-          <criterion comment="package gpg-pubkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}} is installed"
-          test_ref="test_redhat_package_gpgkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}}_installed" />
+          <criteria comment="If RHEL is 10.1 or newer then PQC key must be installed" operator="OR">
+            <criterion comment="RHEL is older than 10.1" test_ref="test_{{{ rule_id }}}_rhel_is_10_1_or_newer" negate="true" />
+            <criteria comment="RHEL is 10.1 or newer AND PQC is installed" operator="AND">
+              <criterion comment="RHEL is 10.1 or newer" test_ref="test_{{{ rule_id }}}_rhel_is_10_1_or_newer" />
+              <criterion comment="package gpg-pubkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}} is installed" test_ref="test_redhat_package_gpgkey-{{{ pqc_pkg_version }}}-{{{ pqc_pkg_release }}}_installed" />
+            </criteria>
+          </criteria>
 {{% endif %}}
       </criteria>
       {{%- if centos_major_version %}}
@@ -87,6 +92,23 @@
     <linux:version>{{{ centos_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
   {{%- endif %}}
+
+{{% if "rhel" in families and major_version_ordinal >= 10 %}}
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is greater than or equal 10.1" id="test_{{{ rule_id }}}_rhel_is_10_1_or_newer" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_rhel_is_10_1_or_newer" />
+    <ind:state state_ref="state_{{{ rule_id }}}_rhel_is_10_1_or_newer" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_rhel_is_10_1_or_newer" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?([\w.]+)[&quot;&apos;]?$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_rhel_is_10_1_or_newer" version="1">
+    <ind:subexpression operation="greater than or equal" datatype="version">10.1</ind:subexpression>
+  </ind:textfilecontent54_state>
+{{% endif %}}
 
 </def-group>
 {{% endif %}}


### PR DESCRIPTION
The redhat-release RPM package in RHEL 10.0 won't contain the postquantum OpenGPG key. This key will be present in RHEL 10.1 and newer.

Addressing:
Failing rule `ensure_redhat_gpgkey_installed` in multiple contest tests `/hardening/host-os/oscap` on RHEL 10.0.

This PR is a backport of PR https://github.com/ComplianceAsCode/content/pull/14462 to the stabilization branch.