### PR TITLE
[Ubuntu 24.04] Add stigid@ubuntu2404 references: Account Management

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -56,6 +56,7 @@ references:
     stigid@ol8: OL08-00-030000
     stigid@sle12: SLES-12-020240
     stigid@sle15: SLES-15-030640
+    stigid@ubuntu2404: UBTU-24-200580
 
 warnings:
     - general: |-

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
@@ -44,6 +44,7 @@ references:
     stigid@ol8: OL08-00-030170
     stigid@sle12: SLES-12-020210
     stigid@sle15: SLES-15-030010
+    stigid@ubuntu2404: UBTU-24-200290
 
 ocil_clause: 'the command does not return a line, or the line is commented out'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
@@ -43,6 +43,7 @@ references:
     stigid@ol8: OL08-00-030160
     stigid@sle12: SLES-12-020590
     stigid@sle15: SLES-15-030040
+    stigid@ubuntu2404: UBTU-24-200310
 
 ocil_clause: 'the system is not configured to audit account changes'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
@@ -45,6 +45,7 @@ references:
     stigid@ol8: OL08-00-030140
     stigid@sle12: SLES-12-020230
     stigid@sle15: SLES-15-030030
+    stigid@ubuntu2404: UBTU-24-200320
 
 ocil_clause: 'the command does not return a line, or the line is commented out'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
@@ -44,6 +44,7 @@ references:
     stigid@ol8: OL08-00-030150
     stigid@sle12: SLES-12-020200
     stigid@sle15: SLES-15-030000
+    stigid@ubuntu2404: UBTU-24-200280
 
 ocil_clause: 'the command does not return a line, or the line is commented out'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
@@ -44,6 +44,7 @@ references:
     stigid@ol8: OL08-00-030130
     stigid@sle12: SLES-12-020220
     stigid@sle15: SLES-15-030020
+    stigid@ubuntu2404: UBTU-24-200300
 
 ocil_clause: 'command does not return a line, or the line is commented out'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -38,6 +38,7 @@ references:
     nist: AC-8(a),AC-8(c),AC-17(a),CM-6(a)
     nist-csf: PR.AC-7
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000228-GPOS-00088
+    stigid@ubuntu2404: UBTU-24-200640
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue.net") }}}
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/rule.yml
@@ -59,6 +59,7 @@ references:
     cis@sle12: 1.8.1.3
     cis@sle15: 1.8.1.3
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000228-GPOS-00088
+    stigid@ubuntu2404: UBTU-24-200640
 
 ocil_clause: 'it does not display the required banner'
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/rule.yml
@@ -54,4 +54,6 @@ ocil: |-
     To check if the system motd banner is compliant,
     run the following command:
     <pre>$ less /etc/profile.d/ssh_confirm.sh</pre>
+references:
+    stigid@ubuntu2404: UBTU-24-200680
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -52,6 +52,7 @@ references:
     stigid@ol8: OL08-00-010049
     stigid@sle12: SLES-12-010040
     stigid@sle15: SLES-15-010080
+    stigid@ubuntu2404: UBTU-24-200650
 
 ocil_clause: 'it is not'
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
@@ -56,6 +56,7 @@ references:
     stigid@ol8: OL08-00-010050
     stigid@sle12: SLES-12-010050
     stigid@sle15: SLES-15-010090
+    stigid@ubuntu2404: UBTU-24-200660
 
 ocil_clause: 'it does not'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -19,6 +19,7 @@ references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020021
+    stigid@ubuntu2404: UBTU-24-200610
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -46,6 +46,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020011
+    stigid@ubuntu2404: UBTU-24-200610
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020013
+    stigid@ubuntu2404: UBTU-24-200610
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020019
+    stigid@ubuntu2404: UBTU-24-200610
 
 ocil_clause: 'the system shows messages when three unsuccessful logon attempts occur'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -47,6 +47,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020015
