### PR TITLE
[Ubuntu 24.04] Add stigid@ubuntu2404 references: File Integrity and Logging

### DIFF
--- a/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.DS-4,PR.PT-1
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010561
+    stigid@ubuntu2404: UBTU-24-100200
 
 ocil_clause: '{{{ ocil_clause_service_enabled(service="rsyslog") }}}'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -73,6 +73,7 @@ references:
     stigid@ol8: OL08-00-010359
     stigid@sle12: SLES-12-010499
     stigid@sle15: SLES-15-010419
+    stigid@ubuntu2404: UBTU-24-100110
 
 ocil_clause: 'there is no database file'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/rule.yml
@@ -14,6 +14,7 @@ severity: medium
 
 references:
     srg: "SRG-OS-000447-GPOS-00201,SRG-OS-000363-GPOS-00150"
+    stigid@ubuntu2404: UBTU-24-100130
 
 ocil_clause: 'silentreports is enabled in aide default configuration, or is missing'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/rule.yml
@@ -40,6 +40,7 @@ references:
     srg: SRG-OS-000363-GPOS-00150,SRG-OS-000446-GPOS-00200,SRG-OS-000447-GPOS-00201
     stigid@ol7: OL07-00-020030
     stigid@sle15: SLES-15-010570
+    stigid@ubuntu2404: UBTU-24-100120
 
 platform: package[aide] and package[systemd]
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -59,6 +59,7 @@ references:
     stigid@ol7: OL07-00-020030
     stigid@sle12: SLES-12-010500
     stigid@sle15: SLES-15-010420
+    stigid@ubuntu2404: UBTU-24-100120
 
 ocil_clause: 'AIDE is not configured to scan periodically'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -37,6 +37,7 @@ references:
     stigid@ol8: OL08-00-010359
     stigid@sle12: SLES-12-010499
     stigid@sle15: SLES-15-010419
+    stigid@ubuntu2404: UBTU-24-100100
 
 ocil_clause: 'the package is not installed'
 


### PR DESCRIPTION
## Summary

Adds missing stigid@ubuntu2404 cross-references to 6 rule.yml files for AIDE file integrity monitoring (install, build database, periodic checking, silent reports) and rsyslog service.

### Coverage Gap Addressed

Ubuntu 24.04 LTS (UBTU-24-XXXXXX) had **zero** `stigid@ubuntu2404` entries in ComplianceAsCode/content prior to this PR series. This PR is part of an 11-PR series covering all 230 rules mapped in `controls/stig_ubuntu2404.yml`.

### Changes

- Category: **File Integrity and Logging**
- Files modified: rule.yml files with `stigid@ubuntu2404: UBTU-24-XXXXXX` added to `references:` block
- No functional logic changes — reference metadata only
- All existing `references:` entries preserved

### Related PRs in this series

This PR is part of the same series as the Ubuntu 22.04 STIG stigid@ gap-filling work (#14463–#14471).

### Testing

```bash
# Verify stigid@ubuntu2404 appears in modified files
grep -r "stigid@ubuntu2404" linux_os/ | wc -l
```

Fixes part of: Ubuntu 24.04 has zero `stigid@ubuntu2404` coverage in CaC (V1R1)