### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Software / Packages (11 rules)

### DIFF
--- a/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/rule.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/rule.yml
@@ -32,6 +32,7 @@ references:
     srg: SRG-OS-000074-GPOS-00042,SRG-OS-000095-GPOS-00049,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040690
     stigid@ol8: OL08-00-040360
+    stigid@ol9: OL09-00-000130
     stigid@sle12: SLES-12-030011
     stigid@sle15: SLES-15-010030
 

--- a/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
+++ b/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
@@ -32,6 +32,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000095-GPOS-00049
     stigid@ol8: OL08-00-040002
+    stigid@ol9: OL09-00-000150
 
 {{{ complete_ocil_entry_package(package="sendmail") }}}
 

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/rule.yml
@@ -27,6 +27,7 @@ references:
     cis@sle12: 2.2.7
     cis@sle15: 2.2.7
     srg: SRG-OS-000095-GPOS-00049
+    stigid@ol9: OL09-00-000100
 
 {{{ complete_ocil_entry_package(package="nfs-utils") }}}
 

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
@@ -48,6 +48,7 @@ references:
     srg: SRG-OS-000095-GPOS-00049
     stigid@ol7: OL07-00-021710
     stigid@ol8: OL08-00-040000
+    stigid@ol9: OL09-00-000110
     stigid@sle12: SLES-12-030000
     stigid@sle15: SLES-15-010180
 

--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -40,6 +40,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040700
     stigid@ol8: OL08-00-040190
+    stigid@ol9: OL09-00-000135
 
 {{{ complete_ocil_entry_package(package=package_name) }}}
 

--- a/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/rule.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/rule.yml
@@ -28,6 +28,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-000140
 
 {{{ complete_ocil_entry_package(package="quagga") }}}
 

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -33,6 +33,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040730
     stigid@ol8: OL08-00-040320
+    stigid@ol9: OL09-00-000145
 
 ocil_clause: 'xorg related packages are not removed and run level is not correctly configured'
 

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     srg: SRG-OS-000095-GPOS-00049,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040370
+    stigid@ol9: OL09-00-000115
 
 {{{ complete_ocil_entry_package(package="gssproxy") }}}
 

--- a/linux_os/guide/system/software/system-tools/package_iprutils_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_iprutils_removed/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
     srg: SRG-OS-000095-GPOS-00049,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040380
+    stigid@ol9: OL09-00-000120
 
 {{{ complete_ocil_entry_package(package="iprutils") }}}
 

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 references:
     srg: SRG-OS-000095-GPOS-00049,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040390
+    stigid@ol9: OL09-00-000125
 
 {{{ complete_ocil_entry_package(package="tuned") }}}
 

--- a/linux_os/guide/system/software/updating/ensure_epel_repos_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_epel_repos_disabled/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000095-GPOS-00049
+    stigid@ol9: OL09-00-000105
 
 ocil_clause: 'EPEL repository is enabled'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Software / Packages** category (11 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.