### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Account Management (88 rules)

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_etc_cron_d/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_etc_cron_d/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 references:
     srg: SRG-OS-000471-GPOS-00215
     stigid@ol8: OL08-00-030645
+    stigid@ol9: OL09-00-002584
     stigid@sle15: SLES-15-030015
 
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_var_spool_cron/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_var_spool_cron/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     srg: SRG-OS-000363-GPOS-00150,SRG-OS-000363-GPOS-00150,SRG-OS-000446-GPOS-00200,SRG-OS-000447-GPOS-00201
     stigid@ol8: OL08-00-030645
+    stigid@ol9: OL09-00-002584
     stigid@sle15: SLES-15-030015
 
 ocil_clause: 'command does not return a line, or the line is commented out'

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.d", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.daily", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_deny/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_deny/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
     nist: CM-6 b
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.deny", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.hourly", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.monthly", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.weekly", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002581
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/crontab", group="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_d/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.d", owner="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_daily/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.daily", owner="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_deny/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_deny/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     nist: CM-6 b
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.deny", owner="root") }}}'

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.hourly", owner="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.monthly", owner="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.weekly", owner="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_owner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_crontab/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002582
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/crontab", owner="root") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002580
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.d", perms="-rwx------") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002580
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.daily", perms="-rwx------") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002580
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.hourly", perms="-rwx------") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002580
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.monthly", perms="-rwx------") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002580
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.weekly", perms="-rwx------") }}}'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002583
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/crontab", perms="-rw-------") }}}'
 

--- a/linux_os/guide/services/cron_and_at/package_cron_installed/rule.yml
+++ b/linux_os/guide/services/cron_and_at/package_cron_installed/rule.yml
@@ -34,6 +34,7 @@ references:
     nist: CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002580
 
 ocil_clause: 'the package is installed'
 

--- a/linux_os/guide/services/ssh/directory_groupowner_sshd_config_d/rule.yml
+++ b/linux_os/guide/services/ssh/directory_groupowner_sshd_config_d/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002507
 
 ocil_clause: '{{{ ocil_clause_directory_group_owner(directory="/etc/ssh/sshd_config.d", group="root") }}}'
 

--- a/linux_os/guide/services/ssh/directory_owner_sshd_config_d/rule.yml
+++ b/linux_os/guide/services/ssh/directory_owner_sshd_config_d/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002508
 
 ocil_clause: '{{{ ocil_clause_directory_owner(directory="/etc/ssh/sshd_config.d", owner="root") }}}'
 

--- a/linux_os/guide/services/ssh/directory_permissions_sshd_config_d/rule.yml
+++ b/linux_os/guide/services/ssh/directory_permissions_sshd_config_d/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002509
 
 ocil_clause: '{{{ ocil_clause_directory_permissions(directory="/etc/ssh/sshd_config.d", perms="-rwx------") }}}'
 

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
@@ -35,6 +35,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002507
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/ssh/sshd_config", group="root") }}}'
 

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_drop_in_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_drop_in_config/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002507
 
 ocil_clause: '{{{ ocil_clause_files_in_directory_group_owner(directory="/etc/ssh/sshd_config.d", group="root") }}}'
 

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
@@ -35,6 +35,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002508
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/ssh/sshd_config", owner="root") }}}'
 

--- a/linux_os/guide/services/ssh/file_owner_sshd_drop_in_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_drop_in_config/rule.yml
@@ -28,6 +28,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002508
 
 ocil_clause: '{{{ ocil_clause_files_in_directory_owner(directory="/etc/ssh/sshd_config.d", owner="root") }}}'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
@@ -35,6 +35,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002509
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/sshd_config", perms="-rw-------") }}}'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_drop_in_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_drop_in_config/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-17(a),CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002509
 
 ocil_clause: '{{{ ocil_clause_files_in_directory_permissions(directory="/etc/ssh/sshd_config.d", perms="-rw-------") }}}'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -52,6 +52,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040420
     stigid@ol8: OL08-00-010490
