### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — System Configuration III (27 rules)

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a)
     nist@sle12: AU-5(a),AU-5.1(ii)
     srg: SRG-OS-000046-GPOS-00022
+    stigid@ol9: OL09-00-002405
     stigid@sle12: SLES-12-020050
     stigid@sle15: SLES-15-030580
 

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/rule.yml
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/rule.yml
@@ -25,6 +25,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040680
     stigid@ol8: OL08-00-040290
+    stigid@ol9: OL09-00-002425
 
 ocil_clause: 'the "smtpd_client_restrictions" parameter contains any entries other than "permit_mynetworks" and "reject"'
 

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
@@ -29,6 +29,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040550
     stigid@ol8: OL08-00-010460
+    stigid@ol9: OL09-00-002419
     stigid@sle12: SLES-12-010410
     stigid@sle15: SLES-15-040030
 

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
@@ -32,6 +32,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040540
     stigid@ol8: OL08-00-010470
+    stigid@ol9: OL09-00-002420
     stigid@sle12: SLES-12-010400
     stigid@sle15: SLES-15-040020
 

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/rule.yml
@@ -42,3 +42,4 @@ identifiers:
 references:
     nist: IA-5 (1) (c)
     srg: SRG-OS-000074-GPOS-00042
+    stigid@ol9: OL09-00-002426

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020013
+    stigid@ol9: OL09-00-002416
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -47,6 +47,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020015
+    stigid@ol9: OL09-00-002417
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -71,6 +71,7 @@ references:
     ospp: FAU_GEN.1.2
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040172
+    stigid@ol9: OL09-00-002412
     stigid@sle15: SLES-15-040062
 
 ocil_clause: 'the system is configured to reboot when Ctrl-Alt-Del is pressed more than 7 times in 2 seconds.'

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
@@ -77,6 +77,7 @@ references:
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020230
     stigid@ol8: OL08-00-040170
+    stigid@ol9: OL09-00-002413
     stigid@sle12: SLES-12-010610
     stigid@sle15: SLES-15-040060
 

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
@@ -36,6 +36,7 @@ references:
     ospp: FIA_UAU.1
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040180
+    stigid@ol9: OL09-00-002403
 
 ocil_clause: |-
     {{{ ocil_clause_service_disabled(service="debug-shell") }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
@@ -39,6 +39,7 @@ references:
     srg: SRG-OS-000027-GPOS-00008
     stigid@ol7: OL07-00-040000
     stigid@ol8: OL08-00-020024
+    stigid@ol9: OL09-00-002415
     stigid@sle12: SLES-12-010120
     stigid@sle15: SLES-15-020020
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -63,6 +63,7 @@ references:
     nist@sle12: AC-11(a)
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000029-GPOS-00010
     stigid@ol7: OL07-00-040160
+    stigid@ol9: OL09-00-002411
     stigid@sle12: SLES-12-010090
     stigid@sle15: SLES-15-010130
 

--- a/linux_os/guide/system/logging/journald/service_systemd-journald_enabled/rule.yml
+++ b/linux_os/guide/system/logging/journald/service_systemd-journald_enabled/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     nist: SC-24
     srg: SRG-OS-000269-GPOS-00103
+    stigid@ol9: OL09-00-002400
 
 ocil_clause: 'the systemd-journald service is not running'
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: CM-6(a),AC-6(1)
     srg: SRG-OS-000312-GPOS-00122,SRG-OS-000312-GPOS-00123,SRG-OS-000324-GPOS-00125
     stigid@ol8: OL08-00-010374
+    stigid@ol9: OL09-00-002401
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="fs.protected_hardlinks", value="1") }}}
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
@@ -28,6 +28,7 @@ references:
     nist: CM-6(a),AC-6(1)
     srg: SRG-OS-000312-GPOS-00122,SRG-OS-000312-GPOS-00123,SRG-OS-000324-GPOS-00125
     stigid@ol8: OL08-00-010373
