### PR TITLE
[OL9 STIG V2R3] Add stigid@ol9 — System Config (PKI / DoD CAs) (1 rules)

### DIFF
--- a/linux_os/guide/system/network/network_ssl/only_allow_dod_certs/rule.yml
+++ b/linux_os/guide/system/network/network_ssl/only_allow_dod_certs/rule.yml
@@ -23,3 +23,4 @@ severity: medium
 
 references:
     srg: SRG-OS-000403-GPOS-00182
+    stigid@ol9: OL09-00-900140


### PR DESCRIPTION
Adds `stigid@ol9` cross-reference to Oracle Linux 9 STIG V2R3 controls for the **System Config (PKI / DoD CAs)** category (1 rules).

Oracle Linux 9 STIG: https://public.cyber.mil/stigs/downloads/ (search: OL 9)

Part of the ongoing effort to provide full STIG stigid@ coverage for all supported distributions in ComplianceAsCode/content. Related to Ubuntu 22.04 PRs #14463–14471.

Generated using the ZTI stig-stigid-generator script.