### PR TITLE
Remove chrony_set_nts from STIG profiles

### DIFF
--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -245,7 +245,6 @@ controls:
             - display_login_attempts
             - installed_OS_is_vendor_supported
             - selinux_all_devicefiles_labeled
-            - chrony_set_nts
             - tftp_uses_secure_mode_systemd
             - grub2_pti_argument
             - chronyd_client_only

--- a/linux_os/guide/services/ntp/chrony_set_nts/rule.yml
+++ b/linux_os/guide/services/ntp/chrony_set_nts/rule.yml
@@ -25,3 +25,10 @@ severity: medium
 
 platforms:
     - package[chrony]
+
+warnings:
+    - general: |-
+        Network Time Security (NTS) is not compatible with systems running in FIPS mode.
+        Enabling NTS on a system in FIPS mode causes chronyd service to abort with a fatal
+        error. This is because NTS uses algorithms (specifically SIV cipher) that are not
+        approved by NIST and are not compliant with FIPS.

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -46,3 +46,4 @@ selections:
     - sshd_use_strong_macs
     - configure_ssh_crypto_policy
     - package_dnsmasq_removed
+    - chrony_set_nts

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -147,7 +147,6 @@ auditd_overflow_action
 auditd_write_logs
 banner_etc_issue
 bios_enable_execution_restrictions
-chrony_set_nts
 chronyd_client_only
 chronyd_no_chronyc_network
 chronyd_or_ntpd_set_maxpoll

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -147,7 +147,6 @@ auditd_overflow_action
 auditd_write_logs
 banner_etc_issue
 bios_enable_execution_restrictions
-chrony_set_nts
 chronyd_client_only
 chronyd_no_chronyc_network
 chronyd_or_ntpd_set_maxpoll


### PR DESCRIPTION
Network Time Security (NTS) is not compatible with systems running in FIPS mode. Enabling NTS on a system in FIPS mode causes chronyd service to abort with a fatal error. This is because NTS uses algorithms (specifically SIV cipher) that are not approved by NIST and are not compliant with FIPS.

This is in direct conflict with STIG requiring FIPS mode: https://www.stigaview.com/products/rhel9/v2r7/RHEL-09-671010/ https://www.stigaview.com/products/rhel10/v1r1/RHEL-10-000500/ and therefore rule `chrony_set_nts` should be removed from STIG profiles.

For more details see:
* https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings#assembly_overview-of-network-time-security-in-chrony_configuring-time-synchronization
* https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_time_synchronization/overview-of-network-time-security-nts-in-chrony
* https://access.redhat.com/solutions/7053784

Resolves #14563