### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — Auditing (Immutable Rules) (2 rules)

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
@@ -50,6 +50,7 @@ references:
     pcidss: Req-10.5.2
     srg: SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029,SRG-APP-000119-CTR-000245,SRG-APP-000120-CTR-000250
     stigid@ol8: OL08-00-030121
+    stigid@ol9: OL09-00-008005
 
 ocil_clause: 'the audit system is not set to be immutable by adding the "-e 2" option to the end of "/etc/audit/audit.rules"'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 references:
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029
     stigid@ol8: OL08-00-030122
+    stigid@ol9: OL09-00-008000
 
 ocil_clause: 'the system is not configured to make login UIDs immutable'
 


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **Auditing (Immutable Rules)** category (2 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.