### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Password Policy (28 rules)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000071-GPOS-00039
     stigid@ol7: OL07-00-010140
     stigid@ol8: OL08-00-020130
+    stigid@ol9: OL09-00-001020
 
 ocil_clause: 'the value of "dcredit" is a positive number or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
@@ -29,6 +29,7 @@ references:
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     srg: SRG-OS-000480-GPOS-00225,SRG-OS-000072-GPOS-00040
     stigid@ol8: OL08-00-020300
+    stigid@ol9: OL09-00-001125
 
 ocil_clause: '"dictcheck" does not have a value other than "0", or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
@@ -45,6 +45,7 @@ references:
     srg: SRG-OS-000072-GPOS-00040
     stigid@ol7: OL07-00-010160
     stigid@ol8: OL08-00-020170
+    stigid@ol9: OL09-00-001025
 
 ocil_clause: 'the value of "difok" is set to less than "{{{ xccdf_value("var_password_pam_difok") }}}", or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_root/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     srg: SRG-OS-000072-GPOS-00040,SRG-OS-000071-GPOS-00039,SRG-OS-000070-GPOS-00038,SRG-OS-000266-GPOS-00101,SRG-OS-000078-GPOS-00046,SRG-OS-000480-GPOS-00225,SRG-OS-000069-GPOS-00037
+    stigid@ol9: OL09-00-001045
 
 ocil_clause: '"enforce_for_root" is commented or missing'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000070-GPOS-00038
     stigid@ol7: OL07-00-010130
     stigid@ol8: OL08-00-020120
+    stigid@ol9: OL09-00-001015
 
 ocil_clause: 'the value of "lcredit" is a positive number or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -37,6 +37,7 @@ references:
     srg: SRG-OS-000072-GPOS-00040,SRG-OS-000730-GPOS-00190
     stigid@ol7: OL07-00-010190
     stigid@ol8: OL08-00-020140
+    stigid@ol9: OL09-00-001030
 
 ocil_clause: the value of "maxclassrepeat" is set to "0", more than "{{{ xccdf_value("var_password_pam_maxclassrepeat") }}}" or is commented out
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
@@ -39,6 +39,7 @@ references:
     srg: SRG-OS-000072-GPOS-00040
     stigid@ol7: OL07-00-010180
     stigid@ol8: OL08-00-020150
+    stigid@ol9: OL09-00-001035
 
 ocil_clause: the value of "maxrepeat" is set to more than "{{{ xccdf_value("var_password_pam_maxrepeat") }}}" or is commented out
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
@@ -51,6 +51,7 @@ references:
     srg: SRG-OS-000072-GPOS-00040
     stigid@ol7: OL07-00-010170
     stigid@ol8: OL08-00-020160
+    stigid@ol9: OL09-00-001040
 
 ocil_clause: the value of "minclass" is set to less than "{{{ xccdf_value("var_password_pam_minclass") }}}" or is commented out
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000078-GPOS-00046
     stigid@ol7: OL07-00-010280
     stigid@ol8: OL08-00-020230
+    stigid@ol9: OL09-00-001105
 
 ocil_clause: 'the command does not return a "minlen" value of "{{{ xccdf_value("var_password_pam_minlen") }}}" or greater, does not return a line, or the line is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -45,6 +45,7 @@ references:
     srg: SRG-OS-000266-GPOS-00101
     stigid@ol7: OL07-00-010150
     stigid@ol8: OL08-00-020280
+    stigid@ol9: OL09-00-001120
 
 ocil_clause: 'value of "ocredit" is a positive number or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     srg: SRG-OS-000069-GPOS-00037,SRG-OS-000070-GPOS-00038,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-020100
+    stigid@ol9: OL09-00-001010
 
 ocil_clause: 'pam_pwquality.so is not enabled in password-auth'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_retry/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000069-GPOS-00037
+    stigid@ol9: OL09-00-001001
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>8.3

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-020101
+    stigid@ol9: OL09-00-001000
 
 ocil_clause: 'pam_pwquality.so is not enabled in system-auth'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -41,6 +41,7 @@ references:
     srg: SRG-OS-000069-GPOS-00037,SRG-OS-000070-GPOS-00038
     stigid@ol7: OL07-00-010120
     stigid@ol8: OL08-00-020110
