### PR TITLE
CMP-3815: Add OCIL instructions for BIOS configuration rules

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_in_bios/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_in_bios/rule.yml
@@ -16,6 +16,16 @@ rationale: |-
 
 severity: unknown
 
+ocil_clause: 'wireless devices (WiFi or Bluetooth) are enabled in BIOS'
+
+ocil: |-
+    Verify that built-in wireless devices (WiFi and Bluetooth) are disabled in the system
+    boot firmware (BIOS/UEFI). The process to configure this setting varies by hardware
+    manufacturer and model. Some systems may not have wireless devices or may not provide
+    BIOS-level controls for wireless devices.
+    Consult your hardware manual or vendor documentation for specific instructions on how to
+    access the firmware setup during boot and disable wireless device support.
+
 identifiers:
     cce@rhcos4: CCE-82659-4
     cce@rhel9: CCE-89909-6

--- a/linux_os/guide/system/permissions/mounting/bios_disable_usb_boot/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/bios_disable_usb_boot/rule.yml
@@ -14,6 +14,14 @@ rationale: |-
 
 severity: unknown
 
+ocil_clause: 'the system allows booting from USB devices'
+
+ocil: |-
+    Verify that booting from USB devices is disabled in the system boot firmware (BIOS/UEFI).
+    The process to configure this setting varies by hardware manufacturer and model.
+    Consult your hardware manual or vendor documentation for specific instructions on how to
+    access the firmware setup during boot and disable USB boot capabilities.
+
 identifiers:
     cce@rhcos4: CCE-82662-8
     cce@rhel9: CCE-87913-0


### PR DESCRIPTION
These rules configure hardware BIOS settings that vary by manufacturer and model. While we cannot provide specific step-by-step instructions that apply to all hardware, we now provide guidance directing users to consult their hardware vendor documentation.

This resolves test failures in CMP-3815 where these MANUAL rules were missing instructions:
- bios_disable_usb_boot
- wireless_disable_in_bios

These base rules generate the product-specific variants:
- rhcos4-high-master-bios-disable-usb-boot
- rhcos4-high-master-wireless-disable-in-bios
- rhcos4-high-worker-bios-disable-usb-boot
- rhcos4-high-worker-wireless-disable-in-bios

Related: https://github.com/ComplianceAsCode/compliance-operator/pull/1051

