### PR TITLE
CMP-3822: Updates the manual remediation script for the configure-network-policies-namespaces

### DIFF
--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# Create a test namespace to ensure we have at least one non-control-plane namespace
+cat << EOF | oc apply -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e-test
+EOF
+sleep 10
+
 # Deploy a single NetworkPolicy per non control plane namespace
 for NS in $(oc get namespaces -o json | jq -r '.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name'); do
 cat << EOF | oc apply -n "$NS" -f -

--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Create a test namespace to ensure we have at least one non-control-plane namespace
 cat << EOF | oc apply -f -
 ---
 apiVersion: v1
@@ -8,7 +7,6 @@ metadata:
   name: e2e-test
 EOF
 sleep 10
-
 # Deploy a single NetworkPolicy per non control plane namespace
 for NS in $(oc get namespaces -o json | jq -r '.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name'); do
 cat << EOF | oc apply -n "$NS" -f -

--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
-cat << EOF | oc apply -f -
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: e2e-test
-EOF
-sleep 10
 # Deploy a single NetworkPolicy per non control plane namespace
 for NS in $(oc get namespaces -o json | jq -r '.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name'); do
 cat << EOF | oc apply -n "$NS" -f -
@@ -14,12 +6,11 @@ cat << EOF | oc apply -n "$NS" -f -
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-all-ingress
+  name: allow-same-namespace
 spec:
-  podSelector: {}
+  podSelector:
   ingress:
-  - {}
-  policyTypes:
-  - Ingress
+  - from:
+    - podSelector: {}
 EOF
 done


### PR DESCRIPTION

Updates the manual remediation script for the configure-network-policies-namespaces rule to align with the downstream test implementation.

Test the remediation script directly
`oc create namespace test-remediation`
`cd applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4`
`bash ./e2e-remediation.sh`
`oc get networkpolicy allow-same-namespace -n test-remediation`
`oc delete namespace test-remediation`