### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Networking & Firewall (6 rules)

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -36,6 +36,7 @@ references:
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000298-GPOS-00116,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00232
     stigid@ol7: OL07-00-040520
     stigid@ol8: OL08-00-040100
+    stigid@ol9: OL09-00-000220
     stigid@sle15: SLES-15-010220
 
 ocil_clause: 'the package is not installed'

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00231,SRG-OS-000480-GPOS-00232
     stigid@ol7: OL07-00-040520
     stigid@ol8: OL08-00-040101
+    stigid@ol9: OL09-00-000221
     stigid@sle15: SLES-15-010220
 
 ocil_clause: '{{{ ocil_clause_service_enabled("firewalld") }}}'

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/rule.yml
@@ -47,6 +47,7 @@ references:
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115
     stigid@ol7: OL07-00-040100
     stigid@ol8: OL08-00-040030
+    stigid@ol9: OL09-00-000222
 
 ocil_clause: 'there are additional ports, protocols, or services that are not in the PPSM CLSA, or there are ports, protocols, or services that are prohibited by the PPSM Category Assurance List (CAL), or there are no firewall rules configured'
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configured_firewalld_default_deny/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configured_firewalld_default_deny/rule.yml
@@ -23,6 +23,7 @@ references:
     nist: AC-17 (1)
     srg: SRG-OS-000297-GPOS-00115
     stigid@ol8: OL08-00-040090
+    stigid@ol9: OL09-00-000224
 
 ocil_clause: 'no zones are active on the interfaces or if the target is set to a different option other than "DROP"'
 

--- a/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-000210
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/selinux/package_policycoreutils_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils_installed/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 references:
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000134-GPOS-00068
     stigid@ol8: OL08-00-010171
+    stigid@ol9: OL09-00-000200
 
 ocil_clause: 'the policycoreutils package is not installed'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Networking & Firewall** category (6 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.