### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Account Management II (20 rules)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/rule.yml
@@ -20,6 +20,7 @@ references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020026
+    stigid@ol9: OL09-00-003012
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/rule.yml
@@ -20,6 +20,7 @@ references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020025
+    stigid@ol9: OL09-00-003011
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -22,6 +22,7 @@ references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020027
+    stigid@ol9: OL09-00-003010
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -19,6 +19,7 @@ references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020021
+    stigid@ol9: OL09-00-003022
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -46,6 +46,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020011
+    stigid@ol9: OL09-00-003020
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -37,6 +37,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010330
     stigid@ol8: OL08-00-020023
+    stigid@ol9: OL09-00-003021
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -36,6 +36,7 @@ references:
     nist: AC-7(b),AC-7(a),AC-7.1(ii)
     srg: SRG-OS-000021-GPOS-00005,SRG-OS-000329-GPOS-00128
     stigid@ol8: OL08-00-020017
+    stigid@ol9: OL09-00-003023
 
 ocil_clause: 'the "dir" option is not set to a non-default documented tally log directory, is missing or commented out'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -51,6 +51,7 @@ references:
     srg: SRG-OS-000118-GPOS-00060
     stigid@ol7: OL07-00-010310
     stigid@ol8: OL08-00-020260
+    stigid@ol9: OL09-00-003065
     stigid@sle12: SLES-12-010340
     stigid@sle15: SLES-15-020050
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -45,6 +45,7 @@ references:
     srg: SRG-OS-000123-GPOS-00064,SRG-OS-000002-GPOS-00002
     stigid@ol7: OL07-00-010271
     stigid@ol8: OL08-00-020000,OL08-00-020270
+    stigid@ol9: OL09-00-003030
     stigid@sle12: SLES-12-010331
     stigid@sle15: SLES-15-020061
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
@@ -26,6 +26,7 @@ references:
     pcidss: Req-8.1.1
     srg: SRG-OS-000104-GPOS-00051,SRG-OS-000121-GPOS-00062
     stigid@ol8: OL08-00-020240
+    stigid@ol9: OL09-00-003001
     stigid@sle12: SLES-12-010640
     stigid@sle15: SLES-15-010230
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
@@ -22,6 +22,7 @@ references:
     cis@sle12: 6.2.15
     cis@sle15: 6.2.15
     srg: SRG-OS-000104-GPOS-00051
+    stigid@ol9: OL09-00-003006
 
 ocil_clause: 'the system has duplicate group ids'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
@@ -35,6 +35,7 @@ references:
     pcidss: Req-8.5.a
     srg: SRG-OS-000104-GPOS-00051
     stigid@ol7: OL07-00-020300
+    stigid@ol9: OL09-00-003005
 
 ocil_clause: 'GIDs referenced in /etc/passwd are returned as not defined in /etc/group'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
@@ -50,6 +50,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020310
     stigid@ol8: OL08-00-040200
+    stigid@ol9: OL09-00-003000
     stigid@sle12: SLES-12-010650
     stigid@sle15: SLES-15-020100
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/rule.yml
@@ -42,6 +42,7 @@ references:
     nist: AC-6,CM-6(a),CM-6(b),CM-6.1(iv)
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-003051
     stigid@sle12: SLES-12-010631
     stigid@sle15: SLES-15-020091
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
@@ -30,6 +30,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020610
     stigid@ol8: OL08-00-010760
+    stigid@ol9: OL09-00-003052
     stigid@sle12: SLES-12-010720
     stigid@sle15: SLES-15-020110
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
@@ -32,6 +32,7 @@ references:
     srg: SRG-OS-000480-GPOS-00226
     stigid@ol7: OL07-00-010430
     stigid@ol8: OL08-00-020310
+    stigid@ol9: OL09-00-003070
     stigid@sle12: SLES-12-010140
 
 ocil_clause: 'the value of "FAIL_DELAY" is not set to "{{{ xccdf_value("var_accounts_fail_delay") }}}" or greater, or the line is commented out'

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_home_paths_only/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_home_paths_only/rule.yml
@@ -34,6 +34,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020720
     stigid@ol8: OL08-00-010690
+    stigid@ol9: OL09-00-003053
     stigid@sle12: SLES-12-010770
     stigid@sle15: SLES-15-040120
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
@@ -30,6 +30,7 @@ identifiers:
 references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010720
+    stigid@ol9: OL09-00-003002
     stigid@sle12: SLES-12-010710
     stigid@sle15: SLES-15-040070
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
@@ -33,6 +33,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020620
     stigid@ol8: OL08-00-010750
+    stigid@ol9: OL09-00-003050
     stigid@sle12: SLES-12-010730
     stigid@sle15: SLES-15-040080
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/rule.yml
@@ -24,6 +24,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00228
     stigid@ol7: OL07-00-021040
     stigid@ol8: OL08-00-020352
+    stigid@ol9: OL09-00-003060
 
 ocil_clause: 'any local interactive user initialization files are found to have a umask statement that sets a value less restrictive than "077"'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Account Management II** category (20 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.