### PR TITLE
Add sysctl_net_ipv6_conf_all_disable_ipv6 to ocp4

### DIFF
--- a/products/ocp4/profiles/default.profile
+++ b/products/ocp4/profiles/default.profile
@@ -55,3 +55,4 @@ selections:
     - kubelet_read_only_port_secured
     - scheduler_port_is_zero
     - project_template_resource_quota
+    - sysctl_net_ipv6_conf_all_disable_ipv6


### PR DESCRIPTION

#### Description:

Add sysctl_net_ipv6_conf_all_disable_ipv6 to ocp4


#### Rationale:

To fix WARNING:root:Missing OVAL component: sysctl_net_ipv6_conf_all_disable_ipv6_runtime


#### Review Hints:
Build the ocp4 product on master and this branch.