+    stigid@ol9: OL09-00-002502
     stigid@sle12: SLES-12-030220
     stigid@sle15: SLES-15-040250
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -36,6 +36,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040410
     stigid@ol8: OL08-00-010480
+    stigid@ol9: OL09-00-002503
     stigid@sle12: SLES-12-030210
     stigid@sle15: SLES-15-040240
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
@@ -38,6 +38,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020270
     stigid@ol8: OL08-00-020320
+    stigid@ol9: OL09-00-002501
     stigid@sle12: SLES-12-010630
     stigid@sle15: SLES-15-020090
 

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
@@ -37,6 +37,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020650
     stigid@ol8: OL08-00-010740
+    stigid@ol9: OL09-00-002514
     stigid@sle12: SLES-12-010750
     stigid@sle15: SLES-15-040100
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files_root/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002513
 
 ocil_clause: 'they are not 0740 or more permissive'
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
@@ -30,6 +30,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020630
     stigid@ol8: OL08-00-010730
+    stigid@ol9: OL09-00-002515
     stigid@sle12: SLES-12-010740
     stigid@sle15: SLES-15-040090
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -39,6 +39,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002530
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -37,6 +37,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002531
 
 ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
@@ -49,6 +49,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000138-GPOS-00069
     stigid@ol8: OL08-00-010190
+    stigid@ol9: OL09-00-002510
     stigid@sle12: SLES-12-010460
     stigid@sle15: SLES-15-010300
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/rule.yml
@@ -27,6 +27,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021031
     stigid@ol8: OL08-00-010700
+    stigid@ol9: OL09-00-002516
 
 identifiers:
     cce@rhel9: CCE-86469-4

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -49,6 +49,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020330
     stigid@ol8: OL08-00-010790
+    stigid@ol9: OL09-00-002511
     stigid@sle12: SLES-12-010700
     stigid@sle15: SLES-15-040410
 

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -46,6 +46,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020320
     stigid@ol8: OL08-00-010780
+    stigid@ol9: OL09-00-002512
     stigid@sle12: SLES-12-010690
     stigid@sle15: SLES-15-040400
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002533
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group-", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -30,6 +30,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002539
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002545
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd-", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -31,6 +31,7 @@ references:
     cis@sle15: 6.1.6
     pcidss: Req-8.7
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002551
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow-", group=target_group) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002532
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -37,6 +37,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002538
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow", group=target_group) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002544
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -39,6 +39,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002550
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow", group=target_group) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002535
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group-", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
@@ -24,6 +24,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002541
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow-", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002547
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd-", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002553
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow-", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002534
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -31,6 +31,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002540
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002546
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -36,6 +36,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002552
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002537
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/group-", perms="-rw-r--r--") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
@@ -32,6 +32,7 @@ references:
     cis@sle15: 6.1.6
     nist: AC-6 (1)
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002543
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow-", perms=target_perms) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
@@ -27,6 +27,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002549
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd-", perms="-rw-r--r--") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -35,6 +35,7 @@ references:
     nist: AC-6 (1)
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002554
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/shadow-", perms=target_perms) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -34,6 +34,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002536
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
@@ -40,6 +40,7 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002542
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow", perms=target_perms) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
@@ -36,6 +36,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002548
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -45,6 +45,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002555
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/shadow", perms=target_perms) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084,SRG-APP-000118-CTR-000240
     stigid@ol8: OL08-00-010260
+    stigid@ol9: OL09-00-002560
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log", group=gid) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084
     stigid@ol8: OL08-00-010230
+    stigid@ol9: OL09-00-002563
 
 {{%- if product in ['ubuntu2404'] %}}
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/messages", group="adm|root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084,SRG-APP-000118-CTR-000240
     stigid@ol8: OL08-00-010250
+    stigid@ol9: OL09-00-002561
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084
     stigid@ol8: OL08-00-010220
