### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Software GPG & Package Integrity (6 rules)

### DIFF
--- a/linux_os/guide/auditing/package_audispd-plugins_installed/rule.yml
+++ b/linux_os/guide/auditing/package_audispd-plugins_installed/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000342-GPOS-00133
+    stigid@ol9: OL09-00-000450
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -46,6 +46,7 @@ references:
     srg: SRG-OS-000437-GPOS-00194
     stigid@ol7: OL07-00-020200
     stigid@ol8: OL08-00-010440
+    stigid@ol9: OL09-00-000495
     stigid@sle12: SLES-12-010570
     stigid@sle15: SLES-15-010560
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -57,6 +57,7 @@ references:
     srg: SRG-OS-000366-GPOS-00153
     stigid@ol7: OL07-00-020050
     stigid@ol8: OL08-00-010370
+    stigid@ol9: OL09-00-000497
     stigid@sle12: SLES-12-010550
     stigid@sle15: SLES-15-010430
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -40,6 +40,7 @@ references:
     srg: SRG-OS-000366-GPOS-00153
     stigid@ol7: OL07-00-020060
     stigid@ol8: OL08-00-010371
+    stigid@ol9: OL09-00-000496
 
 ocil_clause: 'there is no process to validate certificates for local packages that is approved by the organization'
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -49,6 +49,7 @@ references:
     pcidss: Req-6.2
     srg: SRG-OS-000366-GPOS-00153
     stigid@ol8: OL08-00-010370
+    stigid@ol9: OL09-00-000498
 
 ocil_clause: 'GPG checking is disabled'
 

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/rule.yml
@@ -42,6 +42,7 @@ references:
     pcidss: Req-6.2
     stigid@ol7: OL07-00-010019
     stigid@ol8: OL08-00-010019
+    stigid@ol9: OL09-00-000499
 
 ocil_clause: 'the Oracle GPG Key is not installed'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Software GPG & Package Integrity** category (6 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.