### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — File Permissions & Mount Options (30 rules)

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
@@ -26,6 +26,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010640
+    stigid@ol9: OL09-00-002011
 
 ocil_clause: 'the setting does not show'
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
@@ -32,6 +32,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021021
     stigid@ol8: OL08-00-010630
+    stigid@ol9: OL09-00-002012
     stigid@sle12: SLES-12-010820
     stigid@sle15: SLES-15-040170
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
@@ -30,6 +30,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021020
     stigid@ol8: OL08-00-010650
+    stigid@ol9: OL09-00-002013
     stigid@sle12: SLES-12-010810
     stigid@sle15: SLES-15-040160
 

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
@@ -48,6 +48,7 @@ references:
     srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020110
     stigid@ol8: OL08-00-040070
+    stigid@ol9: OL09-00-002000
     stigid@sle12: SLES-12-010590
     stigid@sle15: SLES-15-010240
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -25,6 +25,7 @@ references:
     nist: CM-6(b),CM-6.1(iv)
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010572
+    stigid@ol9: OL09-00-002032
 
 platform: mount[boot-efi]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
@@ -29,6 +29,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
+    stigid@ol9: OL09-00-002030
 
 
 template:

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010571
+    stigid@ol9: OL09-00-002031
 
 
 template:

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -39,6 +39,7 @@ references:
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol7: OL07-00-021024
     stigid@ol8: OL08-00-040120
+    stigid@ol9: OL09-00-002040
 
 
 template:

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -41,6 +41,7 @@ references:
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol7: OL07-00-021024
     stigid@ol8: OL08-00-040122
+    stigid@ol9: OL09-00-002041
 
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -39,6 +39,7 @@ references:
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol7: OL07-00-021024
     stigid@ol8: OL08-00-040121
+    stigid@ol9: OL09-00-002042
 
 
 template:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -32,6 +32,7 @@ references:
     cis@sle12: 1.1.18
     cis@sle15: 1.1.18
     srg: SRG-OS-000368-GPOS-00154
+    stigid@ol9: OL09-00-002070
 
 platform: mount[home]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: CM-6(b)
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010590
+    stigid@ol9: OL09-00-002072
 
 
 {{{ complete_ocil_entry_mount_option("/home", "noexec") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -37,6 +37,7 @@ references:
     srg: SRG-OS-000368-GPOS-00154,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021000
     stigid@ol8: OL08-00-010570
+    stigid@ol9: OL09-00-002071
     stigid@sle12: SLES-12-010790
     stigid@sle15: SLES-15-040140
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
@@ -46,6 +46,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010580
+    stigid@ol9: OL09-00-002080
 
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
@@ -41,6 +41,7 @@ references:
     nist-csf: PR.AC-3,PR.AC-6,PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010600
+    stigid@ol9: OL09-00-002021
 
 
 ocil_clause: 'a file system found in "/etc/fstab" refers to removable media and it does not have the "nodev" option set'

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
@@ -38,6 +38,7 @@ references:
     nist-csf: PR.AC-3,PR.AC-6,PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010610
+    stigid@ol9: OL09-00-002020
 
 ocil_clause: 'removable media partitions are present'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021010
     stigid@ol8: OL08-00-010620
+    stigid@ol9: OL09-00-002022
     stigid@sle12: SLES-12-010800
     stigid@sle15: SLES-15-040150
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -37,6 +37,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040123
+    stigid@ol9: OL09-00-002050
 
 platform: mount[tmp]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -38,6 +38,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040125
+    stigid@ol9: OL09-00-002051
 
 {{% if product == 'slmicro5' %}}
 platform: system_with_kernel

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -38,6 +38,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040124
+    stigid@ol9: OL09-00-002052
 
 platform: mount[tmp]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
@@ -32,6 +32,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040129
+    stigid@ol9: OL09-00-002064
 
 platform: mount[var-log-audit]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
@@ -30,6 +30,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040131
+    stigid@ol9: OL09-00-002065
 
 platform: mount[var-log-audit]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
@@ -31,6 +31,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040130
+    stigid@ol9: OL09-00-002066
 
 platform: mount[var-log-audit]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040126
+    stigid@ol9: OL09-00-002061
 
 platform: mount[var-log]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040128
+    stigid@ol9: OL09-00-002062
 
 platform: mount[var-log]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
@@ -32,6 +32,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040127
+    stigid@ol9: OL09-00-002063
 
 platform: mount[var-log]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
@@ -30,6 +30,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
+    stigid@ol9: OL09-00-002060
 
 platform: mount[var]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -30,6 +30,7 @@ references:
     cis@sle15: 1.1.13
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040132
+    stigid@ol9: OL09-00-002067
 
 platform: mount[var-tmp]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -31,6 +31,7 @@ references:
     cis@sle15: 1.1.12
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040134
+    stigid@ol9: OL09-00-002068
 
 platform: mount[var-tmp]
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -31,6 +31,7 @@ references:
     cis@sle15: 1.1.14
     srg: SRG-OS-000368-GPOS-00154
     stigid@ol8: OL08-00-040133
+    stigid@ol9: OL09-00-002069
 
 platform: mount[var-tmp]
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **File Permissions & Mount Options** category (30 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.