+    stigid@ol9: OL09-00-001005
 
 ocil_clause: 'the value of "ucredit" is a positive number or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/rule.yml
@@ -41,6 +41,7 @@ references:
     pcidss: Req-8.2.1
     srg: SRG-OS-000073-GPOS-00041
     stigid@ol7: OL07-00-010220
+    stigid@ol9: OL09-00-001050
 
 ocil_clause: crypt_style is not set to sha512
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000073-GPOS-00041
     stigid@ol7: OL07-00-010210
     stigid@ol8: OL08-00-010110
+    stigid@ol9: OL09-00-001055
     stigid@sle12: SLES-12-010210
     stigid@sle15: SLES-15-010260
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
@@ -49,6 +49,7 @@ references:
     srg: SRG-OS-000073-GPOS-00041,SRG-OS-000120-GPOS-00061
     stigid@ol7: OL07-00-010200
     stigid@ol8: OL08-00-010160
+    stigid@ol9: OL09-00-001060
 
 ocil_clause: 'it does not'
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
@@ -37,6 +37,7 @@ references:
     nist@sle12: IA-5(1)(c),IA-5(1).1(v),IA-7,IA-7.1
     srg: SRG-OS-000073-GPOS-00041,SRG-OS-000120-GPOS-00061
     stigid@ol8: OL08-00-010130
+    stigid@ol9: OL09-00-001075
     stigid@sle12: SLES-12-010240
     stigid@sle15: SLES-15-020190
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -48,6 +48,7 @@ references:
     srg: SRG-OS-000076-GPOS-00044
     stigid@ol7: OL07-00-010250
     stigid@ol8: OL08-00-020200
+    stigid@ol9: OL09-00-001095
     stigid@sle12: SLES-12-010280
     stigid@sle15: SLES-15-020220
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
@@ -48,6 +48,7 @@ references:
     srg: SRG-OS-000075-GPOS-00043
     stigid@ol7: OL07-00-010230
     stigid@ol8: OL08-00-020190
+    stigid@ol9: OL09-00-001085
     stigid@sle12: SLES-12-010260
     stigid@sle15: SLES-15-020200
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000076-GPOS-00044
     stigid@ol7: OL07-00-010260
     stigid@ol8: OL08-00-020210
+    stigid@ol9: OL09-00-001100
     stigid@sle12: SLES-12-010290
     stigid@sle15: SLES-15-020230
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -34,6 +34,7 @@ references:
     srg: SRG-OS-000075-GPOS-00043
     stigid@ol7: OL07-00-010240
     stigid@ol8: OL08-00-020180
+    stigid@ol9: OL09-00-001090
     stigid@sle12: SLES-12-010270
     stigid@sle15: SLES-15-020210
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
@@ -38,6 +38,7 @@ references:
     nist: IA-5(1)(c),IA-5(1).1(v),IA-7,IA-7.1
     srg:  SRG-OS-000073-GPOS-00041,SRG-OS-000120-GPOS-00061
     stigid@ol8: OL08-00-010120
+    stigid@ol9: OL09-00-001080
     stigid@sle12: SLES-12-010220
     stigid@sle15: SLES-15-020180
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -42,6 +42,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000073-GPOS-00041
+    stigid@ol9: OL09-00-001065
 
 ocil_clause: 'rounds is not set to {{{ xccdf_value("var_password_pam_unix_rounds") }}} or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 
 references:
   srg: SRG-OS-000073-GPOS-00041
+  stigid@ol9: OL09-00-001070
 
 ocil_clause: 'rounds is not set to {{{ xccdf_value("var_password_pam_unix_rounds") }}} or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -53,6 +53,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010290
     stigid@ol8: OL08-00-020331,OL08-00-020332
+    stigid@ol9: OL09-00-001110
     stigid@sle12: SLES-12-010231
     stigid@sle15: SLES-15-020300
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010291
     stigid@ol8: OL08-00-010121
+    stigid@ol9: OL09-00-001130
     stigid@sle12: SLES-12-010221
     stigid@sle15: SLES-15-020181
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -68,6 +68,7 @@ references:
     srg: SRG-OS-000080-GPOS-00048
     stigid@ol7: OL07-00-010482
     stigid@ol8: OL08-00-010150
+    stigid@ol9: OL09-00-001115
     stigid@sle12: SLES-12-010430
     stigid@sle15: SLES-15-010190
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Password Policy** category (28 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.