### PR TITLE
[Ubuntu 24.04] Add stigid@ubuntu2404 references: Networking and Firewall

### DIFF
--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -23,3 +23,6 @@ fixtext: |-
     <pre>$ sudo ufw enable</pre>
 
 platform: system_with_kernel and package[ufw]
+references:
+    stigid@ubuntu2404: UBTU-24-100310
+

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -14,6 +14,7 @@ severity: medium
 
 references:
     srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2404: UBTU-24-100300
 
 ocil_clause: 'the package is not installed'
 


### PR DESCRIPTION
## Summary

Adds missing stigid@ubuntu2404 cross-references to 2 rule.yml files for UFW firewall package installation and active state verification.

### Coverage Gap Addressed

Ubuntu 24.04 LTS (UBTU-24-XXXXXX) had **zero** `stigid@ubuntu2404` entries in ComplianceAsCode/content prior to this PR series. This PR is part of an 11-PR series covering all 230 rules mapped in `controls/stig_ubuntu2404.yml`.

### Changes

- Category: **Networking and Firewall**
- Files modified: rule.yml files with `stigid@ubuntu2404: UBTU-24-XXXXXX` added to `references:` block
- No functional logic changes — reference metadata only
- All existing `references:` entries preserved

### Related PRs in this series

This PR is part of the same series as the Ubuntu 22.04 STIG stigid@ gap-filling work (#14463–#14471).

### Testing

```bash
# Verify stigid@ubuntu2404 appears in modified files
grep -r "stigid@ubuntu2404" linux_os/ | wc -l
```

Fixes part of: Ubuntu 24.04 has zero `stigid@ubuntu2404` coverage in CaC (V1R1)