### PR TITLE
Fix appending of ntp rule

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/bash/shared.sh
@@ -5,6 +5,8 @@
 
 config_file="{{{ chrony_conf_path }}}"
 
+sed -i -e '$a\' "$config_file"
+
 # Check and configigure servers in {{{ chrony_conf_path }}}
 IFS="," read -a SERVERS <<< $var_multiple_time_servers
 for srv in "${SERVERS[@]}"


### PR DESCRIPTION
#### Description:

- And eol if not exist to ntp conf

#### Rationale:

- We received a bug report https://bugs.launchpad.net/usg/+bug/2141667 which witnessed such remediation:
```
include /etc/chrony/conf.d/*.confserver 0.ubuntu.pool.ntp.org
```