### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — System Configuration (11 rules)

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
@@ -35,6 +35,7 @@ references:
     nist-csf: PR.AC-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040321
+    stigid@ol9: OL09-00-000020
 
 ocil_clause: 'the system default target is not set to "multi-user.target" and the Information System Security Officer (ISSO) lacks a documented requirement for a graphical user interface'
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000080-GPOS-00048
     stigid@ol7: OL07-00-010481
     stigid@ol8: OL08-00-010152
+    stigid@ol9: OL09-00-000025
 
 ocil_clause: 'the output is different'
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -45,6 +45,7 @@ references:
     srg: SRG-OS-000080-GPOS-00048
     stigid@ol7: OL07-00-010481
     stigid@ol8: OL08-00-010151
+    stigid@ol9: OL09-00-000030
 
 ocil_clause: 'the output is different'
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
@@ -39,6 +39,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021310
     stigid@ol8: OL08-00-010800
+    stigid@ol9: OL09-00-000003
     stigid@sle12: SLES-12-010850
     stigid@sle15: SLES-15-040200
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -33,6 +33,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021340
     stigid@ol8: OL08-00-010543
+    stigid@ol9: OL09-00-000004
 
 {{{ complete_ocil_entry_separate_partition(part="/tmp") }}}
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021320
     stigid@ol8: OL08-00-010540
+    stigid@ol9: OL09-00-000005
     stigid@sle12: SLES-12-010860
     stigid@sle15: SLES-15-040210
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
@@ -35,6 +35,7 @@ references:
     nist-csf: PR.PT-1,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010541
+    stigid@ol9: OL09-00-000006
 
 {{{ complete_ocil_entry_separate_partition(part="/var/log") }}}
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000341-GPOS-00132,SRG-OS-000480-GPOS-00227,SRG-APP-000357-CTR-000800
     stigid@ol7: OL07-00-021330
     stigid@ol8: OL08-00-010542
+    stigid@ol9: OL09-00-000002
     stigid@sle12: SLES-12-010870
     stigid@sle15: SLES-15-030810
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -29,6 +29,7 @@ references:
     cis@sle15: 1.1.11
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010544
+    stigid@ol9: OL09-00-000007
 
 {{{ complete_ocil_entry_separate_partition(part="/var/tmp") }}}
 

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
@@ -52,6 +52,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020250
     stigid@ol8: OL08-00-010000
+    stigid@ol9: OL09-00-000010
     stigid@sle12: SLES-12-010000
     stigid@sle15: SLES-15-010000
 

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -66,6 +66,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020260
     stigid@ol8: OL08-00-010010
+    stigid@ol9: OL09-00-000015
     stigid@sle12: SLES-12-010010
     stigid@sle15: SLES-15-010010
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **System Configuration** category (11 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.