### PR TITLE
ensure_redhat_gpgkey_installed: use command module instead of rpm_key in Ansible remediation

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -64,9 +64,7 @@
 {{% endif %}}
 
 - name: "{{{ rule_title }}}: Import RedHat GPG key"
-  ansible.builtin.rpm_key:
-    state: present
-    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+  ansible.builtin.command: rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
   when:
    - gpg_key_directory_permission.stat.mode <= '0755'
    - (gpg_installed_fingerprints | difference(gpg_valid_fingerprints)) | length == 0


### PR DESCRIPTION
#### Description:

- Replace the `ansible.builtin.rpm_key` module with `ansible.builtin.command: rpm --import` in the Ansible remediation for rule `ensure_redhat_gpgkey_installed`. This makes the Ansible remediation consistent with the Bash remediation approach by calling `rpm --import` directly.

#### Rationale:

- The `ansible.builtin.rpm_key` Ansible module is currently broken when encountering GPG keys with PQC (Post-Quantum Cryptography) signatures, as tracked in [ansible/ansible#86157](https://github.com/ansible/ansible/issues/86157). Using `rpm --import` directly bypasses the module and works correctly regardless of key signature type.

#### Review Hints:

- Single file change in `linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml`
- Affected products: rhel8, rhel9, rhel10, rhcos4
- Build and verify with: `./build_product --datastream-only rhel9`
- The rule is non-templated and has existing test scenarios (`key_installed.pass.sh`, `missing_key.fail.sh`, `fedora_key.fail.sh`), but since only the Ansible remediation is changed (not OVAL checks), existing tests remain valid
- The change replaces 3 lines (rpm_key module invocation) with 1 line (command module invocation) — straightforward to review
