### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — GNOME Display Manager (16 rules)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -50,6 +50,7 @@ references:
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000228-GPOS-00088
     stigid@ol7: OL07-00-010030
     stigid@ol8: OL08-00-010049
+    stigid@ol9: OL09-00-002122
     stigid@sle12: SLES-12-010040
     stigid@sle15: SLES-15-010080
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
@@ -54,6 +54,7 @@ references:
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000228-GPOS-00088
     stigid@ol7: OL07-00-010040
     stigid@ol8: OL08-00-010050
+    stigid@ol9: OL09-00-002151
     stigid@sle12: SLES-12-010050
     stigid@sle15: SLES-15-010090
 

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
@@ -33,6 +33,7 @@ references:
     hipaa: 164.308(a)(1)(ii)(B),164.308(a)(5)(ii)(A)
     pcidss: Req-6.2
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002162
     stigid@sle12: SLES-12-010040
     stigid@sle15: SLES-15-010090
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
@@ -41,6 +41,7 @@ references:
     nist: CM-6(a),AC-6(1),CM-7(b)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002128
 
 ocil_clause: 'disable-restart-buttons has not been configured or is not disabled'
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
@@ -40,6 +40,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010063
     stigid@ol8: OL08-00-020032
+    stigid@ol9: OL09-00-002102
 
 ocil_clause: 'disable-user-list has not been configured or is not disabled'
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 references:
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020050
+    stigid@ol9: OL09-00-002126
 
 ocil_clause: 'removal-action has not been configured'
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
@@ -35,6 +35,7 @@ references:
     srg: SRG-OS-000480-GPOS-00229
     stigid@ol7: OL07-00-010440
     stigid@ol8: OL08-00-010820
+    stigid@ol9: OL09-00-002161
 
 ocil_clause: 'GDM allows users to automatically login'
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/rule.yml
@@ -44,6 +44,7 @@ references:
     nist-csf: PR.AC-3,PR.AC-6
     srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020111
+    stigid@ol9: OL09-00-002120
 
 ocil_clause: 'GNOME automounting is not disabled'
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/rule.yml
@@ -43,6 +43,7 @@ references:
     nist-csf: PR.AC-3,PR.AC-6
     srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020111
+    stigid@ol9: OL09-00-002121
 
 ocil_clause: 'GNOME autorun is not disabled'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -46,6 +46,7 @@ references:
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol7: OL07-00-010070
     stigid@ol8: OL08-00-020060
+    stigid@ol9: OL09-00-002104
     stigid@sle12: SLES-12-010080
     stigid@sle15: SLES-15-010120
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol7: OL07-00-010110
     stigid@ol8: OL08-00-020031
+    stigid@ol9: OL09-00-002103
 
 ocil_clause: 'the screensaver lock delay is missing, or is set to a value greater than {{{ xccdf_value("var_screensaver_lock_delay") }}}'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -53,6 +53,7 @@ references:
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol7: OL07-00-010060
     stigid@ol8: OL08-00-020030,OL08-00-020082
+    stigid@ol9: OL09-00-002123
     stigid@sle12: SLES-12-010060
     stigid@sle15: SLES-15-010100
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -65,6 +65,7 @@ references:
     nist-csf: PR.AC-7
     pcidss: Req-8.1.8
     srg: SRG-OS-000031-GPOS-00012
+    stigid@ol9: OL09-00-002106
     stigid@sle12: SLES-12-010100
     stigid@sle15: SLES-15-010140
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol7: OL07-00-010081
     stigid@ol8: OL08-00-020080
+    stigid@ol9: OL09-00-002125
 
 ocil_clause: 'GNOME3 session settings are not locked or configured properly'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
@@ -41,6 +41,7 @@ references:
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol7: OL07-00-010082
     stigid@ol8: OL08-00-020081
+    stigid@ol9: OL09-00-002124
     stigid@sle12: SLES-12-010080
     stigid@sle15: SLES-15-010120
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020231
     stigid@ol8: OL08-00-040171
+    stigid@ol9: OL09-00-002129
 
 ocil_clause: 'GNOME3 is configured to reboot when Ctrl-Alt-Del is pressed'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **GNOME Display Manager** category (16 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.