### PR TITLE
Disable audit_rules_immutable rule for sle15

### DIFF
--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -1496,9 +1496,7 @@ controls:
       levels:
           - l2_server
           - l2_workstation
-      status: automated
-      rules:
-          - audit_rules_immutable
+      status: manual 
 
     - id: 4.2.1.1
       title: Ensure rsyslog is installed (Automated)

--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -78,3 +78,5 @@ selections:
     - '!audit_rules_mac_modification_etc_selinux'
     - '!no_nis_in_nsswitch'
     - '!service_chronyd_enabled'
+    - '!audit_rules_immutable'
+

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -104,3 +104,5 @@ selections:
     - '!service_chronyd_enabled'
     - '!audit_rules_mac_modification_etc_selinux'
     - '!no_nis_in_nsswitch'
+    - '!audit_rules_immutable'
+

--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -72,3 +72,5 @@ selections:
     - '!ldap_client_start_tls'
     - '!ldap_client_tls_cacertpath'
     - '!no_nis_in_nsswitch'
+    - '!audit_rules_immutable'
+

--- a/products/sle15/profiles/anssi_bp28_minimal.profile
+++ b/products/sle15/profiles/anssi_bp28_minimal.profile
@@ -42,6 +42,7 @@ selections:
     - '!accounts_passwords_pam_faillock_interval'
     - '!accounts_password_pam_ucredit'
     - '!accounts_password_pam_minlen'
+    - '!audit_rules_immutable'
     - '!ensure_oracle_gpgkey_installed'
     - '!ensure_almalinux_gpgkey_installed'
     - '!enable_authselect'

--- a/products/sle15/profiles/hipaa.profile
+++ b/products/sle15/profiles/hipaa.profile
@@ -70,7 +70,7 @@ selections:
     - service_auditd_enabled
     - audit_rules_privileged_commands_sudo
     - audit_rules_privileged_commands_su
-    - audit_rules_immutable
+    - '!audit_rules_immutable'
     - kernel_module_usb-storage_disabled
     - service_autofs_disabled
     - auditd_audispd_syslog_plugin_activated

--- a/products/sle15/profiles/pcs-hardening.profile
+++ b/products/sle15/profiles/pcs-hardening.profile
@@ -155,7 +155,7 @@ selections:
     - audit_rules_file_deletion_events_renameat
     - audit_rules_file_deletion_events_unlink
     - audit_rules_file_deletion_events_unlinkat
-    - audit_rules_immutable
+    - '!audit_rules_immutable'
     - audit_rules_kernel_module_loading_delete
     - audit_rules_kernel_module_loading_finit
     - audit_rules_kernel_module_loading_init


### PR DESCRIPTION
#### Description:

- Disable usage of audit_rules_immutable rule for SLE15 platform

#### Rationale:

- Currently it is incompatible with the system boot logic , so disabling it for the platform. Further improvements in order to support it will be made in newer SLE platforms
