### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — SSH & Crypto Policy (18 rules)

### DIFF
--- a/linux_os/guide/services/ssh/file_sshd_50_redhat_exists/rule.yml
+++ b/linux_os/guide/services/ssh/file_sshd_50_redhat_exists/rule.yml
@@ -17,6 +17,7 @@ identifiers:
 references:
     nist: AC-17 (2)
     srg: SRG-OS-000250-GPOS-00093
+    stigid@ol9: OL09-00-000252
 
 severity: medium
 

--- a/linux_os/guide/services/ssh/package_openssh-clients_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-clients_installed/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
     ospp: FIA_UAU.5,FTP_ITC_EXT.1,FCS_SSH_EXT.1,FCS_SSHC_EXT.1
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-000260
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
@@ -31,6 +31,7 @@ references:
     srg: SRG-OS-000423-GPOS-00187,SRG-OS-000424-GPOS-00188,SRG-OS-000425-GPOS-00189,SRG-OS-000426-GPOS-00190
     stigid@ol7: OL07-00-040300
     stigid@ol8: OL08-00-040159
+    stigid@ol9: OL09-00-000250
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -40,6 +40,7 @@ references:
     srg: SRG-OS-000423-GPOS-00187,SRG-OS-000424-GPOS-00188,SRG-OS-000425-GPOS-00189,SRG-OS-000426-GPOS-00190
     stigid@ol7: OL07-00-040310
     stigid@ol8: OL08-00-040160
+    stigid@ol9: OL09-00-000251
     stigid@sle12: SLES-12-030100
     stigid@sle15: SLES-15-010530
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -46,6 +46,7 @@ references:
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000228-GPOS-00088
     stigid@ol7: OL07-00-040170
     stigid@ol8: OL08-00-010040
+    stigid@ol9: OL09-00-000256
     stigid@sle12: SLES-12-030050
     stigid@sle15: SLES-15-010040
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_include_crypto_policy/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_include_crypto_policy/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     nist: AC-17 (2)
     srg: SRG-OS-000250-GPOS-00093
+    stigid@ol9: OL09-00-000252
 
 checktext: |-
     Verify that {{{ full_name }}} implements DOD-approved encryption ciphers for SSH connections.

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -67,6 +67,7 @@ references:
     ospp: FCS_COP.1(1),FCS_COP.1(2),FCS_COP.1(3),FCS_COP.1(4),FCS_CKM.1,FCS_CKM.2,FCS_TLSC_EXT.1
     srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
     stigid@ol8: OL08-00-010020
+    stigid@ol9: OL09-00-000241
 
 ocil_clause: 'cryptographic policy is not configured or is configured incorrectly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
@@ -30,6 +30,7 @@ identifiers:
 references:
     nist: AC-17(2)
     srg: SRG-OS-000033-GPOS-00014,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174,SRG-OS-000423-GPOS-00187
+    stigid@ol9: OL09-00-000261
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
@@ -31,6 +31,7 @@ references:
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
     stigid@ol8: OL08-00-010291
+    stigid@ol9: OL09-00-000254
 
 ocil_clause: 'Crypto Policy for OpenSSH Server is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
+    stigid@ol9: OL09-00-000262
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
@@ -29,6 +29,7 @@ references:
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
     stigid@ol8: OL08-00-010290
+    stigid@ol9: OL09-00-000255
 
 ocil_clause: 'Crypto Policy for OpenSSH Server is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     ospp: FCS_COP.1(1),FCS_COP.1(2),FCS_COP.1(3),FCS_COP.1(4),FCS_CKM.1,FCS_CKM.2,FCS_TLSC_EXT.1
     srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
+    stigid@ol9: OL09-00-000240
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
@@ -32,6 +32,7 @@ severity: medium
 references:
     nist: SC-13,MA-4(6)
     srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
+    stigid@ol9: OL09-00-000242
 
 ocil_clause: Any file shows a different output
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_crypto_policies/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_crypto_policies/rule.yml
@@ -24,6 +24,7 @@ severity: high
 
 references:
     srg: SRG-OS-000478-GPOS-00223,SRG-OS-000396-GPOS-00176
+    stigid@ol9: OL09-00-000244
 
 ocil_clause: 'there is output'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
@@ -53,6 +53,7 @@ references:
     pcidss: Req-11.5
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010020
+    stigid@ol9: OL09-00-000243
 
 ocil_clause: 'there is output'
 

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
@@ -30,6 +30,7 @@ references:
     nist: CM-6(a)
     ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000324-GPOS-00125
+    stigid@ol9: OL09-00-000230
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/sudo/sudo_restrict_privilege_elevation_to_authorized/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_restrict_privilege_elevation_to_authorized/rule.yml
@@ -32,6 +32,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010341
     stigid@ol8: OL08-00-010382
+    stigid@ol9: OL09-00-000232
     stigid@sle12: SLES-12-010111
     stigid@sle15: SLES-15-020101
 

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
@@ -37,6 +37,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010342
     stigid@ol8: OL08-00-010383
+    stigid@ol9: OL09-00-000231
     stigid@sle12: SLES-12-010112
     stigid@sle15: SLES-15-020103
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **SSH & Crypto Policy** category (18 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.