+    stigid@ol9: OL09-00-002402
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="fs.protected_symlinks", value="1") }}}
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -47,6 +47,7 @@ references:
     nist: SC-39,CM-6(a)
     nist-csf: PR.PT-4
     srg: SRG-OS-000433-GPOS-00192
+    stigid@ol9: OL09-00-002422
 
 ocil_clause: 'ExecShield is not supported by the hardware, is not enabled, or has been disabled by the kernel configuration.'
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -30,6 +30,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000132-GPOS-00067,SRG-OS-000433-GPOS-00192,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040283
+    stigid@ol9: OL09-00-002408
     stigid@sle12: SLES-12-030320
     stigid@sle15: SLES-15-010540
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
@@ -36,6 +36,7 @@ references:
     srg: SRG-OS-000433-GPOS-00193,SRG-OS-000480-GPOS-00227,SRG-APP-000450-CTR-001105
     stigid@ol7: OL07-00-040201
     stigid@ol8: OL08-00-010430
+    stigid@ol9: OL09-00-002423
     stigid@sle12: SLES-12-030330
     stigid@sle15: SLES-15-010550
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -30,6 +30,7 @@ references:
     srg: SRG-OS-000132-GPOS-00067,SRG-OS-000138-GPOS-00069,SRG-APP-000243-CTR-000600
     stigid@ol7: OL07-00-010375
     stigid@ol8: OL08-00-010375
+    stigid@ol9: OL09-00-002406
     stigid@sle12: SLES-12-010375
     stigid@sle15: SLES-15-010375
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
@@ -22,6 +22,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000366-GPOS-00153
     stigid@ol8: OL08-00-010372
+    stigid@ol9: OL09-00-002428
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.kexec_load_disabled", value="1") }}}
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
@@ -24,6 +24,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000132-GPOS-00067,SRG-OS-000138-GPOS-00069,SRG-APP-000243-CTR-000600
     stigid@ol8: OL08-00-010376
+    stigid@ol9: OL09-00-002407
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.perf_event_paranoid", value="2") }}}
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
@@ -21,6 +21,7 @@ references:
     nist: AC-6,SC-7(10)
     srg: SRG-OS-000132-GPOS-00067,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040281
+    stigid@ol9: OL09-00-002409
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.unprivileged_bpf_disabled", value="1") }}}
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -26,6 +26,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000132-GPOS-00067,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040282
+    stigid@ol9: OL09-00-002410
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.yama.ptrace_scope", value="1") }}}
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
@@ -22,6 +22,7 @@ references:
     nist: CM-6,SC-7(10)
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040286
+    stigid@ol9: OL09-00-002430
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.core.bpf_jit_harden", value="2") }}}
 

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -83,6 +83,7 @@ references:
     nist@sle15: SC-28,SC-28.1
     srg: SRG-OS-000405-GPOS-00184,SRG-OS-000185-GPOS-00079,SRG-OS-000404-GPOS-00183
     stigid@ol8: OL08-00-010030
+    stigid@ol9: OL09-00-002418
     stigid@sle12: SLES-12-010450
     stigid@sle15: SLES-15-010330
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -31,6 +31,7 @@ references:
     nist: SC-13,SC-12(2),SC-12(3)
     srg: SRG-OS-000423-GPOS-00187,SRG-OS-000426-GPOS-00190
     stigid@ol8: OL08-00-010020
+    stigid@ol9: OL09-00-002421
 
 ocil_clause: |-
     BIND is installed and the BIND config file doesn't contain the

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -35,6 +35,7 @@ references:
     pcidss: Req-2.2
     srg: SRG-OS-000033-GPOS-00014
     stigid@ol8: OL08-00-010020
+    stigid@ol9: OL09-00-002404
 
 ocil_clause: |-
     the "IPsec" service is active and the ipsec configuration file does not contain does not contain <tt>include /etc/crypto-policies/back-ends/libreswan.config</tt>


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **System Configuration III** category (27 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.