### PR TITLE
Add service_kdump_disabled to e8 and ism_o

### DIFF
--- a/controls/e8.yml
+++ b/controls/e8.yml
@@ -179,4 +179,7 @@ controls:
           - package_firewalld_installed
           - service_firewalld_enabled
           - network_sniffer_disabled
+
+          ### Services
+          - service_kdump_disabled
       status: partial  # Always will be partial as more could be done

--- a/tests/data/profile_stability/rhel10/e8.profile
+++ b/tests/data/profile_stability/rhel10/e8.profile
@@ -62,6 +62,7 @@ service_auditd_enabled
 service_avahi-daemon_disabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_rsyslog_enabled
 service_squid_disabled
 service_telnet_disabled

--- a/tests/data/profile_stability/rhel10/ism_o.profile
+++ b/tests/data/profile_stability/rhel10/ism_o.profile
@@ -129,6 +129,7 @@ service_avahi-daemon_disabled
 service_chronyd_enabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_pcscd_enabled
 service_rsyslog_enabled
 service_snmpd_disabled

--- a/tests/data/profile_stability/rhel10/ism_o_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_secret.profile
@@ -129,6 +129,7 @@ service_avahi-daemon_disabled
 service_chronyd_enabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_pcscd_enabled
 service_rsyslog_enabled
 service_snmpd_disabled

--- a/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
@@ -129,6 +129,7 @@ service_avahi-daemon_disabled
 service_chronyd_enabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_pcscd_enabled
 service_rsyslog_enabled
 service_snmpd_disabled

--- a/tests/data/profile_stability/rhel8/e8.profile
+++ b/tests/data/profile_stability/rhel8/e8.profile
@@ -69,6 +69,7 @@ service_auditd_enabled
 service_avahi-daemon_disabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_rsyslog_enabled
 service_squid_disabled
 service_telnet_disabled

--- a/tests/data/profile_stability/rhel8/ism_o.profile
+++ b/tests/data/profile_stability/rhel8/ism_o.profile
@@ -111,6 +111,7 @@ service_chronyd_enabled
 service_chronyd_or_ntpd_enabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_rsyslog_enabled
 service_snmpd_disabled
 service_squid_disabled

--- a/tests/data/profile_stability/rhel9/e8.profile
+++ b/tests/data/profile_stability/rhel9/e8.profile
@@ -67,6 +67,7 @@ service_auditd_enabled
 service_avahi-daemon_disabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_rsyslog_enabled
 service_squid_disabled
 service_telnet_disabled

--- a/tests/data/profile_stability/rhel9/ism_o.profile
+++ b/tests/data/profile_stability/rhel9/ism_o.profile
@@ -107,6 +107,7 @@ service_avahi-daemon_disabled
 service_chronyd_enabled
 service_fapolicyd_enabled
 service_firewalld_enabled
+service_kdump_disabled
 service_rsyslog_enabled
 service_snmpd_disabled
 service_squid_disabled


### PR DESCRIPTION

#### Description:

Add service_kdump_disabled to e8 and ism_o

#### Rationale:

Fixes #14558


#### Review Hints:
Run `/scanning/boot-errors` for e8 and ISM O.