+    stigid@ol9: OL09-00-002564
 
 {{%- if product in ['ubuntu2404'] %}}
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/messages", owner="syslog|root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084,SRG-APP-000118-CTR-000240
     stigid@ol8: OL08-00-010240
+    stigid@ol9: OL09-00-002562
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log", perms="drwxr-xr-x") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_messages/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     srg: SRG-OS-000206-GPOS-00084
     stigid@ol8: OL08-00-010210
+    stigid@ol9: OL09-00-002565
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/messages", perms=target_perms) }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
@@ -40,6 +40,7 @@ references:
     nist: CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010351
+    stigid@ol9: OL09-00-002520
     stigid@sle12: SLES-12-010876
     stigid@sle15: SLES-15-010356
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
@@ -39,6 +39,7 @@ references:
     nist: CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010341
+    stigid@ol9: OL09-00-002521
     stigid@sle12: SLES-12-010874
     stigid@sle15: SLES-15-010354
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
@@ -46,6 +46,7 @@ references:
     nist: CM-5,CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010331
+    stigid@ol9: OL09-00-002522
     stigid@sle12: SLES-12-010872
     stigid@sle15: SLES-15-010352
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
@@ -50,6 +50,7 @@ references:
     nist: CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010320
+    stigid@ol9: OL09-00-002504
     stigid@sle12: SLES-12-010882
     stigid@sle15: SLES-15-010361
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
@@ -45,6 +45,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010310
+    stigid@ol9: OL09-00-002505
     stigid@sle12: SLES-12-010879
     stigid@sle15: SLES-15-010359
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -45,6 +45,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010340
+    stigid@ol9: OL09-00-002524
     stigid@sle12: SLES-12-010873
     stigid@sle15: SLES-15-010353
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/rule.yml
@@ -45,6 +45,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010300
+    stigid@ol9: OL09-00-002506
     stigid@sle12: SLES-12-010878
     stigid@sle15: SLES-15-010358
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -45,6 +45,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010330
+    stigid@ol9: OL09-00-002525
     stigid@sle12: SLES-12-010871
     stigid@sle15: SLES-15-010351
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -47,6 +47,7 @@ references:
     nist: CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
     stigid@ol8: OL08-00-010350
+    stigid@ol9: OL09-00-002523
     stigid@sle12: SLES-12-010875
     stigid@sle15: SLES-15-010355
 

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-002513
 
 ocil_clause: 'that rootfiles are not configured correctly'
 

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
@@ -38,6 +38,7 @@ references:
     nist-csf: DE.CM-1,DE.CM-7,PR.AC-4,PR.DS-5,PR.IP-1,PR.IP-3,PR.PT-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020900
+    stigid@ol9: OL09-00-002500
 
 ocil_clause: 'there is output'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
@@ -25,6 +25,7 @@ references:
     nist: AU-9
     srg: SRG-OS-000256-GPOS-00097,SRG-OS-000257-GPOS-00098,SRG-OS-000258-GPOS-00099
     stigid@ol8: OL08-00-030640
+    stigid@ol9: OL09-00-002570
 
 ocil_clause: 'any audit tools are not group-owned by root'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_ownership/rule.yml
@@ -25,6 +25,7 @@ references:
     nist: AU-9
     srg: SRG-OS-000256-GPOS-00097,SRG-OS-000257-GPOS-00098,SRG-OS-000258-GPOS-00099
     stigid@ol8: OL08-00-030630
+    stigid@ol9: OL09-00-002571
 
 ocil_clause: 'any audit tools are not owned by root'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_permissions/rule.yml
@@ -25,6 +25,7 @@ references:
     nist: AU-9
     srg: SRG-OS-000256-GPOS-00097,SRG-OS-000257-GPOS-00098,SRG-OS-000258-GPOS-00099
     stigid@ol8: OL08-00-030620
+    stigid@ol9: OL09-00-002572
 
 ocil_clause: 'any of these files have more permissive permissions than 0755'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Account Management** category (88 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.