### PR TITLE
WIP: Align OSPP audit rules with new official audit rules

### DIFF
--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -45,77 +45,50 @@ title: 'Perform general configuration of Audit for OSPP'
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F arch=b32 -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
--a always,exit -F arch=b64 -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
--a always,exit -F arch=b32 -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
--a always,exit -F arch=b64 -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F arch=b32 -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 ## Special case for systemd-run. It is not audit aware, specifically watch it
--a always,exit -F arch=b32 -F path=/usr/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation
--a always,exit -F arch=b64 -F path=/usr/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation
+-a always,exit -F path=/usr/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation
 ## Special case for pkexec. It is not audit aware, specifically watch it
--a always,exit -F arch=b32 -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation
--a always,exit -F arch=b64 -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation
 
 
 ## Watch for configuration changes to privilege escalation.
--a always,exit -F arch=b32 -F path=/etc/sudoers -F perm=wa -F key=special-config-changes
--a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa -F key=special-config-changes
--a always,exit -F arch=b32 -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
--a always,exit -F arch=b64 -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
+-a always,exit -F path=/etc/sudoers -F perm=wa -F key=special-config-changes
+-a always,exit -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 
 ## Audit log access
--a always,exit -F arch=b32 -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
--a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
+-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F arch=b32 -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b64 -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b32 -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b64 -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b32 -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b64 -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F arch=b32 -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
--a always,exit -F arch=b64 -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.
 


### PR DESCRIPTION
#### Description:

- Modify rule `audit_ospp_general` to remove duplicate `arch=b32`/`arch=b64` pairs from audit rules that monitor file paths and directories. In the new Audit subsystem, separate rules for b32 and b64 architectures are no longer needed when auditing a path or directory. This reduces the rule count from 54 lines to 27 lines while maintaining the same audit coverage.
- Affected audit rule categories: user/group modification watches (`user-modify`, `group-modify`), special config change watches (`special-config-changes`), privilege escalation watches (`maybe-escalation`), sudoers config watches, audit log access (`access-audit-trail`), session initiation watches (`session`), and MAC policy watches (`MAC-policy`).

#### Rationale:

- The new Audit subsystem no longer requires separate b32 and b64 rules when auditing paths and directories. The `-F arch=` filter is unnecessary for `-F path=` and `-F dir=` rules because the kernel handles both architectures transparently. This aligns the OSPP audit content with the updated official audit sample rules.

#### Review Hints:

- Affected products: rhel8, rhel9, rhel10 (rule has CCEs for all three). Build with:
  ```
  ./build_product --datastream-only rhel8
  ./build_product --datastream-only rhel9
  ./build_product --datastream-only rhel10
  ```
- The rule uses the `audit_file_contents` template — note that the template's `contents` variable in the `rule.yml` is what gets checked against the system file `/etc/audit/rules.d/30-ospp-v42.rules`. The diff only modifies the `contents` block within the Jinja2 template rendering section of the description.
- Key file to review: `linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml`
- This is a single-commit PR, review as a whole.
- The "User add delete modify" section at the top of the rule (lines using `-S openat,open_by_handle_at` syscalls) still retains `arch=b32`/`arch=b64` because those rules filter by syscall, not just path — only path/dir-only rules had the arch filter removed.
in new Audit, separate rules for b32 and b64 are not needed anymore when auditing path / dir
