### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Network DoS Prevention (27 rules)

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: SC-5
     srg: SRG-OS-000420-GPOS-00186
     stigid@ol8: OL08-00-040150
+    stigid@ol9: OL09-00-006000
 
 ocil_clause: 'the "nftables" is not set as the "firewallbackend"'
 

--- a/linux_os/guide/system/network/network-ipsec/libreswan_approved_tunnels/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/libreswan_approved_tunnels/rule.yml
@@ -37,6 +37,7 @@ references:
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040820
+    stigid@ol9: OL09-00-006010
 
 ocil_clause: 'the IPSec tunnels are not approved'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040261
+    stigid@ol9: OL09-00-006040
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra", value="0") }}}
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040280
+    stigid@ol9: OL09-00-006041
     stigid@sle12: SLES-12-030363
     stigid@sle15: SLES-15-040341
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040830
     stigid@ol8: OL08-00-040240
+    stigid@ol9: OL09-00-006042
     stigid@sle12: SLES-12-030361
     stigid@sle15: SLES-15-040310
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -33,6 +33,7 @@ references:
     nist-csf: DE.CM-1,PR.DS-4,PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040260
+    stigid@ol9: OL09-00-006043
     stigid@sle12: SLES-12-030364
     stigid@sle15: SLES-15-040381
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040262
+    stigid@ol9: OL09-00-006044
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra", value="0") }}}
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -36,6 +36,7 @@ references:
     nist@slmicro5: CM-6(b),CM-6.1(iv)
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040210
+    stigid@ol9: OL09-00-006045
     stigid@sle12: SLES-12-030401
     stigid@sle15: SLES-15-040350
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -42,6 +42,7 @@ references:
     pcidss: Req-1.4.3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040250
+    stigid@ol9: OL09-00-006046
     stigid@sle12: SLES-12-030362
     stigid@sle15: SLES-15-040321
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040641
     stigid@ol8: OL08-00-040279
+    stigid@ol9: OL09-00-006020
     stigid@sle12: SLES-12-030390
     stigid@sle15: SLES-15-040330
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
@@ -43,6 +43,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040610
     stigid@ol8: OL08-00-040239
+    stigid@ol9: OL09-00-006021
     stigid@sle12: SLES-12-030360
     stigid@sle15: SLES-15-040300
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_forwarding/rule.yml
@@ -21,6 +21,7 @@ references:
     nist: CM-6(b)
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040259
+    stigid@ol9: OL09-00-006028
 
 ocil_clause: 'IP forwarding value is "1" and the system is not router'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
@@ -34,6 +34,7 @@ references:
     nist: CM-7(a),CM-7(b),SC-5(3)(a)
     nist-csf: DE.CM-1,PR.AC-3,PR.DS-4,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-006022
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.log_martians", value="1") }}}
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -39,6 +39,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040611
     stigid@ol8: OL08-00-040285
+    stigid@ol9: OL09-00-006024
 
 ocil: |-
     The runtime status of the <code>net.ipv4.conf.all.rp_filter</code> parameter can be queried

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
@@ -42,6 +42,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040640
     stigid@ol8: OL08-00-040209
+    stigid@ol9: OL09-00-006025
     stigid@sle12: SLES-12-030400
     stigid@sle15: SLES-15-040340
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
@@ -44,6 +44,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040620
     stigid@ol8: OL08-00-040249
+    stigid@ol9: OL09-00-006026
     stigid@sle12: SLES-12-030370
     stigid@sle15: SLES-15-040320
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
@@ -34,6 +34,7 @@ references:
     nist: CM-7(a),CM-7(b),SC-5(3)(a)
     nist-csf: DE.CM-1,PR.AC-3,PR.DS-4,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-006023
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.log_martians", value="1") }}}
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
@@ -37,6 +37,7 @@ references:
     nist-csf: DE.AE-1,DE.CM-1,ID.AM-3,PR.AC-5,PR.DS-4,PR.DS-5,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040612
+    stigid@ol9: OL09-00-006027
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.rp_filter", value="1") }}}
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
@@ -41,6 +41,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040630
     stigid@ol8: OL08-00-040230
+    stigid@ol9: OL09-00-006030
     stigid@sle12: SLES-12-030380
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.icmp_echo_ignore_broadcasts", value="1") }}}

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
@@ -35,6 +35,7 @@ references:
     nist-csf: DE.CM-1,PR.DS-4,PR.IP-1,PR.PT-3
     pcidss: Req-1.4.3
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-006031
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.icmp_ignore_bogus_error_responses", value="1") }}}
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -40,6 +40,7 @@ references:
     nist-csf: DE.AE-1,DE.CM-1,ID.AM-3,PR.AC-5,PR.DS-4,PR.DS-5,PR.PT-4
     pcidss: Req-1.4.1
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000420-GPOS-00186,SRG-OS-000142-GPOS-00071
+    stigid@ol9: OL09-00-006050
     stigid@sle12: SLES-12-030350
     stigid@sle15: SLES-15-010310
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
@@ -41,6 +41,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040660
     stigid@ol8: OL08-00-040220
+    stigid@ol9: OL09-00-006032
     stigid@sle12: SLES-12-030420
     stigid@sle15: SLES-15-040370
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
@@ -41,6 +41,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040650
     stigid@ol8: OL08-00-040270
+    stigid@ol9: OL09-00-006033
     stigid@sle12: SLES-12-030410
     stigid@sle15: SLES-15-040360
 

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -61,6 +61,7 @@ references:
     srg: SRG-OS-000299-GPOS-00117,SRG-OS-000300-GPOS-00118,SRG-OS-000424-GPOS-00188,SRG-OS-000481-GPOS-00481
     stigid@ol7: OL07-00-041010
     stigid@ol8: OL08-00-040110
+    stigid@ol9: OL09-00-006001
     stigid@sle12: SLES-12-030450
     stigid@sle15: SLES-15-010380
 

--- a/linux_os/guide/system/network/network_configure_name_resolution/rule.yml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/rule.yml
@@ -51,6 +51,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040600
     stigid@ol8: OL08-00-010680
+    stigid@ol9: OL09-00-006003
 
 ocil_clause: 'less than two lines are returned that are not commented out'
 

--- a/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
@@ -47,6 +47,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040670
     stigid@ol8: OL08-00-040330
+    stigid@ol9: OL09-00-006004
     stigid@sle12: SLES-12-030440
     stigid@sle15: SLES-15-040390
 

--- a/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/rule.yml
+++ b/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 references:
     nist: CM-6(b)
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol9: OL09-00-006002
 
 ocil_clause: 'the dns key under main does not exist or is not set to "none" or "default"'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Network DoS Prevention** category (27 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.