### PR TITLE
[Ubuntu 24.04] Add stigid@ubuntu2404 references: Packages

### DIFF
--- a/linux_os/guide/services/deprecated/package_telnetd_removed/rule.yml
+++ b/linux_os/guide/services/deprecated/package_telnetd_removed/rule.yml
@@ -23,6 +23,7 @@ references:
     iso27001-2013: A.11.2.6,A.12.1.2,A.12.5.1,A.12.6.2,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.2,A.14.2.3,A.14.2.4,A.6.2.1,A.6.2.2,A.9.1.2
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
+    stigid@ubuntu2404: UBTU-24-100030
 
 template:
     name: package_removed

--- a/linux_os/guide/services/ntp/package_ntp_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_ntp_removed/rule.yml
@@ -18,3 +18,6 @@ template:
     name: package_removed
     vars:
         pkgname: ntp
+references:
+    stigid@ubuntu2404: UBTU-24-100020
+

--- a/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
@@ -27,3 +27,6 @@ template:
     vars:
         pkgname: systemd-timesyncd
 {{%- endif %}}
+references:
+    stigid@ubuntu2404: UBTU-24-100010
+

--- a/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
@@ -35,6 +35,7 @@ references:
     srg: SRG-OS-000095-GPOS-00049
     stigid@ol7: OL07-00-020000
     stigid@ol8: OL08-00-040010
+    stigid@ubuntu2404: UBTU-24-100040
 
 {{{ complete_ocil_entry_package(package="rsh-server") }}}
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -44,6 +44,7 @@ references:
     stigid@ol8: OL08-00-030650
     stigid@sle12: SLES-12-010540
     stigid@sle15: SLES-15-030630
+    stigid@ubuntu2404: UBTU-24-90890
 
 ocil_clause: 'integrity checks of the audit tools are missing or incomplete'
 


### PR DESCRIPTION
## Summary

Adds missing stigid@ubuntu2404 cross-references to 5 rule.yml files for prohibited package removal (telnet, rsh-server, ntp, systemd-timesyncd) and one miscellaneous control.

### Coverage Gap Addressed

Ubuntu 24.04 LTS (UBTU-24-XXXXXX) had **zero** `stigid@ubuntu2404` entries in ComplianceAsCode/content prior to this PR series. This PR is part of an 11-PR series covering all 230 rules mapped in `controls/stig_ubuntu2404.yml`.

### Changes

- Category: **Packages**
- Files modified: rule.yml files with `stigid@ubuntu2404: UBTU-24-XXXXXX` added to `references:` block
- No functional logic changes — reference metadata only
- All existing `references:` entries preserved

### Related PRs in this series

This PR is part of the same series as the Ubuntu 22.04 STIG stigid@ gap-filling work (#14463–#14471).

### Testing

```bash
# Verify stigid@ubuntu2404 appears in modified files
grep -r "stigid@ubuntu2404" linux_os/ | wc -l
```

Fixes part of: Ubuntu 24.04 has zero `stigid@ubuntu2404` coverage in CaC (V1R1)