### PR TITLE
Add Claude Code skills for content development workflows

### DIFF
--- a/.claude/skills/build-product/SKILL.md
+++ b/.claude/skills/build-product/SKILL.md
@@ -29,9 +29,22 @@ This skill uses `mcp__content-mcp__*` tools when available (preferred — determ
 
 ## Phase 2: Build Product
 
-Build all artifacts (SCAP, guides, playbooks, tables):
+**Always use the `build_product` script.** Do not use CMake, make, or ninja directly.
+
+Parse user arguments for optional flags:
+- `--datastream-only` — skip guides, tables, playbooks (faster)
+- `--rule-id <rule_id>` — build only a specific rule (fastest, for testing)
+
+Build command:
 ```bash
-./build_product $ARGUMENTS
+./build_product [flags] $PRODUCT
+```
+
+Examples:
+```bash
+./build_product rhel9                                          # Full build
+./build_product --datastream-only rhel9                        # Data stream only
+./build_product --datastream-only --rule-id sshd_set_idle_timeout rhel9  # Single rule
 ```
 
 ### Build Output
@@ -48,9 +61,9 @@ Expected artifacts in `build/`:
 - `ssg-$ARGUMENTS-ds-1.2.xml` - SCAP 1.2 data stream
 - `ssg-$ARGUMENTS-xccdf.xml` - XCCDF document
 - `ssg-$ARGUMENTS-oval.xml` - OVAL definitions
-- `guides/` - HTML guides
-- `ansible/` - Ansible playbooks
-- `bash/` - Bash scripts
+- `guides/` - HTML guides (skipped with `--datastream-only`)
+- `ansible/` - Ansible playbooks (skipped with `--datastream-only`)
+- `bash/` - Bash scripts (skipped with `--datastream-only`)
 
 ## Phase 3: Verify Build Success
 
@@ -123,34 +136,24 @@ Debugging Steps:
 
 ### Common Build Errors
 
-1. **CMake configuration failed**:
+1. **Python import errors**:
    ```bash
-   # Ensure CMake is installed
-   cmake --version
-
-   # Try with explicit generator
-   cd build && cmake -G "Unix Makefiles" ..
-   ```
-
-2. **Python import errors**:
-   ```bash
-   # Install requirements
    pip3 install -r requirements.txt
    pip3 install -r test-requirements.txt
    ```
 
-3. **Missing dependencies**:
+2. **Missing dependencies**:
    ```bash
    # RHEL/Fedora
    dnf install cmake make openscap-utils python3-pyyaml python3-jinja2
    ```
 
-4. **Jinja2 errors**:
+3. **Jinja2 errors**:
    - Check for undefined macros
    - Verify macro imports in the file
    - Check for syntax errors in `{{{ }}}` blocks
 
-5. **OVAL validation errors**:
+4. **OVAL validation errors**:
    - Check template parameters match expected types
    - Verify referenced variables exist
    - Check platform applicability
@@ -160,13 +163,4 @@ Debugging Steps:
 For more detailed output:
 ```bash
 ./build_product $ARGUMENTS 2>&1 | tee build.log
-```
-
-### Ninja Build (Faster)
-
-If ninja is available:
-```bash
-cd build
-cmake -G Ninja ..
-ninja $ARGUMENTS
 ```

--- a/.claude/skills/build-product/SKILL.md
+++ b/.claude/skills/build-product/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: build-product
+description: Build a ComplianceAsCode product
+---
+
+# Build Product
+
+Build a ComplianceAsCode product.
+
+**Product**: $ARGUMENTS
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+## Phase 1: Validate Product
+
+1. **Check if product is valid**:
+   Use `mcp__content-mcp__get_product_details` with `product_id=$ARGUMENTS` to validate the product exists and get its metadata.
+   **Fallback**: Read `products/$ARGUMENTS/product.yml` directly. If the file doesn't exist, the product is invalid.
+
+2. **If product not found**, list available products:
+   Use `mcp__content-mcp__list_products` to get all available products.
+   **Fallback**: Run `ls products/` to list available product directories.
+
+3. **If no product specified**, ask user using AskUserQuestion:
+   - Use the product list to populate options
+   - Allow "Other" for unlisted products
+
+## Phase 2: Build Product
+
+Build all artifacts (SCAP, guides, playbooks, tables):
+```bash
+./build_product $ARGUMENTS
+```
+
+### Build Output
+
+Monitor build progress:
+- CMake configuration
+- Content resolution
+- OVAL generation
+- XCCDF generation
+- Data stream assembly
+
+Expected artifacts in `build/`:
+- `ssg-$ARGUMENTS-ds.xml` - SCAP data stream
+- `ssg-$ARGUMENTS-ds-1.2.xml` - SCAP 1.2 data stream
+- `ssg-$ARGUMENTS-xccdf.xml` - XCCDF document
+- `ssg-$ARGUMENTS-oval.xml` - OVAL definitions
+- `guides/` - HTML guides
+- `ansible/` - Ansible playbooks
+- `bash/` - Bash scripts
+
+## Phase 3: Verify Build Success
+
+1. **Check build exit code**:
+   - Exit 0 = Success
+   - Non-zero = Build failed
+
+2. **Verify key artifacts exist**:
+   Use `mcp__content-mcp__get_datastream_info` with `product=$ARGUMENTS` to verify the datastream was built successfully and get artifact details.
+   **Fallback**: Check files directly:
+   ```bash
+   ls -la build/ssg-$ARGUMENTS-ds.xml
+   ls -la build/ssg-$ARGUMENTS-xccdf.xml
+   ls -la build/ssg-$ARGUMENTS-oval.xml
+   ```
+
+3. **Check for build warnings**:
+   - Look for deprecation warnings
+   - Template processing warnings
+   - Missing reference warnings
+
+## Phase 4: Report Results
+
+### Success Report
+
+```
+Build Complete
+==============
+
+Product: $ARGUMENTS
+
+Build Status: SUCCESS
+  Artifacts:
+    - build/ssg-$ARGUMENTS-ds.xml
+    - build/ssg-$ARGUMENTS-xccdf.xml
+    - build/ssg-$ARGUMENTS-oval.xml
+
+Ready for:
+  - Validation tests: /run-tests
+  - Automatus testing: /test-rule <rule_id>
+  - OpenSCAP scanning: oscap xccdf eval --profile <profile> build/ssg-$ARGUMENTS-ds.xml
+  - PR creation
+```
+
+### Build Failure Report
+
+```
+Build Failed
+============
+
+Product: $ARGUMENTS
+
+Error Output:
+[error message from build]
+
+Common Causes:
+  1. Jinja2 template syntax error in rule.yml
+  2. Missing macro or variable reference
+  3. Invalid platform specification
+  4. Circular dependency in profiles
+
+Debugging Steps:
+  1. Check the specific file mentioned in the error
+  2. Validate YAML: python3 -c "import yaml; yaml.safe_load(open('path/to/file.yml'))"
+  3. Check Jinja2: Look for unclosed tags, missing macros
+  4. Review recent changes: git diff HEAD~1
+```
+
+## Troubleshooting
+
+### Common Build Errors
+
+1. **CMake configuration failed**:
+   ```bash
+   # Ensure CMake is installed
+   cmake --version
+
+   # Try with explicit generator
+   cd build && cmake -G "Unix Makefiles" ..
+   ```
+
+2. **Python import errors**:
+   ```bash
+   # Install requirements
+   pip3 install -r requirements.txt
+   pip3 install -r test-requirements.txt
+   ```
+
+3. **Missing dependencies**:
+   ```bash
+   # RHEL/Fedora
+   dnf install cmake make openscap-utils python3-pyyaml python3-jinja2
+   ```
+
+4. **Jinja2 errors**:
+   - Check for undefined macros
+   - Verify macro imports in the file
+   - Check for syntax errors in `{{{ }}}` blocks
+
+5. **OVAL validation errors**:
+   - Check template parameters match expected types
+   - Verify referenced variables exist
+   - Check platform applicability
+
+### Verbose Build
+
+For more detailed output:
+```bash
+./build_product $ARGUMENTS 2>&1 | tee build.log
+```
+
+### Ninja Build (Faster)
+
+If ninja is available:
+```bash
+cd build
+cmake -G Ninja ..
+ninja $ARGUMENTS
+```

--- a/.claude/skills/create-rule/SKILL.md
+++ b/.claude/skills/create-rule/SKILL.md
@@ -1,0 +1,585 @@
+---
+name: create-rule
+description: Create a new security rule with all required components
+---
+
+# Create Rule
+
+Create a new security rule for ComplianceAsCode. This skill handles both templated and non-templated rules.
+
+**Rule ID**: $ARGUMENTS
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+## Phase 1: Validate Input
+
+1. **Validate rule ID format**:
+   - Must be lowercase with underscores (no hyphens or uppercase)
+   - Example valid IDs: `sshd_max_auth_tries`, `accounts_password_minlen`
+
+2. **Check if rule already exists**:
+   Use `mcp__content-mcp__search_rules` with `query=$ARGUMENTS` to check if a rule with this ID already exists.
+   **Fallback**: Use `Glob` to search for `**/$ARGUMENTS/rule.yml`.
+   - If rule exists, inform user and ask if they want to modify it instead
+
+3. **Determine rule location**:
+   - Ask user where to create the rule within the guide hierarchy
+   - Provide suggestions based on rule ID prefix (e.g., `sshd_*` goes under `linux_os/guide/services/ssh/ssh_server/`)
+
+## Phase 2: Determine Rule Type
+
+Use AskUserQuestion to ask the user:
+
+**Question**: "What type of rule do you want to create?"
+
+**Options**:
+1. **Templated rule (Recommended)** - Uses an existing template for checks and remediations. Faster to create, inherits tests from template.
+2. **Non-templated rule** - Custom OVAL, Bash, and Ansible implementations. Requires writing test scenarios.
+
+## Phase 3: Template Selection (if templated)
+
+If user chose templated rule:
+
+1. **List available templates** using `mcp__content-mcp__list_templates` to get all available templates with their descriptions.
+   **Fallback**: Run `ls shared/templates/` to list available template directories.
+
+2. **Common templates for quick reference**:
+   | Template | Use Case | Key Parameters |
+   |----------|----------|----------------|
+   | `sshd_lineinfile` | SSH server configuration | `parameter`, `value` |
+   | `package_installed` | Package installation | `pkgname` |
+   | `package_removed` | Package removal | `pkgname` |
+   | `service_enabled` | Service enablement | `servicename` |
+   | `service_disabled` | Service disablement | `servicename` |
+   | `file_permissions` | File permission checks | `filepath`, `filemode` |
+   | `file_owner` | File ownership | `filepath`, `uid_or_name` |
+   | `file_groupowner` | File group ownership | `filepath`, `gid_or_name` |
+   | `sysctl` | Sysctl settings | `sysctlvar`, `sysctlval` |
+   | `grub2_bootloader_argument` | Kernel boot args | `arg_name`, `arg_value` |
+   | `kernel_module_disabled` | Disable kernel modules | `kernmodule` |
+   | `mount_option` | Mount options | `mountpoint`, `mountoption` |
+   | `shell_lineinfile` | Shell variable settings | `path`, `parameter`, `value` |
+   | `auditd_lineinfile` | Auditd configuration | `parameter`, `value` |
+   | `lineinfile` | Generic line in file | `path`, `text` |
+
+3. **Ask for template selection** using AskUserQuestion
+
+4. **Get template parameter schema** using `mcp__content-mcp__get_template_schema` with `template_name=<selected_template>` to get the full parameter schema, supported languages, and documentation.
+   **Fallback**: Read `shared/templates/<template_name>/template.yml` or `template.py` for parameter definitions. Check existing rules using this template for usage examples.
+
+5. **Collect template variables**:
+   - Use the schema from step 4 to identify required and optional parameters
+   - Ask user for each required variable
+
+## Phase 4: Gather Rule Metadata
+
+Collect the following information using AskUserQuestion or prompts:
+
+### Required Fields
+
+1. **Title**: Short descriptive title (displayed in scan results)
+   - Example: "Disable SSH Root Login"
+
+2. **Description**: Detailed description using Jinja2 templating
+   - Can use macros like `{{{ sshd_config_file() }}}`, `{{{ describe_mount(...) }}}`
+
+3. **Rationale**: Why this rule is important for security
+
+4. **Severity**: One of `low`, `medium`, `high`, `unknown`
+
+### Identifiers
+
+5. **CCE identifiers**: Ask which RHEL products need CCEs (rhel8, rhel9, rhel10)
+   - Format: `cce@rhel9: CCE-XXXXX-X`
+   - **Automatic CCE allocation**:
+     1. Read available CCEs from `shared/references/cce-redhat-avail.txt`
+     2. For each requested product, take the first available CCE from the file
+     3. After adding the CCE to `rule.yml`, remove it from `cce-redhat-avail.txt` to prevent reuse
+   - If user doesn't want CCEs now, leave blank (can be added later)
+
+   ```bash
+   # Read first available CCE
+   head -1 shared/references/cce-redhat-avail.txt
+
+   # After using a CCE, remove it from the file
+   sed -i '1d' shared/references/cce-redhat-avail.txt
+   ```
+
+### References (Optional but Recommended)
+
+6. **Security references** - ask if user has any of:
+   - `nist`: NIST SP 800-53 controls (e.g., `AC-6(2),CM-6(a)`)
+   - `srg`: DISA SRG IDs (e.g., `SRG-OS-000480-GPOS-00227`)
+   - `stigid` and `cis` references are filled in automatically by placing the rule into an appropriate control file
+
+### Additional Fields
+
+7. **Platform** (optional): Platform applicability
+   - Example: `platform: machine` (not for containers)
+   - Example: `platform: package[openssh-server]`
+
+8. **OCIL** (optional): OCIL check description
+   - Often uses macros like `{{{ complete_ocil_entry_sshd_option(...) }}}`
+
+## Phase 5: Generate Rule
+
+### For Templated Rules
+
+Use `mcp__content-mcp__generate_rule_from_template` with:
+- `template_name`: The selected template name
+- `parameters`: Template variables collected from the user
+- `rule_id`: $ARGUMENTS
+- `product`: The target product
+
+This generates the rule directory and rule.yml with the template configuration automatically.
+
+**Fallback**: Create the rule directory and `rule.yml` manually using `Write` tool. Include the `template:` key with `name:` and `vars:` based on the selected template.
+
+### For Non-Templated Rules
+
+Use `mcp__content-mcp__generate_rule_boilerplate` with:
+- `rule_id`: $ARGUMENTS
+- `title`: The rule title
+- `description`: The rule description
+- `severity`: The severity level
+- `product`: The target product
+- `rationale`: The rationale (optional)
+- `location`: The guide path (optional, e.g., `linux_os/guide/services/ssh`)
+
+**Fallback**: Create the directory structure and all files manually using `Write` tool, following the skeleton templates below.
+
+This generates the rule directory structure with skeleton files:
+```
+<location>/$ARGUMENTS/
+├── rule.yml
+├── oval/
+│   └── shared.xml
+├── bash/
+│   └── shared.sh
+├── ansible/
+│   └── shared.yml
+└── tests/
+    ├── correct.pass.sh
+    └── wrong.fail.sh
+```
+
+### Post-Generation Customization
+
+After MCP generates the boilerplate, customize the generated files:
+- Add CCE identifiers, references, and platform applicability to rule.yml
+- For non-templated rules, implement the OVAL, Bash, Ansible, and test content
+
+### Skeleton Files for Non-Templated Rules
+
+**oval/shared.xml**:
+```xml
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("{DESCRIPTION}", rule_title=rule_title) }}}
+    <criteria>
+      <!-- Add OVAL criteria here -->
+    </criteria>
+  </definition>
+  <!-- Add OVAL tests, objects, and states here -->
+</def-group>
+```
+
+Note: `rule_id` and `rule_title` are automatically populated during build from the rule.yml.
+
+**bash/shared.sh**:
+```bash
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+# Remediation script for $ARGUMENTS
+# TODO: Implement remediation
+```
+
+**ansible/shared.yml**:
+```yaml
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: "{TITLE}"
+  # TODO: Implement remediation
+  ansible.builtin.debug:
+    msg: "Remediation not yet implemented"
+```
+
+**tests/correct.pass.sh**:
+```bash
+#!/bin/bash
+# packages = {REQUIRED_PACKAGES}
+
+# Set up compliant state
+# TODO: Configure system to be compliant
+```
+
+**tests/wrong.fail.sh**:
+```bash
+#!/bin/bash
+# packages = {REQUIRED_PACKAGES}
+
+# Set up non-compliant state
+# TODO: Configure system to be non-compliant
+```
+
+## Phase 6: Add to Component
+
+Every rule must belong to a component. Components are defined in `components/*.yml` and map rules to their associated packages and groups.
+
+### Step 1: Identify Appropriate Component
+
+Based on the rule's purpose and location, suggest likely components:
+
+```bash
+# List all available components
+ls components/*.yml | sed 's|components/||;s|\.yml||' | sort
+```
+
+**Common component mappings**:
+| Rule Prefix | Likely Component |
+|-------------|------------------|
+| `sshd_*` | `openssh` |
+| `audit_*`, `auditd_*` | `audit` |
+| `sudo_*` | `sudo` |
+| `firewalld_*` | `firewalld` |
+| `selinux_*` | `selinux` |
+| `package_*_installed/removed` | Component for that package |
+| `service_*_enabled/disabled` | Component for that service |
+| `sysctl_*` | `kernel` or specific subsystem |
+| `mount_option_*` | `systemd` |
+| `grub2_*` | `grub2` |
+| `file_permissions_*`, `file_owner_*` | Component for the file's package |
+
+### Step 2: Verify Component Exists
+
+```bash
+# Check if suggested component exists
+cat components/<component_name>.yml
+```
+
+### Step 3: Ask User to Confirm or Select Component
+
+Use AskUserQuestion with options:
+1. Suggested component (if identified)
+2. Browse/search for another component
+3. Create a new component
+
+### Step 4a: Add Rule to Existing Component
+
+If user selects an existing component:
+
+1. **Read the component file**:
+   ```bash
+   cat components/<component_name>.yml
+   ```
+
+2. **Add the rule ID** to the `rules:` list in alphabetical order:
+   ```yaml
+   rules:
+   - existing_rule_1
+   - existing_rule_2
+   - $ARGUMENTS        # Add new rule here
+   - existing_rule_3
+   ```
+
+3. **If using a template**, verify the template is listed in `templates:` section. If not, add it:
+   ```yaml
+   templates:
+   - existing_template
+   - {TEMPLATE_NAME}   # Add if not present
+   ```
+
+### Step 4b: Create New Component
+
+If no suitable component exists:
+
+1. **Ask for component details**:
+   - Component name (lowercase, hyphenated, e.g., `my-service`)
+   - Associated packages (list)
+   - Associated groups (from rule hierarchy)
+
+2. **Create the component file** `components/<component_name>.yml`:
+   ```yaml
+   groups:
+   - <group_from_rule_hierarchy>
+   name: <component_name>
+   packages:
+   - <package_name>
+   rules:
+   - $ARGUMENTS
+   templates:
+   - {TEMPLATE_NAME}   # If templated rule
+   ```
+
+3. **Verify the new component**:
+   ```bash
+   python3 -c "import yaml; yaml.safe_load(open('components/<component_name>.yml'))"
+   ```
+
+### Component File Structure Reference
+
+```yaml
+groups:        # Rule groups this component covers (from guide hierarchy)
+- service_name
+- service_name_server
+name: component-name   # Matches filename without .yml
+packages:      # Packages associated with this component
+- package-name
+- package-name-server
+rules:         # Rule IDs belonging to this component (alphabetical)
+- rule_id_1
+- rule_id_2
+templates:     # Templates used by rules in this component
+- template_name
+```
+
+## Phase 7: Add to Profile(s) or Control File(s)
+
+Most profiles in the project reference control files rather than listing rules directly. When adding a rule to a profile that uses a control file, add the rule to the control file instead.
+
+### Step 1: List Available Profiles
+
+Use `mcp__content-mcp__list_profiles` with `product=<product>` to list all available profiles for each target product.
+   **Fallback**: Run `ls products/<product>/profiles/*.profile` to list profiles.
+
+### Step 2: Ask User Which Profile(s)
+
+Use AskUserQuestion to ask which profile(s) to add the rule to. Allow multiple selection.
+
+### Step 3: Detect Control File Reference
+
+For each selected profile, read it and check if it references a control file:
+
+```bash
+grep -E "^\s+-\s+\w+:all" products/<product>/profiles/<profile>.profile
+```
+
+**Control file reference patterns**:
+- `cis_rhel9:all` or `cis_rhel9:all:l2_server` → Control file: `products/rhel9/controls/cis_rhel9.yml`
+- `stig_rhel9:all` → Control file: `products/rhel9/controls/stig_rhel9.yml`
+- `hipaa:all` → Control file: `controls/hipaa.yml` (shared across products)
+
+**How to find the control file**:
+1. Extract the control ID from the selection (e.g., `cis_rhel9` from `cis_rhel9:all:l2_server`)
+2. Look in `products/<product>/controls/<control_id>.yml` first
+3. If not found, look in `controls/<control_id>.yml`
+
+### Step 4a: Add to Control File (if profile uses control file)
+
+If the profile references a control file:
+
+1. **Read the control file** to understand its structure
+2. **Ask user for control placement**:
+   - For CIS: Ask for the section ID (e.g., `5.2.15` for SSH settings)
+   - For STIG: Ask for the STIG ID (e.g., `RHEL-09-123456`)
+   - Show the control file structure to help user decide
+
+3. **Determine the level(s)** for the rule:
+   - CIS: `l1_server`, `l2_server`, `l1_workstation`, `l2_workstation`
+   - STIG: `high`, `medium`, `low`
+
+4. **Add a new control entry** to the control file:
+
+   **For CIS control files**:
+   ```yaml
+   - id: 5.2.15
+     title: Ensure SSH MaxAuthTries is set to 4 or less (Automated)
+     levels:
+         - l1_server
+         - l1_workstation
+     status: automated
+     rules:
+         - $ARGUMENTS
+   ```
+
+   **For STIG control files**:
+   ```yaml
+   - id: RHEL-09-123456
+     levels:
+         - medium
+     title: RHEL 9 must limit the number of SSH authentication attempts.
+     rules:
+         - $ARGUMENTS
+     status: automated
+   ```
+
+5. **Insert in the correct position** (controls are typically ordered by ID)
+
+### Step 4b: Add Directly to Profile (if no control file)
+
+If the profile lists rules directly (no control file reference):
+
+1. Read the profile file
+2. Add the rule ID to the `selections:` list
+3. Maintain alphabetical order if the profile uses it
+
+### Control File Locations
+
+**Product-specific** (preferred for product-specific benchmarks):
+- `products/rhel8/controls/*.yml`
+- `products/rhel9/controls/*.yml`
+- `products/rhel10/controls/*.yml`
+
+**Shared** (for cross-product policies):
+- `controls/*.yml`
+
+### Common Control Files by Profile
+
+| Profile | Control File |
+|---------|--------------|
+| `cis.profile` (rhel9) | `products/rhel9/controls/cis_rhel9.yml` |
+| `stig.profile` (rhel9) | `products/rhel9/controls/stig_rhel9.yml` |
+| `hipaa.profile` | `controls/hipaa.yml` |
+| `pci-dss.profile` | `controls/pcidss_4.yml` |
+| `ospp.profile` | `controls/ospp.yml` |
+| `anssi_bp28_*.profile` | `controls/anssi.yml` |
+
+### Reference Security Policies
+
+When adding to CIS or STIG control files, reference the corresponding security policy document to find the correct control ID:
+- CIS RHEL 9: `security_policies/CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v2.0.0.md`
+- STIG RHEL 9: `security_policies/Red Hat Enterprise Linux 9 STIG V2R5 - STIG-A-View.md`
+
+### Step 5: Update Profile Stability Test Data
+
+**IMPORTANT**: Whenever a rule is added to a profile (whether directly or via control file), the profile stability test data must also be updated.
+
+Profile stability test data is located in `tests/data/profile_stability/<product>/<profile>.profile` and contains a sorted list of rule IDs, one per line.
+
+1. **Check if stability test file exists**:
+   ```bash
+   ls tests/data/profile_stability/<product>/<profile>.profile
+   ```
+
+2. **If the file exists**, add the rule ID in alphabetical order:
+   ```bash
+   # Read current file, add new rule, sort, and write back
+   (cat tests/data/profile_stability/<product>/<profile>.profile; echo "$ARGUMENTS") | sort -u > /tmp/profile_stability_tmp
+   mv /tmp/profile_stability_tmp tests/data/profile_stability/<product>/<profile>.profile
+   ```
+
+3. **If the file doesn't exist**, this may be a new profile or a product without stability tests. Check if the product directory exists:
+   ```bash
+   ls tests/data/profile_stability/<product>/
+   ```
+   - If the product directory exists but the profile file doesn't, create it with just the new rule
+   - If the product directory doesn't exist, skip this step (stability tests may not be set up for this product)
+
+**Profile stability test file format**:
+```
+rule_id_1
+rule_id_2
+rule_id_3
+...
+```
+
+Rules are listed one per line, sorted alphabetically, with no duplicates.
+
+**Products with stability tests**:
+- `rhel8`
+- `rhel9`
+- `rhel10`
+- `fedora`
+
+## Phase 8: Verify and Report
+
+1. **Verify created files**:
+   ```bash
+   ls -la <rule_directory>/
+   cat <rule_directory>/rule.yml
+   ```
+
+2. **Validate rule YAML** using `mcp__content-mcp__validate_rule_yaml` with the content of the generated rule.yml. This validates syntax, structure, and reference formats.
+   **Fallback**: Validate against the JSON schema:
+   ```bash
+   python3 -c "
+   import json, yaml, sys
+   from jsonschema import validate, ValidationError
+   schema = json.load(open('shared/schemas/rule.json'))
+   data = yaml.safe_load(open(sys.argv[1]))
+   try:
+       validate(instance=data, schema=schema)
+       print('Valid')
+   except ValidationError as e:
+       print(f'Invalid: {e.message}')
+   " <path_to_rule.yml>
+   ```
+
+   For control files, use `mcp__content-mcp__validate_control_file` with the control file path.
+   **Fallback**: Validate against the control schema:
+   ```bash
+   python3 -c "
+   import json, yaml, sys
+   from jsonschema import validate, ValidationError
+   schema = json.load(open('shared/schemas/control.json'))
+   data = yaml.safe_load(open(sys.argv[1]))
+   try:
+       validate(instance=data, schema=schema)
+       print('Valid')
+   except ValidationError as e:
+       print(f'Invalid: {e.message}')
+   " <path_to_control.yml>
+   ```
+
+3. **Verify CCE was removed** from available list (if CCE was allocated):
+   ```bash
+   grep "<allocated_cce>" shared/references/cce-redhat-avail.txt  # should return nothing
+   ```
+
+4. **Verify rule is in component**:
+   ```bash
+   grep "$ARGUMENTS" components/<component>.yml
+   ```
+
+5. **Verify profile stability test data** (if profile was modified):
+   ```bash
+   grep "$ARGUMENTS" tests/data/profile_stability/<product>/<profile>.profile
+   ```
+
+7. **Report to user**:
+   - List all created files
+   - Show CCE allocations (and confirm removal from available list)
+   - Show component file modification
+   - Show control file or profile modifications
+   - Show profile stability test data updates
+   - Explain that `stigid` and `cis` references will be automatically populated from the control file
+   - Provide next steps:
+     - For templated rules: "Use `/test-rule $ARGUMENTS` to test"
+     - For non-templated rules: "Complete the OVAL, Bash, Ansible, and test files, then use `/test-rule $ARGUMENTS`"
+     - "Use `/build-product <product>` to build and `/run-tests` to validate"
+
+## Important Notes
+
+- **Do NOT make test files executable** - the test framework handles this
+- **Use proper Jinja2 syntax** for macros in description, rationale, etc.
+- **Check existing similar rules** for reference on structure and content
+- **Templated rules are preferred** when a suitable template exists
+- **Every rule must belong to a component** - add to existing component or create new one
+- **Control files are preferred over direct profile modification** - they provide better structure and automatic reference population
+- **CCE identifiers must be unique** - always remove allocated CCEs from `cce-redhat-avail.txt`
+- **Update profile stability test data** - when adding to a profile, also update `tests/data/profile_stability/<product>/<profile>.profile`
+
+## Error Handling
+
+- If rule creation fails, clean up any partially created files
+- If CCE allocation fails, do not remove CCEs from the available list
+- Validate YAML syntax before writing
+- Check for common mistakes:
+  - Missing required fields
+  - Invalid template names
+  - Malformed references
+  - Duplicate control IDs in control files
+  - Invalid level names in control files
+  - Rule not added to any component
+  - Component file syntax errors
+  - Profile stability test data not updated

--- a/.claude/skills/create-rule/SKILL.md
+++ b/.claude/skills/create-rule/SKILL.md
@@ -45,24 +45,7 @@ If user chose templated rule:
 1. **List available templates** using `mcp__content-mcp__list_templates` to get all available templates with their descriptions.
    **Fallback**: Run `ls shared/templates/` to list available template directories.
 
-2. **Common templates for quick reference**:
-   | Template | Use Case | Key Parameters |
-   |----------|----------|----------------|
-   | `sshd_lineinfile` | SSH server configuration | `parameter`, `value` |
-   | `package_installed` | Package installation | `pkgname` |
-   | `package_removed` | Package removal | `pkgname` |
-   | `service_enabled` | Service enablement | `servicename` |
-   | `service_disabled` | Service disablement | `servicename` |
-   | `file_permissions` | File permission checks | `filepath`, `filemode` |
-   | `file_owner` | File ownership | `filepath`, `uid_or_name` |
-   | `file_groupowner` | File group ownership | `filepath`, `gid_or_name` |
-   | `sysctl` | Sysctl settings | `sysctlvar`, `sysctlval` |
-   | `grub2_bootloader_argument` | Kernel boot args | `arg_name`, `arg_value` |
-   | `kernel_module_disabled` | Disable kernel modules | `kernmodule` |
-   | `mount_option` | Mount options | `mountpoint`, `mountoption` |
-   | `shell_lineinfile` | Shell variable settings | `path`, `parameter`, `value` |
-   | `auditd_lineinfile` | Auditd configuration | `parameter`, `value` |
-   | `lineinfile` | Generic line in file | `path`, `text` |
+2. **Present available templates** from the list obtained in step 1 and help the user select the right one based on their use case.
 
 3. **Ask for template selection** using AskUserQuestion
 
@@ -245,20 +228,11 @@ Based on the rule's purpose and location, suggest likely components:
 ls components/*.yml | sed 's|components/||;s|\.yml||' | sort
 ```
 
-**Common component mappings**:
-| Rule Prefix | Likely Component |
-|-------------|------------------|
-| `sshd_*` | `openssh` |
-| `audit_*`, `auditd_*` | `audit` |
-| `sudo_*` | `sudo` |
-| `firewalld_*` | `firewalld` |
-| `selinux_*` | `selinux` |
-| `package_*_installed/removed` | Component for that package |
-| `service_*_enabled/disabled` | Component for that service |
-| `sysctl_*` | `kernel` or specific subsystem |
-| `mount_option_*` | `systemd` |
-| `grub2_*` | `grub2` |
-| `file_permissions_*`, `file_owner_*` | Component for the file's package |
+**Finding the right component**: Search existing component files for rules with a similar prefix to identify the likely component:
+```bash
+# Find which component contains rules with a similar prefix
+grep -l '<rule_prefix>' components/*.yml
+```
 
 ### Step 2: Verify Component Exists
 
@@ -485,11 +459,10 @@ rule_id_3
 
 Rules are listed one per line, sorted alphabetically, with no duplicates.
 
-**Products with stability tests**:
-- `rhel8`
-- `rhel9`
-- `rhel10`
-- `fedora`
+**Discover products with stability tests**:
+```bash
+ls tests/data/profile_stability/
+```
 
 ## Phase 8: Verify and Report
 

--- a/.claude/skills/create-rule/SKILL.md
+++ b/.claude/skills/create-rule/SKILL.md
@@ -70,7 +70,7 @@ Collect the following information using AskUserQuestion or prompts:
 
 3. **Rationale**: Why this rule is important for security
 
-4. **Severity**: One of `low`, `medium`, `high`, `unknown`
+4. **Severity**: One of `low`, `medium`, `high`, `unknown`. Default value would be `medium`.
 
 ### Identifiers
 

--- a/.claude/skills/create-rule/SKILL.md
+++ b/.claude/skills/create-rule/SKILL.md
@@ -534,7 +534,11 @@ ls tests/data/profile_stability/
 ## Important Notes
 
 - **Do NOT make test files executable** - the test framework handles this
-- **Use proper Jinja2 syntax** for macros in description, rationale, etc.
+- **Use the project's custom Jinja2 delimiters** — this project does NOT use standard Jinja2 syntax. The custom delimiters (defined in `ssg/jinja.py`) avoid conflicts with YAML/XML curly braces:
+  - **Variables/expressions**: `{{{ expr }}}` (triple braces), NOT `{{ expr }}`
+  - **Statements** (if/for/set): `{{% stmt %}}`, NOT `{% stmt %}`
+  - **Comments**: `{{# comment #}}`, NOT `{# comment #}`
+  - Examples: `{{{ full_name }}}`, `{{{ describe_service_enable(service="auditd") }}}`, `{{% if product in ["rhel9"] %}}`, `{{% set var="value" %}}`
 - **Check existing similar rules** for reference on structure and content
 - **Templated rules are preferred** when a suitable template exists
 - **Every rule must belong to a component** - add to existing component or create new one

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: draft-pr
+description: Draft a PR description based on branch changes and the project PR template
+---
+
+# Draft Pull Request Description
+
+Generate a pull request description for the current branch by analyzing commits since the branching point from master, following the project's PR template format.
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+## Phase 1: Gather Branch Data
+
+1. **Get current branch and branching point**:
+   ```bash
+   git branch --show-current
+   git merge-base HEAD master
+   ```
+
+2. **Abort if not on a feature branch**:
+   - If on `master`, or if `merge-base` equals `HEAD` (no diverging commits), inform the user:
+     "No diverging commits found. Please switch to your feature branch first."
+   - Stop execution.
+
+3. **Collect commit history** (all commits since branching point):
+   ```bash
+   MERGE_BASE=$(git merge-base HEAD master)
+   git log --no-merges --format="%H %s%n%b---" ${MERGE_BASE}..HEAD
+   ```
+
+4. **Collect diff information**:
+   ```bash
+   MERGE_BASE=$(git merge-base HEAD master)
+   git diff --stat ${MERGE_BASE}..HEAD
+   git diff ${MERGE_BASE}..HEAD
+   git diff --name-only ${MERGE_BASE}..HEAD
+   ```
+
+## Phase 2: Analyze Changes
+
+### 2.1 Categorize Change Type
+
+Determine which categories apply based on changed files and diff content:
+- New rule (new `rule.yml` added)
+- Modified rule (existing `rule.yml` changed)
+- New or modified template (`shared/templates/`)
+- Remediation changes (Bash/Ansible files)
+- Profile changes (`.profile` files)
+- Control file changes (`controls/`)
+- Test scenario changes (`tests/`)
+- Build system or infrastructure changes
+- Documentation changes
+
+### 2.2 Identify Affected Products
+
+Look for product indicators:
+- CCE identifiers in `rule.yml` files (`cce@rhel8`, `cce@rhel9`, `cce@rhel10`, etc.)
+- Product-specific paths (`products/<product>/`)
+- Profile or control file names containing product identifiers
+- Platform applicability in rule definitions
+
+### 2.3 Read Key Changed Files
+
+For significant changed files, use MCP functions to get structured metadata:
+- **Rules**: Use `mcp__content-mcp__get_rule_details` with the rule ID to get title, description, rationale, template, severity, references, and platform info
+- **Profiles**: Use `mcp__content-mcp__get_profile_details` with product and profile ID to get profile structure and rule selections
+- **Controls**: Use `mcp__content-mcp__get_control_details` to understand control framework structure
+- **Templates**: Use `mcp__content-mcp__get_template_schema` to get template parameter info
+
+**Fallback**: Read the files directly — `rule.yml`, `.profile`, control YAML, and template files in `shared/templates/<name>/`.
+
+### 2.4 Check Test Coverage
+
+- Look for added/modified test scenarios in `tests/` subdirectories
+- Check if rules use templates (inheriting template tests)
+
+### 2.5 Detect Issue References
+
+Scan commit messages for patterns like `Fixes #N`, `Resolves #N`, `Closes #N`, or bare `#N` references.
+
+## Phase 3: Draft PR Description
+
+Read the PR template:
+```bash
+cat .github/pull_request_template.md
+```
+
+Draft all three sections following the template format exactly:
+
+### 3.1 Description Section
+
+Auto-generate from analysis:
+
+- **New rules**: "Add new rule `<rule_id>` that <what the rule checks>. The rule has `<severity>` severity and targets <products>. It uses the `<template>` template / includes custom OVAL and <Bash/Ansible/both> remediation."
+- **Rule modifications**: "Modify rule `<rule_id>` to <what changed>."
+- **Profile/control changes**: "Update <profile/control> for <product> to <what changed>."
+- **Template changes**: "Modify template `<template_name>` to <what changed>."
+- **Multi-change PRs**: List each major change as a separate bullet point.
+
+### 3.2 Rationale Section
+
+Attempt to infer from:
+- Commit message bodies (look for explanations of "why")
+- Rule `rationale` field in `rule.yml`
+- Security references indicating compliance requirements
+- Profile additions indicating framework alignment
+
+If rationale cannot be fully inferred, include what was found and mark gaps for user input.
+
+Include issue reference if detected in commit messages, otherwise leave a placeholder.
+
+### 3.3 Review Hints Section
+
+Auto-generate:
+- **Affected products** with build commands: `./build_product --datastream-only <product>`
+- **Test commands** if test scenarios exist:
+  ```
+  ./tests/automatus.py rule --libvirt qemu:///session <product_vm_name> --datastream build/ssg-<product>-ds.xml <rule_id>
+  ```
+  Note: Adjust `qemu:///session` to `qemu:///system` and `<product_vm_name>` to the actual VM name based on reviewer's local setup.
+- **Key files to review**: highlight the most important changed files
+- **Review approach**: suggest reviewing all commits together or in sequence, based on how related the commits are
+- **Related issues/PRs**: include any references found in commit messages
+
+## Phase 4: Write Output File
+
+### 4.1 Write PR_DESCRIPTION.md
+
+Write the final description to `PR_DESCRIPTION.md` in the repository root. If the file already exists, inform the user and ask whether to overwrite.
+
+The file must begin with the suggested PR title on the first line, followed by a blank line, then the PR template sections:
+
+```
+<suggested PR title>
+
+#### Description:
+
+- <description content>
+
+#### Rationale:
+
+- <rationale content>
+
+- Fixes #<number> (only if user provided one, otherwise omit this line)
+
+#### Review Hints:
+
+- <review hints content>
+```
+
+### 4.2 PR Title
+
+Generate a PR title following project conventions:
+- Under 70 characters
+- Imperative mood ("Add", "Fix", "Update")
+- Useful for changelog
+
+The title is included at the top of `PR_DESCRIPTION.md` so the user can edit it alongside the body.
+
+### 4.3 Report Next Steps
+
+Tell the user:
+- Path to the output file (`PR_DESCRIPTION.md`)
+- Suggested PR title
+- Commands to create the PR:
+  ```bash
+  git push -u origin <current_branch>
+  gh pr create --title "<suggested title>" --body-file PR_DESCRIPTION.md
+  ```
+- Reminder: do not commit `PR_DESCRIPTION.md` to the repository
+
+## Important Notes
+
+- **Do NOT push or create the PR** — only draft the description file
+- **Match the PR template format exactly** — the output must be drop-in compatible with `.github/pull_request_template.md`
+- **Analyze ALL commits** in the branch, not just the latest one
+- **Use `--no-merges`** when reading commit log to skip merge commits
+- **Be specific about products** — use actual product names (rhel8, rhel9, rhel10)
+- **Handle large diffs gracefully** — for branches with many changes, summarize by category rather than listing every file

--- a/.claude/skills/inspect-control/SKILL.md
+++ b/.claude/skills/inspect-control/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: inspect-control
+description: Inspect a control file showing requirement stats, mapping status, and cross-framework context. Use for triage before mapping.
+---
+
+# Inspect Control
+
+Analyze a control file and report its current state: how many requirements are mapped, unmapped, manual, etc. Useful for understanding a control file before starting a mapping session.
+
+**Arguments**: $ARGUMENTS (control file ID, e.g., `anssi`, `srg_gpos`, `hipaa`)
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+## Phase 1: Validate and Load Control File
+
+1. **Parse arguments**: Extract control_id from `$ARGUMENTS`.
+
+2. **Validate control exists**: Call `mcp__content-mcp__get_control_stats` with `control_id=$ARGUMENTS`.
+   - If the tool returns an error (control not found), call `mcp__content-mcp__list_controls` and present available control files via `AskUserQuestion`:
+     - "Control file '$ARGUMENTS' not found. Which control file do you want to inspect?"
+     - Options: top 4 most relevant from the list + Other
+   - **Fallback**: Look for `controls/$ARGUMENTS.yml` or `products/**/controls/$ARGUMENTS.yml`. If not found, run `ls controls/*.yml` and `ls products/*/controls/*.yml` to list available control files. To compute stats, read the control YAML and count requirements grouped by `status` field.
+
+3. **Display basic info**: Show the control file title, ID, and total requirement count from the stats result.
+
+## Phase 2: Report Statistics
+
+Using the `get_control_stats` result, present:
+
+```
+## Control File: {title} ({control_id})
+
+| Status           | Count |
+|------------------|-------|
+| Total            | {total} |
+| Mapped (rules)   | {mapped} |
+| Unmapped (no rules) | {unmapped} |
+| automated        | {by_status.automated} |
+| pending          | {by_status.pending} |
+| manual           | {by_status.manual} |
+| not applicable   | {by_status.not_applicable} |
+| partial          | {by_status.partial} |
+| ...              | ... |
+
+Coverage: {mapped}/{total} ({percentage}%)
+```
+
+Only show status rows that have non-zero counts.
+
+## Phase 3: List Unmapped Requirements
+
+1. Call `mcp__content-mcp__list_unmapped_requirements` with `control_id` and default `status_filter` (pending).
+   **Fallback**: Read the control YAML and filter requirements where `status` is `pending` or where `rules:` is empty/missing.
+
+2. Present the unmapped work queue:
+
+```
+### Unmapped Requirements (pending)
+
+| # | ID | Title |
+|---|-----|-------|
+| 1 | R3  | Disk partitioning |
+| 2 | R7  | Dedicated admin accounts |
+| ... | ... | ... |
+```
+
+3. If there are requirements with status `partial` or `does not meet`, also call `list_unmapped_requirements` with `status_filter=["partial", "does not meet"]` and show them separately.
+   **Fallback**: Filter the control YAML for requirements with `status: partial` or `status: does not meet`.
+
+```
+### Partially Mapped / Needs Work
+
+| # | ID | Title | Status |
+|---|-----|-------|--------|
+| 1 | R12 | Audit logging | partial |
+```
+
+## Phase 4: Next Steps
+
+Present actionable next steps based on the analysis:
+
+```
+### Next Steps
+
+- To map all unmapped requirements interactively: `/map-controls {control_id} --product <product>`
+- To map a single requirement: `/map-requirement {control_id} <requirement_id> --product <product>`
+- To view full control details: use `mcp__content-mcp__get_control_details`
+
+**Tip**: If you have the source security policy document (PDF, Markdown, or HTML), pass it with `--policy <path>` to enrich mapping with the original requirement text. This improves cross-framework matching by using the full policy context instead of just the control file's summary. Example:
+  `/map-controls {control_id} --product <product> --policy security_policies/<file>`
+```

--- a/.claude/skills/map-controls/SKILL.md
+++ b/.claude/skills/map-controls/SKILL.md
@@ -31,9 +31,10 @@ Examples:
    - If not found, call `mcp__content-mcp__list_controls` and present options via `AskUserQuestion`.
    - **Fallback**: Read `controls/<control_id>.yml` or `products/**/controls/<control_id>.yml`. Count requirements by status manually. List controls with `ls controls/*.yml` and `ls products/*/controls/*.yml`.
 
-3. **If no `--product` specified**, ask user via `AskUserQuestion`:
+3. **If no `--product` specified**, discover available products and ask user via `AskUserQuestion`:
+   - Run `ls products/` (or call `mcp__content-mcp__list_products`) to get the list of available products
    - "Which product are you mapping rules for?"
-   - Options: "rhel9", "rhel10", "rhel8", "fedora" + Other
+   - Options: present the most common products from the discovered list + Other
 
 4. **Check build artifacts**: Call `mcp__content-mcp__list_built_products`.
    - If the target product is NOT in the built list, ask the user via `AskUserQuestion`:

--- a/.claude/skills/map-controls/SKILL.md
+++ b/.claude/skills/map-controls/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: map-controls
+description: Interactive control-to-rule mapping session. Walk through unmapped requirements, suggest rules using cross-framework analysis, and write selections to control files.
+---
+
+# Map Controls
+
+Run an interactive mapping session for a control file. Walks through each unmapped requirement, finds candidate rules via cross-framework search and AI suggestions, lets the author select rules, and writes them back to the control file.
+
+This skill orchestrates `/inspect-control` for setup and `/map-requirement` logic for each requirement.
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+**Without MCP server**: Cross-framework similarity search is unavailable. Candidate rules will be found by keyword search only, which may miss semantically similar but differently-worded requirements.
+
+**Arguments**: $ARGUMENTS — format: `<control_id> [--product <product_id>] [--policy <path>]`
+
+Examples:
+- `/map-controls anssi --product rhel9`
+- `/map-controls srg_gpos --product rhel10`
+- `/map-controls hipaa`
+- `/map-controls anssi --product rhel9 --policy security_policies/anssi_2.md`
+
+## Phase 1: Setup and Validation
+
+1. **Parse arguments**: Extract `control_id`, optional `--product`, and optional `--policy` from `$ARGUMENTS`.
+
+2. **Load control stats**: Call `mcp__content-mcp__get_control_stats` with `control_id`.
+   - If not found, call `mcp__content-mcp__list_controls` and present options via `AskUserQuestion`.
+   - **Fallback**: Read `controls/<control_id>.yml` or `products/**/controls/<control_id>.yml`. Count requirements by status manually. List controls with `ls controls/*.yml` and `ls products/*/controls/*.yml`.
+
+3. **If no `--product` specified**, ask user via `AskUserQuestion`:
+   - "Which product are you mapping rules for?"
+   - Options: "rhel9", "rhel10", "rhel8", "fedora" + Other
+
+4. **Check build artifacts**: Call `mcp__content-mcp__list_built_products`.
+   - If the target product is NOT in the built list, ask the user via `AskUserQuestion`:
+     - "Product '{product}' has not been built yet. Rule search works best with build artifacts (expanded Jinja templates). Build it now?"
+     - Options:
+       - "Yes, build now (Recommended)" — description: "Runs `/build-product {product} --datastream-only` before starting the mapping session"
+       - "No, continue without build" — description: "Rule search will use raw source files, which may miss some rules due to Jinja template parsing errors"
+   - If user chooses to build, invoke the `build-product` skill: `Skill(skill="build-product", args="{product} --datastream-only")`. Wait for the build to complete before continuing.
+   - **Fallback**: Check if `build/{product}/rules/` directory exists. If not, offer the build prompt above.
+
+5. **Report summary**:
+   ```
+   ## Control File: {title} ({control_id})
+
+   | Status    | Count |
+   |-----------|-------|
+   | Total     | {total} |
+   | Mapped    | {mapped} |
+   | Unmapped  | {unmapped} |
+   ```
+   Show the `by_status` breakdown, only including statuses with non-zero counts.
+
+6. **If no `--policy` specified**, inform the user:
+   > **Tip**: You can enrich mapping with the original security policy document by adding `--policy <path>` (supports PDF, Markdown, HTML). This provides full policy context for each requirement, improving cross-framework matching accuracy.
+
+7. **Get work queue**: Call `mcp__content-mcp__list_unmapped_requirements` with `control_id`.
+   **Fallback**: Read the control YAML and filter requirements where `status` is `pending` or `rules:` is empty/missing.
+
+8. **Ask user scope** via `AskUserQuestion`:
+   - "Which requirements do you want to work on?"
+   - Options:
+     - "Unmapped only ({N} requirements)" — work through the pending/unmapped queue
+     - "All requirements ({total})" — review every requirement including already-mapped ones
+     - "Specific requirement IDs" — let user type specific IDs
+
+## Phase 2: Per-Requirement Mapping Loop
+
+**Note**: Do NOT call `get_control_rule_index` here — it returns a massive payload (1.6MB+) that wastes context. The per-requirement `find_similar_requirements` call in Step 2b already provides cross-framework discovery for each requirement individually.
+
+For each requirement in the selected work queue, execute the mapping workflow. This follows the same logic as `/map-requirement` but in batch.
+
+### For each requirement:
+
+#### Step 2a: Present the Requirement
+
+Display:
+```
+---
+### [{current}/{total}] Requirement: {requirement_id}
+**Title**: {title}
+**Description**: {description}
+**Current status**: {status}
+**Current rules**: {rules or "none"}
+---
+```
+
+If `--policy` was provided:
+1. **Infer document type** from the file extension (`.md` → `markdown`, `.pdf` → `pdf`, `.html` → `html`, otherwise → `text`)
+2. Call `mcp__content-mcp__parse_policy_document` with `source`, `document_type`, and `requirement_id` for the current requirement.
+   **Fallback**: For markdown/text, read the file and search for the requirement ID. For PDF, inform user that PDF parsing requires the MCP server.
+3. If sections returned, display the policy context:
+   ```
+   ### Policy Context (from {policy_path})
+   **{section_title}**
+   {section_content}
+   ```
+4. Store the combined section text as `policy_text` for use in Step 2b
+
+#### Step 2b: Cross-Framework Search
+
+Call `mcp__content-mcp__find_similar_requirements` with:
+- `requirement_text`: if `policy_text` is available, use it; otherwise use the requirement's title + " " + description
+- `exclude_control_id`: current control_id
+- `max_results`: 10
+
+**Fallback**: Extract 3-5 key terms from the requirement text. Use `Grep` to search for each term across `controls/*.yml` and `products/*/controls/*.yml`. Read matched requirements to extract their `rules:` lists.
+
+If results found, present grouped by framework:
+```
+Similar requirements in other frameworks:
+- [{control_id}] {req_id}: "{title}" → rules: {rules}
+```
+
+Extract the union of all rules as cross-framework candidates.
+
+#### Step 2c: Rule Search in Build Artifacts
+
+Search for candidate rules using rendered build artifacts (Jinja-expanded, product-specific):
+
+1. Extract 3-5 key terms from the requirement title and description.
+2. For each key term, call `mcp__content-mcp__search_rendered_content` with:
+   - `query`: the key term
+   - `product`: the target product from Phase 1
+   - `limit`: 15
+   - **Fallback**: If the product is not built, use `Grep` to search for key terms in `rule.yml` files under `linux_os/guide/` and `applications/`. This may miss rules with Jinja-templated descriptions.
+
+3. Deduplicate results across all term searches. Combine with cross-framework candidates from Step 2b.
+
+4. For each candidate rule, use `mcp__content-mcp__get_rendered_rule` (or `get_rule_details`) to read its title and description. Reason about which rules best match the requirement semantically.
+
+5. Present the top candidates in a table:
+   ```
+   ### Rule Candidates
+
+   | Rule ID | Title | Source | Reasoning |
+   |---------|-------|--------|-----------|
+   | {rule_id} | {title} | cross-ref / search | {why it matches} |
+   ```
+
+#### Step 2d: Product Availability Check
+
+Since `search_rendered_content` only returns rules present in the target product's build, all search results are already confirmed available. For cross-framework candidates (from Step 2b) that did NOT appear in the rendered search, call `mcp__content-mcp__get_rule_product_availability` to verify availability.
+**Fallback**: Check each rule's `rule.yml` for `cce@<product>` entries and grep for the rule ID in target product profiles/controls.
+
+Flag rules NOT available for the target product. Assess portability:
+- Templated rules are likely portable
+- Check platform constraints if present
+
+#### Step 2e: Author Decision
+
+1. Build unified candidate list: combine cross-framework and AI suggestions, deduplicated, sorted by confidence.
+
+2. Use `AskUserQuestion` with `multiSelect: true`:
+   - "Select rules for '{requirement_id}: {title}'"
+   - Options: top candidates (up to 4), with confidence and source info
+   - If more than 4 candidates, present top 3 + "Show more candidates"
+
+3. Use a separate `AskUserQuestion`:
+   - "How should this requirement be marked?"
+   - Options:
+     - "Automated" — fully covered
+     - "Partially automated" — partially covered
+     - "Not applicable" — doesn't apply
+     - "Create new rule" — will be collected for gap analysis
+     - "Skip for now"
+
+#### Step 2f: Write Selection
+
+- **If rules selected**: Call `mcp__content-mcp__update_requirement_rules` with `control_id`, `requirement_id`, `rules`, and appropriate `status`.
+  **Fallback**: Find and edit the requirement's YAML file directly using `Edit` tool.
+- **If not applicable**: Call `mcp__content-mcp__update_requirement_rules` with empty rules and `status="not_applicable"`.
+  **Fallback**: Edit the requirement's YAML file to set `status: not_applicable` and `rules: []`.
+- **If create new rule**: Add to the "new rules needed" list for Phase 3.
+- **If skipped**: Record as skipped, move to next.
+
+Track all changes for the final report.
+
+## Phase 3: Gap Analysis
+
+For requirements where the author chose "Create new rule":
+
+1. For each gap requirement, use LLM analysis to:
+   - Decompose the requirement into atomic checks (one config change per rule)
+   - Suggest rule IDs following naming conventions (lowercase, underscores)
+   - Suggest which template might apply (call `mcp__content-mcp__list_templates` and match; **Fallback**: `ls shared/templates/`)
+   - Suggest severity based on the requirement
+
+2. Present the decomposition:
+   ```
+   ### Gap: {requirement_id} — {title}
+
+   This requirement could be covered by:
+   1. {suggested_rule_id} (template: {template_name}) — {description}
+   2. {suggested_rule_id} (template: {template_name}) — {description}
+   ```
+
+3. Ask user which rules to create via `AskUserQuestion`.
+
+4. For each approved new rule, tell the user to run `/create-rule <rule_id>` with the suggested parameters after this session completes.
+
+## Phase 4: Final Report
+
+Present a complete summary of the mapping session:
+
+```
+## Mapping Session Complete
+
+**Control file**: {control_id} ({title})
+**Target product**: {product}
+
+### Changes Made
+- {X} requirements mapped to existing rules
+- {Y} requirements marked not applicable
+- {Z} requirements skipped
+
+### Rules Added
+| Requirement | Rules | Status |
+|-------------|-------|--------|
+| {req_id}    | {rules} | automated |
+| ...         | ...   | ... |
+
+### New Rules Needed
+| Requirement | Suggested Rules | Template |
+|-------------|----------------|----------|
+| {req_id}    | {rule_ids}     | {template} |
+
+### Updated Stats
+```
+
+Call `mcp__content-mcp__get_control_stats` again to show the updated coverage.
+**Fallback**: Re-read the control YAML and recount requirements by status.
+```
+| Status   | Before | After |
+|----------|--------|-------|
+| Mapped   | {before} | {after} |
+| Unmapped | {before} | {after} |
+| Coverage | {before}% | {after}% |
+```
+
+```
+### Next Steps
+1. Review changes: `git diff controls/`
+2. Build product: `/build-product {product}`
+3. Create new rules: `/create-rule <rule_id>` for each gap
+4. Test rules: `/test-rule <rule_id>`
+5. Draft PR: `/draft-pr`
+```
+
+## Important Notes
+
+- **The `update_requirement_rules` tool replaces existing rules** — if a requirement already has rules and the author wants to add more, include the existing rules in the selection.
+- **AI suggestions require API key** — if `suggest_rule_mappings` fails, fall back to cross-framework search only.
+- **Large control files** (e.g., srg_gpos with 300+ requirements) — consider processing in batches. After every 10 requirements, ask if the user wants to continue or pause.
+- **Track before/after stats** — call `get_control_stats` at the start and end to show progress.
+- **Don't overwhelm the user** — if cross-framework search and AI both return many candidates, focus on the top 5-10 with highest confidence.

--- a/.claude/skills/map-requirement/SKILL.md
+++ b/.claude/skills/map-requirement/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: map-requirement
+description: Map rules to a single control file requirement using cross-framework analysis and rule search.
+---
+
+# Map Requirement
+
+Map rules to a single requirement in a control file. This is the atomic unit of the mapping workflow — it finds candidate rules, presents them to the author, and writes the selection back to the control file.
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+**Without MCP server**: Cross-framework similarity search is unavailable. Candidate rules will be found by keyword search only, which may miss semantically similar but differently-worded requirements.
+
+**Arguments**: $ARGUMENTS — format: `<control_id> <requirement_id> --product <product_id> [--policy <path>]`
+
+Examples:
+- `/map-requirement anssi R3 --product rhel9`
+- `/map-requirement srg_gpos SRG-OS-000001-GPOS-00001 --product rhel10`
+- `/map-requirement hipaa 164.312(a)(1) --product rhel9`
+- `/map-requirement anssi R34 --product rhel9 --policy security_policies/anssi_2.md`
+
+## Phase 1: Parse and Validate
+
+1. **Parse arguments**: Extract `control_id`, `requirement_id`, `--product` flag, and optional `--policy` flag from `$ARGUMENTS`.
+
+2. **If no `--product` specified**, ask the user via `AskUserQuestion`:
+   - "Which product are you mapping rules for?"
+   - Options: "rhel9", "rhel10", "rhel8", "fedora" + Other
+
+3. **Check build artifacts**: Call `mcp__content-mcp__list_built_products`.
+   - If the target product is NOT in the built list, ask the user via `AskUserQuestion`:
+     - "Product '{product}' has not been built yet. Rule search works best with build artifacts (expanded Jinja templates). Build it now?"
+     - Options:
+       - "Yes, build now (Recommended)" — description: "Runs `/build-product {product} --datastream-only` before starting the mapping session"
+       - "No, continue without build" — description: "Rule search will use raw source files, which may miss some rules due to Jinja template parsing errors"
+   - If user chooses to build, invoke the `build-product` skill: `Skill(skill="build-product", args="{product} --datastream-only")`. Wait for the build to complete before continuing.
+   - **Fallback**: Check if `build/{product}/rules/` directory exists. If not, offer the build prompt above.
+
+4. **Load the requirement**: Call `mcp__content-mcp__get_control_details` with `control_id`.
+   - If control not found, call `mcp__content-mcp__list_controls` and show options.
+   - Find the requirement matching `requirement_id` in the controls list.
+   - If requirement not found, list available requirement IDs and ask user to pick.
+   - **Fallback**: Read the control YAML directly from `controls/<control_id>.yml` or `products/<product>/controls/<control_id>.yml`. If the file has `controls_dir:`, read individual requirement files from that directory. To list controls, run `ls controls/*.yml` and `ls products/*/controls/*.yml`.
+
+5. **Display the requirement**:
+   ```
+   ## Requirement: {requirement_id}
+   **Title**: {title}
+   **Description**: {description}
+   **Current status**: {status}
+   **Current rules**: {rules or "none"}
+   ```
+
+6. **If no `--policy` specified**, show a tip:
+   > **Tip**: Pass `--policy <path>` to enrich mapping with the original security policy text (PDF, Markdown, HTML). This improves cross-framework matching accuracy.
+
+## Phase 1.5: Policy Enrichment (if `--policy` provided)
+
+If `--policy` was specified:
+
+1. **Infer document type** from the file extension:
+   - `.md` → `markdown`
+   - `.pdf` → `pdf`
+   - `.html` → `html`
+   - Otherwise → `text`
+
+2. **Call `mcp__content-mcp__parse_policy_document`** with:
+   - `source`: the policy path
+   - `document_type`: inferred from extension
+   - `requirement_id`: the requirement ID from Phase 1
+   - **Fallback**: For markdown/text files, read the file directly and search for the requirement ID. For PDF files, inform the user that PDF parsing requires the MCP server.
+
+3. **If sections returned**, display the policy context:
+   ```
+   ### Policy Context (from {policy_path})
+   **{section_title}**
+   {section_content}
+   {subsection contents...}
+   ```
+
+4. **Store the combined section text** as `policy_text` for use in Phase 2.
+
+## Phase 2: Find Candidate Rules
+
+Execute steps 2a-2c to build a candidate list from multiple sources.
+
+### Step 2a: Cross-Framework Search
+
+Call `mcp__content-mcp__find_similar_requirements` with:
+- `requirement_text`: if `policy_text` is available, use it; otherwise use the requirement's title + " " + description
+- `exclude_control_id`: current control_id
+- `max_results`: 10
+
+**Fallback**: Extract 3-5 key terms from the requirement text. Use `Grep` to search for each term across `controls/*.yml` and `products/*/controls/*.yml`. Requirements matching multiple terms are likely similar. Read matched requirements to extract their `rules:` lists.
+
+If results found, present them grouped by control framework:
+```
+### Similar Requirements in Other Frameworks
+
+- [{control_id}] {requirement_id}: "{title}" → rules: {rules}
+- [{control_id}] {requirement_id}: "{title}" → rules: {rules}
+```
+
+Extract the union of all rules from similar requirements as "cross-framework candidates".
+
+### Step 2b: Rule Search in Build Artifacts
+
+Search for candidate rules using rendered build artifacts (Jinja-expanded, product-specific):
+
+1. Extract 3-5 key terms from the requirement title and description.
+2. For each key term, call `mcp__content-mcp__search_rendered_content` with:
+   - `query`: the key term
+   - `product`: the target product from Phase 1
+   - `limit`: 15
+   - **Fallback**: If the product is not built, use `Grep` to search for key terms in `rule.yml` files under `linux_os/guide/` and `applications/`. This may miss rules with Jinja-templated descriptions.
+
+3. Deduplicate results across all term searches. Combine with cross-framework candidates from Step 2a.
+
+4. For each candidate rule, use `mcp__content-mcp__get_rendered_rule` (or `get_rule_details`) to read its title and description. Reason about which rules best match the requirement:
+   - Look for rules whose title/description semantically matches the requirement
+   - Prioritize rules that also appeared in Step 2a cross-framework results
+   - Consider rule severity alignment with the requirement's intent
+   - Rank candidates by relevance
+
+5. Present the top candidates in a table:
+   ```
+   ### Rule Candidates
+
+   | Rule ID | Title | Source | Reasoning |
+   |---------|-------|--------|-----------|
+   | {rule_id} | {title} | cross-ref / search | {why it matches} |
+   ```
+
+### Step 2c: Product Availability Check
+
+Since `search_rendered_content` only returns rules present in the target product's build, all search results are already confirmed available. For cross-framework candidates (from Step 2a) that did NOT appear in the rendered search, call `mcp__content-mcp__get_rule_product_availability` to verify availability.
+**Fallback**: For each rule, find its `rule.yml` and check the `identifiers:` section for `cce@<product>` entries. Also grep for the rule ID in `products/<target_product>/profiles/*.profile` and `products/<target_product>/controls/*.yml`.
+
+Flag rules that are NOT available for the target product:
+```
+Warning: Rule '{rule_id}' has identifiers for {other_products} but NOT for {target_product}.
+  May need platform/identifier additions to work for {target_product}.
+```
+
+For rules missing from the target product, use LLM judgment to assess portability:
+- If the rule uses a template (`template` is not None in get_rule_details), it's likely portable
+- If it has platform constraints mentioning specific products, note the constraint
+- Optionally call `mcp__content-mcp__get_rule_details` with `rendered_detail=full` and `product=<a product that has it>` to read the actual OVAL/remediation and assess whether it's product-specific
+
+## Phase 3: Author Decision
+
+1. **Build unified candidate list**: Combine cross-framework and search candidates, deduplicated by rule_id, sorted by relevance.
+
+2. **Present candidates** using `AskUserQuestion` with `multiSelect: true`:
+   - "Select rules to map to requirement '{requirement_id}: {title}'"
+   - Options: top candidates (up to 4, the AskUserQuestion limit), each with description showing source (cross-framework, search, or both) and reasoning
+   - If more than 4 candidates, present top 3 + "Show more candidates"
+
+3. **Ask about status** using a separate `AskUserQuestion`:
+   - "How should this requirement be marked?"
+   - Options:
+     - "Automated" — rules fully cover the requirement
+     - "Partially automated" — rules cover some aspects
+     - "Not applicable" — requirement doesn't apply to this product
+     - "Skip for now" — don't change anything
+
+## Phase 4: Write Selection
+
+Based on author's decision:
+
+### If rules were selected (automated or partially_automated):
+
+1. Call `mcp__content-mcp__update_requirement_rules` with:
+   - `control_id`: the control file ID
+   - `requirement_id`: the requirement ID
+   - `rules`: the selected rule IDs
+   - `status`: "automated" or "partially_automated" based on author's choice
+   - **Fallback**: Find the requirement file using `get_requirement_file_path` fallback (see above). Use `Edit` tool to update the `rules:` and `status:` fields in the YAML. Be careful to preserve existing formatting, comments, and Jinja2 templating.
+
+2. Verify the result:
+   - Check `success` field in the response
+   - If failed, report the error and suggest manual editing
+
+3. Report:
+   ```
+   Updated requirement '{requirement_id}' in '{control_id}':
+   - Rules: {rules}
+   - Status: {status}
+   - File: {file_path}
+   ```
+
+### If marked not applicable:
+
+1. Call `mcp__content-mcp__update_requirement_rules` with:
+   - `control_id`: the control file ID
+   - `requirement_id`: the requirement ID
+   - `rules`: [] (empty list)
+   - `status`: "not_applicable"
+   - **Fallback**: Edit the requirement YAML directly to set `status: not_applicable` and `rules: []`.
+
+2. Report the change.
+
+### If skipped:
+
+Report that no changes were made and move on.
+
+## Phase 5: Summary
+
+Present a brief summary:
+
+```
+## Mapping Complete
+
+Requirement: {requirement_id} ({title})
+Control file: {control_id}
+Action: {mapped N rules / marked not applicable / skipped}
+File modified: {file_path or "none"}
+
+Next steps:
+- Map another requirement: `/map-requirement {control_id} <next_req_id> --product {product}`
+- Map all unmapped: `/map-controls {control_id} --product {product}`
+- Review changes: `git diff controls/`
+```
+
+## Error Handling
+
+- If `update_requirement_rules` fails, display the error message and suggest the user manually edit the file. Use `mcp__content-mcp__get_requirement_file_path` to find the correct file, or **Fallback**: locate it by reading the control YAML's `controls_dir:` field or searching for the requirement in the inline `controls:` list.
+- If rule search returns no results, rely only on cross-framework candidates from step 2a.
+- If no candidates are found from any source, inform the user and offer options: "Skip", "Enter rule IDs manually", "Create new rule (use /create-rule)".

--- a/.claude/skills/map-requirement/SKILL.md
+++ b/.claude/skills/map-requirement/SKILL.md
@@ -25,9 +25,10 @@ Examples:
 
 1. **Parse arguments**: Extract `control_id`, `requirement_id`, `--product` flag, and optional `--policy` flag from `$ARGUMENTS`.
 
-2. **If no `--product` specified**, ask the user via `AskUserQuestion`:
+2. **If no `--product` specified**, discover available products and ask the user via `AskUserQuestion`:
+   - Run `ls products/` (or call `mcp__content-mcp__list_products`) to get the list of available products
    - "Which product are you mapping rules for?"
-   - Options: "rhel9", "rhel10", "rhel8", "fedora" + Other
+   - Options: present the most common products from the discovered list + Other
 
 3. **Check build artifacts**: Call `mcp__content-mcp__list_built_products`.
    - If the target product is NOT in the built list, ask the user via `AskUserQuestion`:

--- a/.claude/skills/onboard-control/SKILL.md
+++ b/.claude/skills/onboard-control/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: onboard-control
+description: Onboard a new security policy as a control file. Parse the document, create control file structure, and map existing rules to requirements.
+---
+
+# Onboard Control
+
+Parse a security policy document (PDF, Markdown, HTML, or text), create a ComplianceAsCode control file structure from it, and optionally map existing rules to the extracted requirements.
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+**Without MCP server**: PDF parsing is unavailable (use markdown/text instead). Control file generation and validation must be done manually. Cross-framework similarity search for auto-mapping is unavailable; keyword-based search is used instead.
+
+**Arguments**: $ARGUMENTS — format: `<document_path> [--id <policy_id>] [--product <product_id>] [--no-map]`
+
+Examples:
+- `/onboard-control security_policies/anssi_r2.pdf --id anssi --product rhel9`
+- `/onboard-control security_policies/cis_benchmark_v1.md --id cis_workstation --product fedora`
+- `/onboard-control https://example.com/policy.html --id my_policy --no-map`
+- `/onboard-control security_policies/stig.pdf --id rhel9_stig --product rhel9`
+
+## Phase 1: Parse and Validate Input
+
+1. **Parse arguments**: Extract `document_path`, optional `--id <policy_id>`, optional `--product <product_id>`, and optional `--no-map` flag from `$ARGUMENTS`.
+
+2. **Infer document type** from the file extension:
+   - `.pdf` → `pdf`
+   - `.md` → `markdown`
+   - `.html` / `.htm` → `html`
+   - Otherwise → `text`
+
+3. **Validate product** (if specified): Call `mcp__content-mcp__get_product_details` with `product_id`.
+   - If not found, call `mcp__content-mcp__list_products` and present options via `AskUserQuestion`:
+     - "Product '{product_id}' not found. Which product is this control for?"
+     - Options: top 4 relevant products + Other
+   - **Fallback**: Check if `products/<product_id>/product.yml` exists. List products with `ls products/`.
+
+4. **If no `--product` specified**, ask the user via `AskUserQuestion`:
+   - "Which product is this control file for? (optional — leave blank for product-agnostic)"
+   - Options: "rhel9", "rhel10", "fedora", "Product-agnostic (global controls/)" + Other
+
+5. **Check for existing control**: If `--id` was provided, call `mcp__content-mcp__get_control_stats` with `control_id` to check whether a control file with this ID already exists.
+   **Fallback**: Check if `controls/<policy_id>.yml` or `products/<product>/controls/<policy_id>.yml` exists.
+   - If it already exists, warn the user via `AskUserQuestion`:
+     - "Control file '{policy_id}' already exists with {total} requirements. What would you like to do?"
+     - Options:
+       - "Overwrite" — proceed and replace
+       - "Choose a different ID" — ask for new ID
+       - "Abort"
+
+## Phase 2: Parse the Policy Document
+
+1. **Parse document**: Call `mcp__content-mcp__parse_policy_document` with:
+   - `source`: document_path
+   - `document_type`: inferred type from Phase 1
+   - **Fallback**: For markdown/text/HTML files, read the file directly and extract structure by splitting on headings. Identify requirements from numbered sections, bullet lists, or tables. For PDF files, inform the user that PDF parsing requires the MCP server and ask for a text/markdown alternative.
+
+2. **Display parse results**:
+   ```
+   ## Parsed: {document_title}
+
+   - Sections found: {count}
+   - Requirements extracted: {count}
+   - Document type: {type}
+   ```
+
+3. **Show extracted structure** — present a summary of sections and requirements:
+   ```
+   ### Document Structure
+
+   | # | Section | Title | Requirements |
+   |---|---------|-------|-------------|
+   | 1 | 1.1     | Access Control | 5 |
+   | 2 | 1.2     | Authentication | 3 |
+   | ... | ... | ... | ... |
+   ```
+
+4. **If no requirements were extracted** (parsed document returned empty requirements):
+   - Inform the user that automatic extraction found no structured requirements
+   - Ask via `AskUserQuestion`:
+     - "No requirements were automatically extracted. How would you like to proceed?"
+     - Options:
+       - "Show raw sections" — display all parsed sections so user can identify requirements
+       - "Treat each section as a requirement" — use document sections directly as requirements
+       - "Abort"
+   - If "Show raw sections": display all section titles and first ~100 chars of content, then ask user to confirm which sections contain requirements
+   - If "Treat each section as a requirement": map each section to a requirement with `id=section_id`, `title=section_title`, `description=section_content`
+
+5. **Ask user to confirm** via `AskUserQuestion`:
+   - "Proceed with {N} extracted requirements?"
+   - Options:
+     - "Yes, generate control files"
+     - "Show all requirements first" — display full list before proceeding
+     - "Abort"
+
+## Phase 3: Determine Policy Metadata
+
+1. **If `--id` not provided**, suggest a policy ID based on the document title:
+   - Convert title to lowercase, replace spaces/special chars with underscores
+   - Truncate to reasonable length
+   - Ask user via `AskUserQuestion`:
+     - "What ID should this control file use?"
+     - Options:
+       - "{suggested_id}" (based on document title)
+       - "{alternative_id}" (shorter variant)
+       - Other
+
+2. **Ask for additional metadata** via `AskUserQuestion`:
+   - "Does this policy define compliance levels (e.g., high/medium/low, Level 1/Level 2)?"
+   - Options:
+     - "high, medium, low"
+     - "Level 1, Level 2"
+     - "enhanced, intermediate, minimal"
+     - "No levels"
+
+3. **Ask for version** if not obvious from the document:
+   - "What version string should this control use? (e.g., 'v1r1', '1.0', leave blank to skip)"
+   - Only ask if the document title or metadata doesn't already contain a clear version
+
+## Phase 4: Generate Control File Structure
+
+1. **Ask for output format** via `AskUserQuestion`:
+   - "How should the control file be structured?"
+   - Options:
+     - "Directory (Recommended)" — parent YAML file + individual files per requirement in a subdirectory. Best for large policies with many requirements. Uses `controls_dir` in parent file.
+     - "Inline" — single monolithic YAML file with all requirements in a `controls` list. Simpler for small policies with few requirements.
+
+2. **Prepare requirements JSON**: Format the extracted requirements as JSON for the generation tool:
+   ```json
+   {
+     "requirements": [
+       {
+         "id": "...",
+         "title": "...",
+         "description": "...",
+         "section": "..."
+       }
+     ]
+   }
+   ```
+
+3. **Generate control files**: Call `mcp__content-mcp__generate_control_files` with:
+   - `policy_id`: from Phase 3
+   - `policy_title`: from parsed document title
+   - `format`: `"directory"` or `"inline"` based on user choice
+   - `requirements_json`: prepared JSON
+   - `source_document`: original document path
+   - `version`: if provided
+   - `levels`: if provided
+   - `product`: if specified (generates into `products/<product>/controls/` instead of `controls/`)
+   - **Fallback**: Write the control YAML files manually using `Write` tool. Follow the `shared/schemas/control.json` schema for structure. For **inline** format, create a single YAML file with a `controls:` list. For **directory** format, create a parent YAML with `controls_dir:` and individual YAML files per requirement.
+
+4. **Display generation result**:
+
+   For **directory** format:
+   ```
+   ## Control Files Generated
+
+   - Parent file: {parent_file_path}
+   - Requirement files: {count} files in {directory}
+   - Errors: {count}
+   - Warnings: {count}
+   ```
+
+   For **inline** format:
+   ```
+   ## Control File Generated
+
+   - File: {parent_file_path}
+   - Requirements: {count} controls in file
+   - Errors: {count}
+   - Warnings: {count}
+   ```
+
+   If there are errors, display them and ask if the user wants to continue or abort.
+
+4. **Validate generated files**: Call `mcp__content-mcp__validate_control_file` with the generated parent file path.
+   **Fallback**: Validate against the JSON schema:
+   ```bash
+   python3 -c "
+   import json, yaml, sys
+   from jsonschema import validate, ValidationError
+   schema = json.load(open('shared/schemas/control.json'))
+   data = yaml.safe_load(open(sys.argv[1]))
+   try:
+       validate(instance=data, schema=schema)
+       print('Valid')
+   except ValidationError as e:
+       print(f'Invalid: {e.message}')
+   " <path_to_control.yml>
+   ```
+
+5. **Display validation results**:
+   ```
+   ### Validation
+
+   - Valid: {yes/no}
+   - Errors: {list}
+   - Warnings: {list}
+   ```
+
+   If validation fails, attempt to fix issues. Common fixes:
+   - Missing required fields → add them
+   - Invalid YAML syntax → regenerate the file
+   - Rule references that don't exist → remove them (will be added during mapping)
+
+## Phase 5: Initial Rule Mapping (unless `--no-map`)
+
+If `--no-map` was NOT specified, offer to do an initial mapping pass.
+
+1. **Ask user** via `AskUserQuestion`:
+   - "Control file created with {N} requirements. Would you like to do an initial rule mapping now?"
+   - Options:
+     - "Yes, map all requirements" — full mapping session
+     - "Yes, quick auto-map only" — automatic mapping without interactive review (cross-framework only)
+     - "No, I'll map later with /map-controls"
+
+2. **If "Yes, map all requirements"**: Hand off to the `/map-controls` workflow:
+   - Tell the user: "Starting interactive mapping session. This follows the same workflow as `/map-controls {policy_id} --product {product} --policy {document_path}`."
+   - Proceed with the map-controls Phase 2 logic (per-requirement mapping loop)
+
+3. **If "Yes, quick auto-map only"**: Perform automatic mapping:
+
+   For each requirement:
+   a. Call `mcp__content-mcp__find_similar_requirements` with:
+      - `requirement_text`: requirement title + " " + description
+      - `exclude_control_id`: current policy_id
+      - `max_results`: 5
+      - `min_similarity`: 0.4 (higher threshold for auto-mapping to avoid false positives)
+      - **Fallback**: Extract key terms and grep across control files for matching requirements.
+
+   b. Collect all rules from similar requirements across frameworks.
+
+   c. If the target product is specified, call `mcp__content-mcp__get_rule_product_availability` for the top candidate rules to verify they're available for the product.
+      **Fallback**: Check each rule's `rule.yml` for `cce@<product>` identifiers.
+
+   d. If confident matches found (rules appear in 2+ other frameworks for the same concept):
+      - Call `mcp__content-mcp__update_requirement_rules` with the matched rules and `status="automated"`.
+        **Fallback**: Edit the requirement YAML directly using `Edit` tool.
+
+   e. Track auto-mapped vs. skipped requirements.
+
+   After the auto-map pass, report results:
+   ```
+   ### Auto-Mapping Results
+
+   - Auto-mapped: {X} requirements
+   - Skipped (no confident match): {Y} requirements
+   - Total rules assigned: {Z}
+
+   | Requirement | Rules | Source Frameworks |
+   |-------------|-------|-------------------|
+   | {req_id}    | {rules} | {frameworks} |
+   ```
+
+4. **If "No"**: Skip mapping, proceed to Phase 6.
+
+## Phase 6: Final Report
+
+Present a summary of the onboarding:
+
+```
+## Control Onboarding Complete
+
+**Policy**: {policy_title}
+**Control ID**: {policy_id}
+**Product**: {product or "global"}
+**Source**: {document_path}
+
+### Files Created
+- Control file: {parent_file_path}
+- Format: {inline or directory}
+- Requirements: {count} (inline: in single file / directory: individual files in {directory})
+
+### Mapping Status
+```
+
+Call `mcp__content-mcp__get_control_stats` with the new `control_id` (and `product` if specified) to show current state.
+**Fallback**: Read the generated control YAML and count requirements by status.
+
+```
+| Status    | Count |
+|-----------|-------|
+| Total     | {total} |
+| Mapped    | {mapped} |
+| Unmapped  | {unmapped} |
+| Coverage  | {percentage}% |
+```
+
+```
+### Next Steps
+
+1. Review generated files: `git diff controls/` or `git status`
+2. Inspect the control: `/inspect-control {policy_id}`
+3. Map remaining requirements: `/map-controls {policy_id} --product {product} --policy {document_path}`
+4. Map a single requirement: `/map-requirement {policy_id} <req_id> --product {product}`
+5. Build product: `/build-product {product}`
+6. Draft PR: `/draft-pr`
+```
+
+## Important Notes
+
+- **Exact text preservation**: The parsed document text is stored verbatim in requirement descriptions. No AI rewording happens during parsing.
+- **Two output formats**: The `format` parameter controls the structure:
+  - `"directory"` (recommended for most policies): Creates a parent YAML file with a `controls_dir` reference and individual YAML files per requirement in a subdirectory. The subdirectory is flat (not nested by section).
+  - `"inline"`: Creates a single monolithic YAML file with all requirements in a `controls` list. Suitable for small policies.
+- **Product-specific controls**: When `--product` is specified, files are generated in `products/<product>/controls/` which takes precedence over global `controls/` for that product.
+- **Large documents**: For documents with 100+ requirements, the auto-map option in Phase 5 is recommended over interactive mapping, as the full interactive session can be very long. Use `/map-controls` afterward for requirements that need manual attention.
+- **Duplicate detection**: Phase 1 checks for existing control files to prevent accidental overwrites.
+- **Do NOT call `get_control_rule_index`** — it returns a 1.6MB+ payload. Use per-requirement `find_similar_requirements` instead.
+- **Version detection**: Try to detect version from the document title or metadata before asking the user (e.g., "STIG V3R4" → `v3r4`, "CIS Benchmark v1.0" → `v1.0`).

--- a/.claude/skills/onboard-control/SKILL.md
+++ b/.claude/skills/onboard-control/SKILL.md
@@ -37,9 +37,10 @@ Examples:
      - Options: top 4 relevant products + Other
    - **Fallback**: Check if `products/<product_id>/product.yml` exists. List products with `ls products/`.
 
-4. **If no `--product` specified**, ask the user via `AskUserQuestion`:
+4. **If no `--product` specified**, discover available products and ask the user via `AskUserQuestion`:
+   - Run `ls products/` (or call `mcp__content-mcp__list_products`) to get the list of available products
    - "Which product is this control file for? (optional — leave blank for product-agnostic)"
-   - Options: "rhel9", "rhel10", "fedora", "Product-agnostic (global controls/)" + Other
+   - Options: present the most common products from the discovered list + "Product-agnostic (global controls/)" + Other
 
 5. **Check for existing control**: If `--id` was provided, call `mcp__content-mcp__get_control_stats` with `control_id` to check whether a control file with this ID already exists.
    **Fallback**: Check if `controls/<policy_id>.yml` or `products/<product>/controls/<policy_id>.yml` exists.
@@ -108,12 +109,9 @@ Examples:
        - Other
 
 2. **Ask for additional metadata** via `AskUserQuestion`:
+   - Check existing control files for common level patterns: `grep -h 'id:' controls/*.yml products/*/controls/*.yml | grep -A5 'levels:' | head -20` or call `mcp__content-mcp__list_controls` to see level schemes used in other frameworks
    - "Does this policy define compliance levels (e.g., high/medium/low, Level 1/Level 2)?"
-   - Options:
-     - "high, medium, low"
-     - "Level 1, Level 2"
-     - "enhanced, intermediate, minimal"
-     - "No levels"
+   - Options: present common level schemes discovered from existing control files + "No levels" + Other
 
 3. **Ask for version** if not obvious from the document:
    - "What version string should this control use? (e.g., 'v1r1', '1.0', leave blank to skip)"

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: run-tests
+description: Run ctest validation tests on a built product
+---
+
+# Run Validation Tests
+
+Run the ctest validation suite against built content in `build/`.
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+## Phase 1: Verify Build Exists
+
+1. **Check that the build directory exists and contains content**:
+   Use `mcp__content-mcp__list_built_products` to check which products have been built and have artifacts available.
+   **Fallback**: Run `ls build/ssg-*-ds.xml 2>/dev/null` to check for built datastreams.
+
+2. **If no build artifacts found**, inform the user:
+   - No built products found in `build/`
+   - Suggest running `/build-product <product>` first
+
+## Phase 2: Run Validation Tests
+
+Run the full test suite:
+```bash
+cd build && ctest -j$(nproc) --output-on-failure
+```
+
+This includes:
+- YAML syntax validation
+- Schema validation
+- Reference checking
+- Python unit tests
+- Content validation
+- Cross-reference checking
+
+## Phase 3: Analyze Test Results
+
+### Success Output
+
+```
+Test Results Summary
+====================
+
+Tests: ALL PASSED
+
+Validation: COMPLETE
+```
+
+### Failure Output
+
+```
+Test Results Summary
+====================
+
+Tests: FAILURES DETECTED
+  - X/Y tests passed
+
+Failed Tests:
+  1. test-yaml-syntax-<product>
+     - File: linux_os/guide/.../rule.yml
+     - Error: Invalid YAML at line 15
+
+  2. test-oval-schema-<product>
+     - File: build/ssg-<product>-oval.xml
+     - Error: Element 'object': Missing required attribute 'id'
+
+Suggested Fixes:
+  1. Check YAML syntax in the indicated file
+  2. Review OVAL generation for the affected rule
+```
+
+## Phase 4: Lint Checks (Optional)
+
+Ask if user wants additional lint checks:
+
+### ShellCheck (Bash scripts)
+
+```bash
+find linux_os/guide -name "*.sh" -exec shellcheck {} \;
+```
+
+### ansible-lint (Ansible playbooks)
+
+```bash
+ansible-lint build/ansible/*-playbook-*.yml
+```
+
+### yamllint (YAML files)
+
+```bash
+yamllint linux_os/guide/
+```
+
+### Python linting
+
+```bash
+ruff check ssg/
+# or
+tox -e flake8
+```
+
+## Phase 5: Generate Statistics (Optional)
+
+Ask if user wants build statistics:
+
+```bash
+cd build
+make <product>-stats
+```
+
+This generates:
+- Rule count per profile
+- Coverage statistics
+- Reference mapping summary
+
+## Phase 6: Report Results
+
+### Full Success Report
+
+```
+Validation Complete
+===================
+
+Test Status: ALL PASSED
+
+Ready for:
+  - Automatus testing: /test-rule <rule_id>
+  - PR creation
+```
+
+### Failure Report
+
+```
+Validation Complete
+===================
+
+Test Status: FAILURES DETECTED
+  - See details above
+
+Action Required:
+  1. Fix the failing tests before proceeding
+  2. Re-run: /run-tests
+
+Common fixes:
+  - YAML syntax: Check indentation and special characters
+  - OVAL errors: Review template usage in rule.yml
+  - Missing references: Add required identifiers
+```

--- a/.claude/skills/shared/mcp_fallbacks.md
+++ b/.claude/skills/shared/mcp_fallbacks.md
@@ -1,0 +1,217 @@
+# MCP Fallback Reference
+
+When the `mcp__content-mcp__*` tools are not available, use these filesystem-based alternatives.
+
+## Simple Lookups
+
+### list_products
+```bash
+ls products/
+```
+For details, read `products/<product_id>/product.yml`.
+
+### get_product_details
+Read `products/<product_id>/product.yml` directly.
+
+### list_templates
+```bash
+ls shared/templates/
+```
+
+### get_template_schema
+Read the template files in `shared/templates/<template_name>/`. Look for `template.yml` or `template.py` for parameter definitions. Also check `shared/templates/<template_name>/tests/` for usage examples.
+
+### list_profiles
+```bash
+ls products/<product>/profiles/*.profile
+```
+
+### get_profile_details
+Read `products/<product>/profiles/<profile_id>.profile` directly.
+
+### list_controls
+```bash
+ls controls/*.yml
+ls products/*/controls/*.yml
+```
+
+### get_control_details
+Read the control YAML file directly:
+- Global: `controls/<control_id>.yml`
+- Product-specific: `products/<product>/controls/<control_id>.yml`
+
+If the file has `controls_dir:`, individual requirement files are in the referenced subdirectory.
+
+### get_control_stats
+Read the control YAML and count requirements by status. Parse the `controls:` list (inline format) or read all files in `controls_dir:` (directory format). Count entries grouped by `status` field.
+
+### list_unmapped_requirements
+Read the control YAML and filter requirements where `status` is `pending` or where `rules:` is empty/missing.
+
+### get_requirement_file_path
+- **Inline format**: The requirement is in the main control YAML file (e.g., `controls/<control_id>.yml`)
+- **Directory format**: Check the `controls_dir:` field in the parent YAML, then look for `<requirement_id>.yml` in that directory.
+
+### list_built_products
+```bash
+ls build/ssg-*-ds.xml 2>/dev/null | sed 's|build/ssg-||;s|-ds.xml||'
+```
+
+### get_datastream_info
+```bash
+ls -la build/ssg-<product>-ds.xml
+```
+
+### search_rules
+Use Glob to find rule.yml files and Grep to match keywords:
+```
+Glob: **/rule.yml
+Grep: "<keyword>" in matched files
+```
+
+### get_rule_details
+Find and read the rule.yml:
+```
+Glob: **/<<rule_id>>/rule.yml
+```
+Then read the file. The rule directory is typically under `linux_os/guide/` or `applications/`.
+
+### search_control_requirements
+Grep through control files for the query text:
+```
+Grep: "<query>" in controls/*.yml and products/*/controls/*.yml
+```
+
+### get_rule_product_availability
+Search for the rule ID across product profiles and control files:
+```
+Grep: "<rule_id>" in products/*/profiles/*.profile
+Grep: "<rule_id>" in products/*/controls/*.yml
+Grep: "<rule_id>" in controls/*.yml
+```
+Also check the rule's `identifiers:` section in `rule.yml` for `cce@<product>` entries.
+
+### get_rendered_rule
+Read from build artifacts:
+```bash
+cat build/<product>/rules/<rule_id>.yml
+```
+
+### search_rendered_content
+Grep through build artifacts:
+```
+Grep: "<query>" in build/<product>/rules/
+```
+
+## Complex Operations
+
+### find_similar_requirements
+
+No direct filesystem equivalent for semantic similarity. Fallback approach:
+
+1. Extract 3-5 key terms from the requirement text (nouns, technical terms).
+2. Grep each term across all control files:
+   ```
+   Grep: "<term>" in controls/*.yml and products/*/controls/*.yml
+   ```
+3. Requirements that match multiple terms are likely similar.
+4. Read matched requirements and extract their `rules:` lists.
+5. The union of rules from matched requirements forms the cross-framework candidates.
+
+This is less precise than the MCP tool's text similarity but catches most obvious matches.
+
+### parse_policy_document
+
+- **Markdown/text files**: Read the file directly. Split by headings (`#`, `##`, etc.) to identify sections. Extract requirement IDs from section headers or numbered lists.
+- **HTML files**: Read the file. The markup is usually readable enough to extract structure.
+- **PDF files**: Cannot be parsed without the MCP server. Inform the user:
+  > PDF parsing requires the content-mcp server. Please convert the PDF to markdown or text first, or configure the MCP server.
+
+### update_requirement_rules
+
+Edit the control YAML directly using the `Edit` tool.
+
+**Inline format** (requirements in main YAML under `controls:` list):
+1. Read the control file.
+2. Find the requirement by `id:`.
+3. Replace or add the `rules:` list and `status:` field.
+4. Use `Edit` tool to make the change.
+
+**Directory format** (individual files in `controls_dir:`):
+1. Find the requirement file (see `get_requirement_file_path` above).
+2. Edit the `rules:` and `status:` fields.
+
+**Warning**: Be careful to preserve existing YAML formatting, comments, and Jinja2 templating (`{{% ... %}}`).
+
+### generate_rule_boilerplate / generate_rule_from_template
+
+Create the rule directory and files manually using `Write` tool:
+
+```
+<location>/<rule_id>/
+├── rule.yml
+```
+
+For non-templated rules, also create skeleton files:
+```
+├── oval/shared.xml
+├── bash/shared.sh
+├── ansible/shared.yml
+└── tests/
+    ├── correct.pass.sh
+    └── wrong.fail.sh
+```
+
+The skill instructions contain the skeleton file templates to use.
+
+### generate_control_files
+
+Write the control YAML structure manually using `Write` tool.
+
+**Inline format**: Single YAML file with all requirements in a `controls:` list.
+**Directory format**: Parent YAML file with `controls_dir:` reference + individual YAML files per requirement.
+
+See `shared/schemas/control.json` for the expected structure.
+
+## Validation
+
+### validate_rule_yaml
+
+Validate against the JSON schema:
+```bash
+python3 -c "
+import json, yaml, sys
+from jsonschema import validate, ValidationError
+schema = json.load(open('shared/schemas/rule.json'))
+data = yaml.safe_load(open(sys.argv[1]))
+try:
+    validate(instance=data, schema=schema)
+    print('Valid')
+except ValidationError as e:
+    print(f'Invalid: {e.message}')
+" <path_to_rule.yml>
+```
+
+If `jsonschema` is not installed, do a manual check of required fields: `documentation_complete`, `title`, `description`, `rationale`, `severity` (must be one of: high, medium, low, unknown).
+
+### validate_control_file
+
+Validate against the JSON schema:
+```bash
+python3 -c "
+import json, yaml, sys
+from jsonschema import validate, ValidationError
+schema = json.load(open('shared/schemas/control.json'))
+data = yaml.safe_load(open(sys.argv[1]))
+try:
+    validate(instance=data, schema=schema)
+    print('Valid')
+except ValidationError as e:
+    print(f'Invalid: {e.message}')
+" <path_to_control.yml>
+```
+
+If `jsonschema` is not installed, do a manual check:
+- Each control in `controls:` list must have a `title` field
+- `status` must be one of: automated, documentation, does not meet, inherently met, manual, not applicable, partial, pending, planned, supported
+- `rules` and `levels` must be arrays of strings if present

--- a/.claude/skills/test-rule/SKILL.md
+++ b/.claude/skills/test-rule/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: test-rule
+description: Run Automatus tests for a security rule
+---
+
+# Test Rule
+
+Run Automatus tests for a ComplianceAsCode security rule.
+
+**Rule ID**: $ARGUMENTS
+
+## Tool Strategy
+
+This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+
+## Phase 1: Validate Rule Exists
+
+1. **Find the rule** using `mcp__content-mcp__get_rule_details` with `rule_id=$ARGUMENTS`:
+   - This returns the full rule metadata including template info, CCE identifiers, remediation types, and file location.
+   - If the rule is not found, also use `mcp__content-mcp__search_rules` with `query=$ARGUMENTS` to check for similar rule IDs.
+   - **Fallback**: Use `Glob` to find `**/$ARGUMENTS/rule.yml`, then read the file to extract metadata. For similar rule search, use `Grep` to search for `$ARGUMENTS` across rule.yml files.
+
+2. **If rule not found**:
+   - Use `mcp__content-mcp__list_templates` to check if it's a template name instead.
+   **Fallback**: Run `ls shared/templates/` to check for template names.
+   - Inform user and exit if not found
+
+3. **From the rule details**, determine:
+   - Is it templated? (has `template:` key)
+   - What products have CCE identifiers? (determines applicable products)
+   - What remediation types are available?
+
+## Phase 2: Determine Test Scope
+
+1. **Identify testable products** from CCE identifiers:
+   - Only `rhel8`, `rhel9`, `rhel10` are supported by Automatus
+   - Extract from rule.yml identifiers: `cce@rhel8`, `cce@rhel9`, `cce@rhel10`
+
+2. **Ask user for testing scope** using AskUserQuestion:
+
+   **Question**: "Which products do you want to test?"
+
+   **Options** (show only products with CCE identifiers):
+   - rhel10 (if CCE exists)
+   - rhel9 (if CCE exists)
+   - rhel8 (if CCE exists)
+   - All applicable products
+
+   Enable multi-select.
+
+3. **Ask for remediation types** using AskUserQuestion:
+
+   **Question**: "Which remediation types do you want to test?"
+
+   **Options**:
+   - **Bash only** - Test Bash remediation (faster)
+   - **Ansible only** - Test Ansible remediation
+   - **Both Bash and Ansible (Recommended)** - Test both remediation types
+
+## Important: Sandbox Requirements
+
+All `virsh` and `automatus.py` commands require `dangerouslyDisableSandbox: true` on the Bash tool. These commands use libvirt unix sockets and SSH connections to VMs, which are blocked by the default sandbox. Set this flag on **every** Bash call that runs `virsh` or `automatus.py`.
+
+## Phase 3: Determine Libvirt Connection and VM Names
+
+### 3.1 Detect Libvirt Connection URI
+
+The libvirt connection URI depends on the user's VM setup. **Ask the user** using AskUserQuestion:
+
+**Question**: "Which libvirt connection URI does your VM setup use?"
+
+**Options**:
+- **qemu:///session (Recommended)** - User session VMs, no root required
+- **qemu:///system** - System-wide VMs, may require root/sudo
+
+Store the selected URI as `<libvirt_uri>` for all subsequent commands.
+
+### 3.2 Discover VM Names
+
+VM names often differ from product names (e.g., `rhel9-test`, `ssg-rhel9`, `rhel-9.4`). Discover available VMs:
+
+```bash
+virsh -c <libvirt_uri> list --all 2>/dev/null
+```
+
+For each selected product, ask the user to confirm the VM name:
+
+**Question**: "Which VM should be used for testing `<product>`? Available VMs are listed above."
+
+**Options** (populated from `virsh list --all` output, filtered to relevant entries):
+- Matching VMs from the list
+- Allow user to type a custom name
+
+Store the mapping of product → VM name for Phase 5.
+
+**Note on sudo**: When using `qemu:///system`, some operations (starting VMs, creating snapshots) may require `sudo`. When using `qemu:///session`, `sudo` is not needed. Adjust commands accordingly.
+
+## Phase 4: Verify Prerequisites
+
+1. **Check for existing datastreams**:
+   Use `mcp__content-mcp__list_built_products` to see which products have been built.
+   **Fallback**: Run `ls build/ssg-*-ds.xml 2>/dev/null` to list built datastreams.
+
+2. **For each selected product**, check if datastream exists and get details:
+   Use `mcp__content-mcp__get_datastream_info` with `product=<product>` to verify the datastream exists and get its details.
+   **Fallback**: Run `ls -la build/ssg-<product>-ds.xml` to check if the datastream exists.
+
+3. **Build datastreams if needed**:
+   - If datastream doesn't exist or is older than rule.yml modifications
+   - Ask user: "Datastream for <product> is missing/outdated. Build it now?"
+
+   ```bash
+   ./build_product --datastream-only <product>
+   ```
+
+4. **Verify VMs are available and running** (CRITICAL — Automatus requires the VM to be running):
+   ```bash
+   virsh -c <libvirt_uri> list --all 2>/dev/null | grep -E "rhel[0-9]+"
+   ```
+
+   - Inform user of available VMs
+   - If required VM not found, provide guidance on VM setup
+   - **Check that the required VM is in "running" state**. If the VM exists but is shut off, **start it before proceeding**:
+     ```bash
+     # For qemu:///system, prefix with sudo if needed
+     virsh -c <libvirt_uri> start <vm_name>
+     ```
+   - Wait a moment after starting the VM and verify it is running:
+     ```bash
+     virsh -c <libvirt_uri> list --all 2>/dev/null | grep <vm_name>
+     ```
+   - **Do NOT proceed to Phase 5 until the VM is confirmed running.** Automatus will fail if the VM is not started.
+
+5. **Verify VM has a snapshot** (CRITICAL — Automatus reverts to a snapshot between test scenarios):
+   ```bash
+   virsh -c <libvirt_uri> snapshot-list <vm_name>
+   ```
+
+   - Automatus needs at least one snapshot to restore clean state between test scenarios.
+   - If no snapshots exist, inform the user and suggest creating one:
+     ```bash
+     # For qemu:///system, prefix with sudo if needed
+     virsh -c <libvirt_uri> snapshot-create-as <vm_name> clean
+     ```
+   - **Do NOT proceed to Phase 5 if no snapshot exists.** Automatus will fail or leave the VM in a dirty state.
+
+## Phase 5: Run Automatus Tests
+
+### For Rule Testing
+
+Run tests for each selected product and remediation type, using the `<libvirt_uri>` and `<vm_name>` determined in Phase 3:
+
+**Bash remediation**:
+```bash
+cd tests
+./automatus.py rule --libvirt <libvirt_uri> <vm_name> \
+    --datastream ../build/ssg-<product>-ds.xml \
+    $ARGUMENTS
+```
+
+**Ansible remediation**:
+```bash
+cd tests
+./automatus.py rule --libvirt <libvirt_uri> <vm_name> \
+    --datastream ../build/ssg-<product>-ds.xml \
+    --remediate-using ansible \
+    $ARGUMENTS
+```
+
+### For Template Testing
+
+If testing a template instead of a rule:
+```bash
+cd tests
+./automatus.py template --libvirt <libvirt_uri> <vm_name> \
+    --datastream ../build/ssg-<product>-ds.xml \
+    $ARGUMENTS
+```
+
+## Phase 6: Monitor Test Execution
+
+1. **Tests run in foreground** - output is streamed
+
+2. **Test phases to expect**:
+   - Initial scan (check if rule is evaluated)
+   - Remediation application
+   - Final scan (verify remediation worked)
+
+3. **For each test scenario** (e.g., `correct.pass.sh`, `wrong.fail.sh`):
+   - `.pass.sh` scenarios: Should pass on initial scan
+   - `.fail.sh` scenarios: Should fail initially, then pass after remediation
+
+## Phase 7: Analyze Results
+
+1. **Find results directory**:
+   ```bash
+   ls -td tests/logs/rule-custom-* 2>/dev/null | head -1
+   ```
+
+2. **Read results.json**:
+   ```bash
+   cat tests/logs/rule-custom-*/results.json
+   ```
+
+3. **Parse and summarize results**:
+
+   | Scenario | Initial Scan | Remediation | Final Scan | Status |
+   |----------|--------------|-------------|------------|--------|
+   | wrong.fail | FAIL | APPLIED | PASS | OK |
+   | correct.pass | PASS | SKIPPED | N/A | OK |
+
+4. **Check for common issues**:
+   - **Initial scan passed on .fail scenario**: Test scenario didn't properly set up non-compliant state
+   - **Remediation failed**: Bash/Ansible script has errors
+   - **Final scan failed after remediation**: Remediation incomplete or incorrect
+   - **Not applicable**: Platform check excluded the rule
+
+## Phase 8: Report Results
+
+### Success Report
+
+```
+Test Results for $ARGUMENTS
+==============================
+
+Product: rhel9
+Remediation: Bash
+
+Scenarios:
+  - wrong.fail.sh: PASSED (fail -> remediate -> pass)
+  - correct.pass.sh: PASSED (already compliant)
+
+Overall: ALL TESTS PASSED
+
+---
+
+Product: rhel9
+Remediation: Ansible
+
+Scenarios:
+  - wrong.fail.sh: PASSED (fail -> remediate -> pass)
+  - correct.pass.sh: PASSED (already compliant)
+
+Overall: ALL TESTS PASSED
+
+==============================
+Summary: 4/4 tests passed across all products and remediation types
+```
+
+### Failure Report
+
+```
+Test Results for $ARGUMENTS
+==============================
+
+Product: rhel9
+Remediation: Bash
+
+Scenarios:
+  - wrong.fail.sh: FAILED
+    - Initial scan: FAIL (expected)
+    - Remediation: APPLIED
+    - Final scan: FAIL (unexpected!)
+    - Issue: Remediation did not properly configure the setting
+
+  - correct.pass.sh: PASSED
+
+Log files: tests/logs/rule-custom-2024-01-15-1423/
+
+Suggested debugging:
+1. Check remediation script: find linux_os/guide -path "*/$ARGUMENTS/bash/*"
+2. Review test scenario: find linux_os/guide -path "*/$ARGUMENTS/tests/*"
+3. SSH into VM to inspect: virsh console rhel9
+
+==============================
+Summary: 1/2 tests failed
+```
+
+## Phase 9: Provide Next Steps
+
+Based on results:
+
+**If all tests passed**:
+- "Rule is ready. Use `/build-product <product>` to build and `/run-tests` to validate."
+- "Consider testing on additional products if applicable."
+
+**If tests failed**:
+- Provide specific debugging guidance based on failure type
+- Suggest files to check/modify
+- Offer to help fix the issues
+
+**If no tests exist** (non-templated rule without tests):
+- "This rule has no test scenarios. Create tests in `<rule_dir>/tests/`"
+- "Required: At least one `.pass.sh` and one `.fail.sh` scenario"
+
+## Troubleshooting
+
+### Common Issues
+
+1. **VM not found**:
+   ```
+   Error: VM '<vm_name>' not found
+   ```
+   - Ensure VM exists: `virsh -c <libvirt_uri> list --all`
+   - Check connection URI — re-run Phase 3 if needed
+
+2. **Datastream not found**:
+   ```
+   Error: build/ssg-<product>-ds.xml not found
+   ```
+   - Build with: `./build_product --datastream-only <product>`
+
+3. **Permission denied**:
+   - If using `qemu:///system`, may need sudo
+   - Switch to `qemu:///session` for user VMs
+
+4. **Rule not in datastream**:
+   - Verify rule is in at least one profile
+   - Rebuild datastream after adding to profile
+
+5. **Test scenario errors**:
+   - Check bash syntax in test files
+   - Verify required packages are specified: `# packages = <pkg>`
+
+6. **No snapshot available**:
+   ```
+   Error: No snapshot found for domain
+   ```
+   - Automatus needs a snapshot to revert between test scenarios
+   - Create one: `virsh -c <libvirt_uri> snapshot-create-as <vm_name> clean` (prefix with `sudo` for `qemu:///system`)
+
+### Debug Mode (Manual Only)
+
+**Note**: Debug mode requires interactive input and must be run manually by the user, not through this skill.
+
+When tests fail, suggest the user run with `--debug` in their own terminal:
+
+```bash
+cd tests
+./automatus.py rule --libvirt <libvirt_uri> <vm_name> \
+    --datastream ../build/ssg-<product>-ds.xml \
+    --debug \
+    $ARGUMENTS
+```
+
+How `--debug` works:
+1. When an error occurs (e.g., remediation applied but rule still fails), Automatus **pauses** and keeps the VM running
+2. User can SSH into the VM to inspect system state:
+   ```bash
+   ssh root@<vm-ip>   # No password required on test VMs
+   ```
+3. Press **Enter** in the Automatus terminal to continue to the next test, or **Ctrl+C** to abort

--- a/.claude/skills/test-rule/SKILL.md
+++ b/.claude/skills/test-rule/SKILL.md
@@ -110,7 +110,7 @@ Store the mapping of product → VM name for Phase 5.
    - Ask user: "Datastream for <product> is missing/outdated. Build it now?"
 
    ```bash
-   ./build_product --datastream-only <product>
+   ./build_product --rule-id $ARGUMENTS <product>
    ```
 
 4. **Verify VMs are available and running** (CRITICAL — Automatus requires the VM to be running):
@@ -308,7 +308,7 @@ Based on results:
    ```
    Error: build/ssg-<product>-ds.xml not found
    ```
-   - Build with: `./build_product --datastream-only <product>`
+   - Build with: `./build_product --rule-id $ARGUMENTS <product>`
 
 3. **Permission denied**:
    - If using `qemu:///system`, may need sudo

--- a/docs/manual/developer/12_ai_skills.md
+++ b/docs/manual/developer/12_ai_skills.md
@@ -1,0 +1,31 @@
+# AI-Assisted Development Skills
+
+This repository includes a set of skills that automate common
+development tasks such as building products, creating rules, mapping
+control files, reviewing pull requests, and more. Skills are invoked as
+slash commands (e.g., `/build-product rhel9`).
+
+The skills are compatible with any LLM client that supports the
+`.claude/skills/` convention, such as
+[Claude Code](https://claude.ai/code) and
+[Opencode](https://opencode.ai/).
+
+Some skills can optionally use the
+[content-mcp](https://github.com/ComplianceAsCode/content-mcp) MCP
+(Model Context Protocol) server for structured, deterministic operations
+such as rule lookup, control file parsing, and rendered content search.
+When the MCP server is not configured, those skills fall back to
+filesystem-based alternatives so that every skill completes successfully
+either way. The MCP server is not required.
+
+## Finding and Using Skills
+
+Each skill is defined in its own directory under `.claude/skills/`. The
+directory name is the skill name (e.g., `.claude/skills/build-product/`
+corresponds to `/build-product`). Every skill directory contains a
+`SKILL.md` file that fully documents its purpose, usage, arguments,
+phases, and behavior.
+
+Skills are self-documenting. Before using a skill, read its `SKILL.md`
+to understand what it does, what arguments it expects, and what side
+effects it may have.


### PR DESCRIPTION
#### Description:

- Add 10 Claude Code skill definitions under `.claude/skills/` that automate common development tasks: `build-product`, `create-rule`, `draft-pr`, `inspect-control`, `map-controls`, `map-requirement`, `onboard-control`, `run-tests`, `test-rule`, and shared MCP fallback utilities.
- Skills cover the full development lifecycle: building products, creating and testing rules, mapping control file requirements, onboarding new security policies, and drafting PR descriptions.
- Each skill is invoked as a slash command (e.g., `/build-product rhel9`) and is defined by a `SKILL.md` file documenting its purpose, arguments, phases, and behavior.
- Skills optionally use the `content-mcp` MCP server for structured operations but fall back to filesystem-based alternatives when the MCP server is unavailable.
- Add developer documentation (`docs/manual/developer/12_ai_skills.md`) describing how to find and use the skills.

#### Rationale:

- These skills encode project-specific best practices, conventions, and workflows into reusable, self-documenting automation. They reduce onboarding friction for new contributors and help experienced contributors avoid repetitive manual steps.
- The skills are compatible with any LLM client supporting the `.claude/skills/` convention (Claude Code, Opencode, etc.), making AI-assisted development accessible across tooling.

#### Review Hints:


- Key files to review:
  - `.claude/skills/shared/mcp_fallbacks.md` — shared fallback procedures referenced by multiple skills
  - `.claude/skills/create-rule/SKILL.md` — largest skill (~585 lines), covers rule creation end-to-end
  - `docs/manual/developer/12_ai_skills.md` — developer-facing documentation
- The skills themselves are Markdown instruction files, not executable code. Review them for accuracy of project conventions, correct command examples, and completeness of workflows.
- No build or test infrastructure is affected. No products need to be rebuilt to verify this PR.
- Review all commits together — the first commit adds all skills and the second adds documentation.
