### PR TITLE
GH-14516: Make compare_ds.py generate diffs for removed rules in DISA

### DIFF
--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -382,7 +382,7 @@ To execute:
 ### `utils/compare_ds.py` &ndash; Compare two data streams (can also compare XCCDFs)
 
 This script compares two data streams or two benchmarks and generates a diff output.
-It can show what changed in rules, for example in description, references and remediation scripts.
+It shows what changed in rules, for example in description, references and remediation scripts.
 Changes in checks (OVAL and OCIL) are shown too, but the OVAL diff is limited to the `criteria`
 and `criterion` order and their IDs.
 
@@ -396,16 +396,16 @@ diff for the whole data stream or benchmark.
 The option `--rule-diffs` can be used to generate a diff file per rule. In this mode the diff files
 are created in a directory: `./compare_ds-diffs`. To change the output dir use `--output-dir` option.
 
-Compare current DISA's manual benchmark, and generate per file diffs:
+Compare two data streams and save the output to a file:
 
 ```bash
-    $ utils/compare_ds.py --disa-content --rule-diffs ./disa-stig-rhel8-v1r6-xccdf-manual.xml shared/references/disa-stig-rhel8-v1r7-xccdf-manual.xml
+    $ utils/compare_ds.py <source.xml> <target.xml> > content.diff
 ```
 
-Compare two data streams:
+Compare two DISA's benchmarks, and generate per rule diffs in the `compare_ds-diffs` directory:
 
 ```bash
-    $ utils/compare_ds.py /tmp/ssg-rhel8-ds.xml build/ssg-rhel8-ds.xml > content.diff
+    $ utils/compare_ds.py --disa-content --rule-diffs <source.xml> <target.xml>
 ```
 
 #### HTML Diffs
@@ -420,11 +420,12 @@ Install `diff2html`:
     $ sudo npm install -g diff2html-cli
 ```
 
-Generate the HTML diffs:
+Generate the HTML diffs in the `html` directory. Run the `utils/compare_ds.py` first to generate the diffs in the `compare_ds-diffs` directory.
 
 ```bash
+    $ rm -r html/
     $ mkdir -p html
-    $ for f in $(ls compare_ds-diffs/); do diff2html -i file -t $f -F "html/$f.html" "compare_ds-diffs/$f"; done
+    $ for f in compare_ds-diffs/*; do name="${f##*/}"; diff2html -i file -t "$name" -F "html/$name.html" -- "$f" & done; wait
 ```
 
 ### `utils/compare_results.py` &ndash; Compare to two ARF result files

--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -137,8 +137,8 @@ class StandardContentDiffer(object):
 
         if old_rule_text == new_rule_text:
             return
-
-        if old_rule_text != "":
+        # new_rule_text != "" to avoid printing the message when the rule is removed in the new content
+        if old_rule_text != "" and new_rule_text != "":
             print(
                 "New content has different text for rule '%s'." % (identifier))
 
@@ -345,6 +345,10 @@ class StigContentDiffer(StandardContentDiffer):
                 new_sv_rule_id = new_rule_mapping[old_sv_rule_id]
             except KeyError:
                 print("%s is missing in new data stream." % old_stig_id)
+                # Compare against empty rule so that a diff is generated for the removed rule
+                if not self.only_rules and self.show_diffs:
+                    empty_rule = ssg.xml.XMLRule(ET.Element("{%s}Rule" % XCCDF12_NS))
+                    self.compare_rule(old_rule, empty_rule, old_stig_id)
                 continue
             if self.only_rules:
                 continue
@@ -362,7 +366,7 @@ class StigContentDiffer(StandardContentDiffer):
             new_stig_id = self._get_stig_id(new_rule)
             new_sv_rule_id = self.get_stig_rule_SV(new_rule.get_attr("id"))
             try:
-                old_sv_rule_id = old_rule_mapping[new_sv_rule_id]  # noqa: F841
+                _ = old_rule_mapping[new_sv_rule_id]
             except KeyError:
                 print("%s was added in new data stream." % (new_stig_id))
 

--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -22,18 +22,19 @@ def parse_args():
         "--rule", metavar="RULE_ID",
         help="Compare only the rule specified by given RULE_ID"
     )
-    parser.add_argument(
+    diff_group = parser.add_mutually_exclusive_group()
+    diff_group.add_argument(
         "--no-diffs", action="store_true",
         help="Do not perform detailed comparison of checks and remediations contents."
+    )
+    diff_group.add_argument(
+        "--rule-diffs", action="store_true",
+        help="Output diffs per rule, instead of a single diff. "
+             "The rule diffs are output to directory './compare_ds-diffs/', override by --output-dir."
     )
     parser.add_argument(
         "--only-rules", action="store_true",
         help="Print only removals from rule set."
-    )
-    parser.add_argument(
-        "--rule-diffs", action="store_true",
-        help="Output diffs per rule, instead of a single diff. "
-             "The rule diffs are output to directory './compare_ds-diffs/'."
     )
     parser.add_argument(
         "--output-dir", metavar="OUTPUT_DIR",


### PR DESCRIPTION
#### Description:

- When a rule exists in the old DISA data stream but not in the new one, `compare_ds.py` emits a diff (old rule vs empty) instead of only printing the removal message (e.g. `RHEL-09-411115 is missing in new data stream.`)
- Make `--no-diffs` and `--rule-diffs` mutually exclusive to avoid misleading output when both are used.
- Suppress the "different text" message for removed rules, e.g. `New content has different text for rule 'RHEL-09-411115'` - invalid, as the new content does not contain the rule.
- Update documentation.

#### Rationale:

- Reviewers can see the removed content via diffs instead of only a removal notice.
- `--no-diffs` and `--rule-diffs` are contradictory; making them mutually exclusive prevents conflicting behavior. The "different text" message is not useful when the new rule is empty.

- Fixes #14516

#### Review Hints:

- Run with two DISA data streams where the new stream has fewer rules than the old:
  - `$ ./utils/compare_ds.py --disa-content old_ds.xml new_ds.xml`
  - `$ ./utils/compare_ds.py --disa-content --rule-diffs old_ds.xml new_ds.xml`
- Confirm that passing both `--no-diffs` and `--rule-diffs` is rejected or prints a clear error.