### PR TITLE
Enable rule UBTU-24-100050

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -47,7 +47,7 @@ controls:
       status: automated
 
     - id: UBTU-24-100050
-      title: Ubuntu 24.04 LTS must not have the nfs-kernel-server package installed. 
+      title: Ubuntu 24.04 LTS must not have the nfs-kernel-server package installed.
       levels:
           - high
       rules:

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -46,6 +46,15 @@ controls:
           - package_rsh-server_removed
       status: automated
 
+    - id: UBTU-24-100050
+      title: Ubuntu 24.04 LTS must not have the nfs-kernel-server package installed. 
+      levels:
+          - high
+      rules:
+          - package_nfs-kernel-server_removed
+          - service_nfs_disabled
+      status: automated
+
     - id: UBTU-24-100100
       title: Ubuntu 24.04 LTS must use a file integrity tool to verify correct operation of all security
           functions.


### PR DESCRIPTION
#### Description:

- Enable rule package_nfs-kernel-server_removed and service_nfs_disabled for ubuntu stig 24.04

#### Rationale:

- Enable UBTU-24-100050