### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Remote Access & Logging (7 rules)

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/rule.yml
@@ -36,6 +36,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021100
     stigid@ol8: OL08-00-030010
+    stigid@ol9: OL09-00-005010
 
 ocil_clause: 'cron is not logging to rsyslog'
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/rule.yml
@@ -32,6 +32,7 @@ references:
     nist: AU-4(1)
     srg: SRG-OS-000342-GPOS-00133,SRG-OS-000479-GPOS-00224
     stigid@ol8: OL08-00-030720
+    stigid@ol9: OL09-00-005015
 
 ocil_clause: '$ActionSendStreamDriverAuthMode in /etc/rsyslog.conf is not set to x509/name'
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/rule.yml
@@ -33,6 +33,7 @@ references:
     nist: AU-4(1)
     srg: SRG-OS-000342-GPOS-00133,SRG-OS-000479-GPOS-00224
     stigid@ol8: OL08-00-030710
+    stigid@ol9: OL09-00-005020
 
 ocil_clause: 'rsyslogd ActionSendStreamDriverMode is not set to 1'
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/rule.yml
@@ -33,6 +33,7 @@ references:
     nist: AU-4(1)
     srg: SRG-OS-000342-GPOS-00133,SRG-OS-000479-GPOS-00224
     stigid@ol8: OL08-00-030710
+    stigid@ol9: OL09-00-005025
 
 ocil_clause: 'rsyslogd DefaultNetstreamDriver not set to gtls'
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
@@ -34,6 +34,7 @@ references:
     nist: AC-17(1)
     srg: SRG-OS-000032-GPOS-00013
     stigid@ol8: OL08-00-010070
+    stigid@ol9: OL09-00-005000
 
 ocil_clause: 'remote access methods are not logging to rsyslog'
 

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
@@ -49,6 +49,7 @@ references:
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-1,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-031010
+    stigid@ol9: OL09-00-005030
 
 ocil_clause: "rsyslog accepts remote messages and is not documented as a log aggregation system"
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -67,6 +67,7 @@ references:
     srg: SRG-OS-000479-GPOS-00224,SRG-OS-000480-GPOS-00227,SRG-OS-000342-GPOS-00133
     stigid@ol7: OL07-00-031000
     stigid@ol8: OL08-00-030690
+    stigid@ol9: OL09-00-005005
     stigid@sle12: SLES-12-030340
     stigid@sle15: SLES-15-010580
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Remote Access & Logging** category (7 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.