+    stigid@ubuntu2404: UBTU-24-200610
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -53,6 +53,7 @@ references:
     stigid@ol8: OL08-00-020260
     stigid@sle12: SLES-12-010340
     stigid@sle15: SLES-15-020050
+    stigid@ubuntu2404: UBTU-24-200260
 
 ocil_clause: 'the value of INACTIVE is greater than the expected value or is -1'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -47,6 +47,7 @@ references:
     stigid@ol8: OL08-00-020000,OL08-00-020270
     stigid@sle12: SLES-12-010331
     stigid@sle15: SLES-15-020061
+    stigid@ubuntu2404: UBTU-24-200250
 
 ocil_clause: 'any temporary accounts have no expiration date set or do not expire within 72 hours'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
@@ -41,6 +41,7 @@ references:
     stigid@ol8: OL08-00-020024
     stigid@sle12: SLES-12-010120
     stigid@sle15: SLES-15-020020
+    stigid@ubuntu2404: UBTU-24-200000
 
 ocil_clause: |-
     the "maxlogins" item is missing, commented out, or the value is set greater

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -65,6 +65,7 @@ references:
     stigid@ol7: OL07-00-040160
     stigid@sle12: SLES-12-010090
     stigid@sle15: SLES-15-010130
+    stigid@ubuntu2404: UBTU-24-200060
 
 ocil_clause: 'the TMOUT value is not configured, is set to 0, or is not less than or equal to the expected setting'
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
@@ -34,6 +34,7 @@ references:
     nist: AC-17(1)
     srg: SRG-OS-000032-GPOS-00013
     stigid@ol8: OL08-00-010070
+    stigid@ubuntu2404: UBTU-24-200090
 
 ocil_clause: 'remote access methods are not logging to rsyslog'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -48,6 +48,7 @@ references:
     stigid@ol8: OL08-00-020060
     stigid@sle12: SLES-12-010080
     stigid@sle15: SLES-15-010120
+    stigid@ubuntu2404: UBTU-24-200020
 
 ocil_clause: 'idle-delay is set to 0 or a value greater than {{{ xccdf_value("inactivity_timeout_value") }}}'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol7: OL07-00-010110
     stigid@ol8: OL08-00-020031
+    stigid@ubuntu2404: UBTU-24-200020
 
 ocil_clause: 'the screensaver lock delay is missing, or is set to a value greater than {{{ xccdf_value("var_screensaver_lock_delay") }}}'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -55,6 +55,7 @@ references:
     stigid@ol8: OL08-00-020030,OL08-00-020082
     stigid@sle12: SLES-12-010060
     stigid@sle15: SLES-15-010100
+    stigid@ubuntu2404: UBTU-24-200040
 
 
 ocil_clause: 'screensaver locking is not enabled and/or has not been set or configured correctly'


### PR DESCRIPTION
## Summary

Adds missing stigid@ubuntu2404 cross-references to 24 rule.yml files mapping to UBTU-24 STIG IDs for account management controls (concurrent sessions, temp account expiration, inactive accounts, audit rules for passwd/group/shadow modifications).

### Coverage Gap Addressed

Ubuntu 24.04 LTS (UBTU-24-XXXXXX) had **zero** `stigid@ubuntu2404` entries in ComplianceAsCode/content prior to this PR series. This PR is part of an 11-PR series covering all 230 rules mapped in `controls/stig_ubuntu2404.yml`.

### Changes

- Category: **Account Management**
- Files modified: rule.yml files with `stigid@ubuntu2404: UBTU-24-XXXXXX` added to `references:` block
- No functional logic changes — reference metadata only
- All existing `references:` entries preserved

### Related PRs in this series

This PR is part of the same series as the Ubuntu 22.04 STIG stigid@ gap-filling work (#14463–#14471).

### Testing

```bash
# Verify stigid@ubuntu2404 appears in modified files
grep -r "stigid@ubuntu2404" linux_os/ | wc -l
```

Fixes part of: Ubuntu 24.04 has zero `stigid@ubuntu2404` coverage in CaC (V1R1)