### PR TITLE
Fix Ubuntu tests for dconf_gnome_login_banner_text

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_correct_value.pass.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 # packages = gdm3
-# variables = dconf_login_banner_text=Authorized users only. All activity may be monitored and reported.
+# variables = dconf_login_banner_text=TestBanner,dconf_login_banner_contents=TestBanner
 
 source $SHARED/dconf_test_functions.sh
 clean_dconf_settings
 add_dconf_profiles
 
-echo > /etc/gdm3/greeter.dconf-defaults
+banner="TestBanner"
 
-banner_default="Authorized users only. All activity may be monitored and reported."
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'$banner_default'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+echo > "/etc/gdm3/greeter.dconf-defaults"
+
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'$banner'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
 add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_correct_value_defaults.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_correct_value_defaults.pass.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 # packages = gdm3
-# variables = dconf_login_banner_text=Authorized users only. All activity may be monitored and reported.
+# variables = dconf_login_banner_text=TestBanner,dconf_login_banner_contents=TestBanner
 
 source $SHARED/dconf_test_functions.sh
 clean_dconf_settings
 add_dconf_profiles
 
-conffile="/etc/gdm3/greeter.dconf-defaults"
+banner="TestBanner"
 
-banner_default="Authorized users only. All activity may be monitored and reported."
-sed -i '/banner-message-enable=/d;/banner-message-text=/d' ${conffile}
-sed -i "/^\[org\/gnome\/login-screen\]/a""banner-message-text='$banner_default'" ${conffile}
+cat >/etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+banner-message-text='$banner'
+EOF
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_missing_value.fail.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 # packages = gdm3
+# variables = dconf_login_banner_text=TestBanner,dconf_login_banner_contents=TestBanner
 
 source $SHARED/dconf_test_functions.sh
 clean_dconf_settings
 add_dconf_profiles
+
 echo > "/etc/gdm3/greeter.dconf-defaults"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_wrong_value.fail.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 # packages = gdm3
-# variables = dconf_login_banner_text=default
+# variables = dconf_login_banner_text=TestBanner,dconf_login_banner_contents=TestBanner
 
 source $SHARED/dconf_test_functions.sh
 clean_dconf_settings
 add_dconf_profiles
 
+banner="Wrong Banner"
+
 echo > /etc/gdm3/greeter.dconf-defaults
 
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'Wrong banner'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'$banner'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
 add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_wrong_value_defaults.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/ubuntu_wrong_value_defaults.fail.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 # packages = gdm3
-# variables = dconf_login_banner_text=default
+# variables = dconf_login_banner_text=TestBanner,dconf_login_banner_contents=TestBanner
 
 source $SHARED/dconf_test_functions.sh
 clean_dconf_settings
 add_dconf_profiles
 
-conffile="/etc/gdm3/greeter.dconf-defaults"
+banner="Wrong Banner"
 
-sed -i '/banner-message-enable=/d;/banner-message-text=/d' ${conffile}
-sed -i "/^\[org\/gnome\/login-screen\]/a""banner-message-text='Wrong banner'" ${conffile}
+echo >/etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+banner-message-text='$banner'
+EOF
 
 dconf update


### PR DESCRIPTION
#### Description:

- Refactor and fix tests for `dconf_gnome_login_banner_text` on Ubuntu

#### Rationale:

- Tests were not aligned with the recent change in banner vars: https://github.com/ComplianceAsCode/content/pull/14371