### PR TITLE
Add operation and datatype support to grub2_bootloader_argument template

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -462,9 +462,17 @@ they must be of the same length.
     -   **arg_name** - argument name, eg. `audit`
 
     -   **arg_value** - argument value, eg. `'1'`
+        This parameter is mutually exclusive with **arg_variable**.
 
     -   **arg_variable** - the variable used as the value for the argument, eg. `'var_slub_debug_options'`
         This parameter is mutually exclusive with **arg_value**.
+
+    -   **operation** - (optional) OVAL operation used to compare the
+        collected argument value with the expected value. Default value:
+        `pattern match`. When set to a numeric operation such as
+        `greater than or equal`, the OVAL check captures only the
+        numeric portion of the argument and compares it as an integer.
+        Works with both **arg_variable** and **arg_value**.
 
 -   Languages: Ansible, Bash, OVAL, Blueprint, Kickstart
 

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -463,18 +463,16 @@ they must be of the same length.
 
     - **arg_value** (optional) value of the kernel argument, e.g. `'1'`, `'on'`.
         - Mutually exclusive with **arg_variable**.
-        - **Must be quoted** in `rule.yml` — YAML auto-parses unquoted scalars
-          (`8192` becomes int, `on`/`off` become bool), but the template needs a
-          string to build regexes and config file content. The build will fail with
-          a clear error if the value is not a string.
+        - Single-quote `arg_value` in `rule.yml`. This template expects `arg_value` to
+          stay a string, even when `datatype` is `int`, for example `arg_value: '20'`.
 
     - **arg_variable** (optional) - XCCDF variable defined in a `.var` file,
       e.g. `var_audit_backlog_limit`.
         - Mutually exclusive with **arg_value**.
-        - If used,  **operation** and **datatype** has to be set to match the `.var` file's `type` and `operator` variables.
+        - If used, set **operation** and **datatype** to match the `.var` file's `type` and `operator` variables.
 
     - **operation** - OVAL comparison operation applied to the extracted value.
-      Default: `equals`. Supported values:
+      Default: `equals` if omitted. Supported values:
         - `equals` — exact match. Works with `string` or `int`.
           Use for arguments with a single known-good value (e.g. `audit=1`,
           `pti=on`).
@@ -488,8 +486,8 @@ they must be of the same length.
           `less than or equal`) are validated but have no test coverage.
           Adding a rule with these operations requires adding test scenarios and updating `template.py` to support them.
 
-    - **datatype** - OVAL datatype for the comparison. Default: `string`.
-      Supported values: `string`, `int`.
+    - **datatype** - OVAL datatype for the comparison. Default: `string`
+      if omitted. Supported values: `string`, `int`.
         - `string` — lexicographic comparison. Use for non-numeric values
           (e.g. `on`, `force`, `none`).
         - `int` — numeric comparison. Use when the value is a number

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -455,18 +455,48 @@ they must be of the same length.
 -   Languages: Bash, OVAL
 
 #### grub2_bootloader_argument
--   Ensures that a kernel command line argument is present in GRUB 2 configuration.
+- Ensures that a kernel command line argument is present in GRUB 2 configuration. For example `nousb` or `audit_backlog_limit=8192`.
 
--   Parameters:
+- Parameters:
 
-    -   **arg_name** - argument name, eg. `audit`
+    - **arg_name** (required) - kernel argument name, e.g. `audit`, `audit_backlog_limit`, `nousb`.
 
-    -   **arg_value** - argument value, eg. `'1'`
+    - **arg_value** (optional) value of the kernel argument, e.g. `'1'`, `'on'`.
+        - Mutually exclusive with **arg_variable**.
+        - **Must be quoted** in `rule.yml` — YAML auto-parses unquoted scalars
+          (`8192` becomes int, `on`/`off` become bool), but the template needs a
+          string to build regexes and config file content. The build will fail with
+          a clear error if the value is not a string.
 
-    -   **arg_variable** - the variable used as the value for the argument, eg. `'var_slub_debug_options'`
-        This parameter is mutually exclusive with **arg_value**.
+    - **arg_variable** (optional) - XCCDF variable defined in a `.var` file,
+      e.g. `var_audit_backlog_limit`.
+        - Mutually exclusive with **arg_value**.
+        - If used,  **operation** and **datatype** has to be set to match the `.var` file's `type` and `operator` variables.
 
--   Languages: Ansible, Bash, OVAL, Blueprint, Kickstart
+    - **operation** - OVAL comparison operation applied to the extracted value.
+      Default: `equals`. Supported values:
+        - `equals` — exact match. Works with `string` or `int`.
+          Use for arguments with a single known-good value (e.g. `audit=1`,
+          `pti=on`).
+        - `pattern match` — regex match. Works with `string` only.
+          Use when multiple values are acceptable (e.g. `slub_debug` on OL8
+          where `P` must appear anywhere inside values like `FZP`).
+          Replaces the deprecated `is_substring` parameter.
+        - `greater than or equal` — numeric comparison. Works with `int` only.
+          Use for threshold arguments (e.g. `audit_backlog_limit>=8192`).
+        - Other operations (`not equal`, `greater than`, `less than`,
+          `less than or equal`) are validated but have no test coverage.
+          Adding a rule with these operations requires adding test scenarios and updating `template.py` to support them.
+
+    - **datatype** - OVAL datatype for the comparison. Default: `string`.
+      Supported values: `string`, `int`.
+        - `string` — lexicographic comparison. Use for non-numeric values
+          (e.g. `on`, `force`, `none`).
+        - `int` — numeric comparison. Use when the value is a number
+          (e.g. `audit_backlog_limit=8192`, `audit=1`). Required for numeric
+          operations like `greater than or equal`.
+
+- Languages: Ansible, Bash, OVAL, Blueprint, Kickstart
 
 #### grub2_bootloader_argument_absent
 -   Ensures that a kernel command line argument is absent in GRUB 2 configuration.

--- a/linux_os/guide/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/auditing/grub2_audit_argument/rule.yml
@@ -57,6 +57,8 @@ template:
     vars:
         arg_name: audit
         arg_value: '1'
+        datatype: int
+        operation: equals
 
 fixtext: |-
     {{{ describe_grub2_argument("audit=1") | indent(4) }}}

--- a/linux_os/guide/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -51,3 +51,4 @@ template:
     vars:
         arg_name: audit_backlog_limit
         arg_variable: var_audit_backlog_limit
+        operation: greater than or equal

--- a/linux_os/guide/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -52,3 +52,5 @@ template:
     vars:
         arg_name: audit_backlog_limit
         arg_variable: var_audit_backlog_limit
+        datatype: int
+        operation: greater than or equal

--- a/linux_os/guide/auditing/var_audit_backlog_limit.var
+++ b/linux_os/guide/auditing/var_audit_backlog_limit.var
@@ -7,9 +7,9 @@ description: |-
     The audit_backlog_limit parameter determines how auditd records can
     be held in the auditd backlog.
 
-type: string
+type: number
 
-operator: equals
+operator: greater than or equal
 
 interactive: true
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
@@ -37,3 +37,5 @@ template:
     vars:
         arg_name: iommu
         arg_value: 'force'
+        datatype: string
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
@@ -33,3 +33,5 @@ template:
     vars:
         arg_name: init_on_alloc
         arg_value: '1'
+        datatype: int
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_init_on_free/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_init_on_free/rule.yml
@@ -29,3 +29,5 @@ template:
     vars:
         arg_name: init_on_free
         arg_value: '1'
+        datatype: int
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -52,5 +52,7 @@ template:
     vars:
         arg_name: random.trust_cpu
         arg_value: 'on'
+        datatype: string
+        operation: equals
     backends:
         oval: "off"

--- a/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
@@ -43,3 +43,5 @@ template:
     vars:
         arg_name: l1tf
         arg_variable: var_l1tf_options
+        datatype: string
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_mce_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mce_argument/rule.yml
@@ -36,3 +36,5 @@ template:
     vars:
         arg_name: mce
         arg_value: '0'
+        datatype: int
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
@@ -53,3 +53,5 @@ template:
     vars:
         arg_name: mds
         arg_variable: var_mds_options
+        datatype: string
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_page_alloc_shuffle_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_page_alloc_shuffle_argument/rule.yml
@@ -39,3 +39,5 @@ template:
     vars:
         arg_name: page_alloc.shuffle
         arg_value: '1'
+        datatype: int
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -38,6 +38,8 @@ template:
     vars:
         arg_name: pti
         arg_value: 'on'
+        datatype: string
+        operation: equals
 
 fixtext: |-
     {{{ describe_grub2_argument("pti=on") | indent(4) }}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
@@ -44,3 +44,5 @@ template:
     vars:
         arg_name: rng_core.default_quality
         arg_variable: var_rng_core_default_quality
+        datatype: int
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_slab_nomerge_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_slab_nomerge_argument/rule.yml
@@ -42,3 +42,5 @@ template:
     vars:
         arg_name: slab_nomerge
         arg_value: 'yes'
+        datatype: string
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
@@ -46,3 +46,5 @@ template:
     vars:
         arg_name: spec_store_bypass_disable
         arg_variable: var_spec_store_bypass_disable_options
+        datatype: string
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
@@ -38,6 +38,6 @@ template:
     name: grub2_bootloader_argument
     vars:
         arg_name: spectre_v2
-        arg_value: on
+        arg_value: 'on'
         datatype: string
         operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
@@ -39,3 +39,5 @@ template:
     vars:
         arg_name: spectre_v2
         arg_value: on
+        datatype: string
+        operation: equals

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -37,7 +37,7 @@ template:
     name: grub2_bootloader_argument
     vars:
         arg_name: vsyscall
-        arg_value: none
+        arg_value: 'none'
         datatype: string
         operation: equals
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -38,6 +38,8 @@ template:
     vars:
         arg_name: vsyscall
         arg_value: none
+        datatype: string
+        operation: equals
 
 fixtext: |-
     {{{ describe_grub2_argument("vsyscall=none") | indent(4) }}}

--- a/linux_os/guide/system/bootloader-grub2/var_rng_core_default_quality.var
+++ b/linux_os/guide/system/bootloader-grub2/var_rng_core_default_quality.var
@@ -8,7 +8,7 @@ description: |-
 
 interactive: true
 
-type: string
+type: number
 
 operator: equals
 

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -38,3 +38,5 @@ template:
     vars:
         arg_name: ipv6.disable
         arg_value: '1'
+        datatype: int
+        operation: equals

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
@@ -40,6 +40,8 @@ template:
     vars:
         arg_name: page_poison
         arg_value: '1'
+        datatype: int
+        operation: equals
 
 fixtext: |-
     {{{ describe_grub2_argument("page_poison=1") | indent(4) }}}

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -40,7 +40,9 @@ template:
     vars:
         arg_name: slub_debug
         arg_variable: var_slub_debug_options
-        is_substring@ol8: "true"
+        datatype: string
+        operation: equals
+        operation@ol8: "pattern match"
 
 fixtext: |-
     {{{ describe_grub2_argument("slub_debug=" ~ xccdf_value("var_slub_debug_options")) | indent(4) }}}

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -14,7 +14,7 @@ if {{{ bash_bootc_build() }}} ; then
     if grep -q -E "{{{ ARG_NAME }}}" "$KARGS_DIR/*.toml" ; then
         sed -i -E "s/^(\s*kargs\s*=\s*\[.*)\"{{{ ARG_NAME }}}=[^\"]*\"(.*]\s*)/\1\"{{{ ARG_NAME_VALUE }}}\"\2/" "$KARGS_DIR/*.toml"
     else
-        echo "kargs = [\"{{{ ARG_NAME_VALUE }}}\"]" >> "$KARGS_DIR/10-{{{ SANITIZED_ARG_NAME }}}.toml"
+        echo "kargs = [\"{{{ ARG_NAME_VALUE }}}\"]" >> "$KARGS_DIR/10-{{{ ARG_NAME_UNDERSCORED }}}.toml"
     fi
 else
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) | indent(4) }}}

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -1,10 +1,76 @@
 {{#-
-  We set defaults to "off", and products should enable relevant ones depending on how the product configures grub.
-   - /boot/loader/entries/* may not exist.
-   - If they exist, they can reference variables defined in grubenv, or they can contain literal args
-   - The grub cfg may either use those loader entries, or it can contain literal values as well
-   - Kernel opts can be stored in /etc/default/grub so they are persistent between kernel upgrades
+  OVAL check for a GRUB bootloader kernel argument.
+
+  Verifies ARG_NAME (and optionally ARG_VALUE / ARG_VARIABLE) is present
+  across every GRUB config location the product uses.  Supports two modes
+  controlled by the OPERATION template parameter:
+
+    "pattern match" (default)
+        Object captures the full value line; state matches via regex.
+        Works for any string argument (e.g. audit=1, nosmt).
+
+    "greater than or equal" (numeric)
+        Object captures only the digits after ARG_NAME=; state compares
+        the integer against ARG_VARIABLE or ARG_VALUE.
+        Use when a minimum threshold is required (e.g. audit_backlog_limit).
+
+  Why numeric_comparison branches appear throughout the template:
+
+    OVAL has no "extract then compare" — the object's regex capture group IS
+    the value the state receives.  A state with datatype="int" needs a pure
+    integer, so every object must switch its regex between wide capture (.*)
+    and narrow capture (\d+).  This is an OVAL spec limitation and cannot be
+    consolidated into a single guard.
+
+    Three consequences:
+      - Every object has a {%% if numeric_comparison %%} regex branch.
+      - RHEL8 (ol8/rhel8) needs a separate test+criterion (entries_numeric)
+        because the same path also needs the wide-capture object for
+        $kernelopts detection — two objects, two tests, criteria branch.
+        This goes away when RHEL8 reaches EOL.
+      - bootc duplicates the state logic (section 6) because TOML wraps
+        values in quotes ("arg=value") vs space-delimited kernel cmdline,
+        so the regex patterns are structurally different.
+
+  Variables from rule.yml template vars:
+    ARG_NAME          – kernel argument name (e.g. "audit_backlog_limit")
+    ARG_VALUE         – literal expected value; mutually exclusive with ARG_VARIABLE
+    ARG_VARIABLE      – XCCDF variable name supplying the value at scan time
+    OPERATION         – OVAL comparison operation (default: "pattern match")
+    IS_SUBSTRING      – "true" if ARG_VALUE may appear as a substring
+
+  Variables computed by template.py (preprocess):
+    ARG_NAME_VALUE        – "name=value" string used in metadata and remediations
+    ESCAPED_ARG_NAME      – ARG_NAME with dots escaped for regex (OVAL only)
+    ESCAPED_ARG_NAME_VALUE – ARG_NAME_VALUE with dots escaped (OVAL only)
+    SANITIZED_ARG_NAME    – ARG_NAME with special chars replaced; used in OVAL IDs
+
+  Variables from the build system (product properties):
+    product                         – product ID (e.g. "rhel9", "fedora")
+    grub2_boot_path                 – BIOS GRUB dir (e.g. /boot/grub2)
+    grub2_uefi_boot_path            – UEFI GRUB dir (e.g. /boot/efi/EFI/redhat)
+    bootable_containers_supported   – "true" if product supports bootc Image Mode
+
+  Template structure:
+    1. Product flags   – which GRUB config locations to check
+    2. Comparison mode – numeric_comparison flag
+    3. Criteria tree   – AND/OR across locations + bootc Image Mode
+    4. Tests, objects & helper states — per config location:
+       4a. RHEL8 entries-or-grubenv  (+ rescue filter state)
+       4b. /etc/default/grub
+       4c. /etc/default/grub.d/*.cfg  (Ubuntu drop-ins)
+       4d. grubenv
+       4e. BLS entries  (+ rescue filter state)
+       4f. grub.cfg
+       4g. $kernelopts detection state  (RHEL8 only)
+    5. Shared state & variables — state_grub2_{SANITIZED_ARG_NAME}_argument;
+       branched by (numeric_comparison, ARG_VARIABLE):
+         5a. numeric — state with datatype="int", optional external_variable
+         5b. pattern match, literal — state with regex
+         5c. pattern match, variable — state + local_variable + external_variable
+    6. bootc Image Mode — self-contained test, object & state
 -#}}
+{{#- 1. Product flags: each product enables the GRUB locations it uses -#}}
 {{% set system_with_expanded_kernel_options_in_loader_entries = false -%}}
 {{% set system_with_kernel_options_in_grubenv = false -%}}
 {{% set system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv = false -%}}
@@ -33,6 +99,10 @@
 {{% set system_with_bios_and_uefi_support = true %}}
 {{%- endif -%}}
 
+{{#- 2. Comparison mode switch: numeric_comparison drives pattern and state branches -#}}
+{{% set numeric_comparison = (OPERATION != "pattern match") -%}}
+
+{{#- 3. Criteria tree: AND/OR across all checked locations -#}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is configured in the kernel line in /etc/default/grub.", rule_title=rule_title) }}}
@@ -42,8 +112,13 @@
         <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" negate="true" />
       {{% endif %}}
       {{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
+      {{% if numeric_comparison %}}
+      <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_numeric"
+      comment="Check {{{ ARG_NAME }}} value in /boot/loader/entries meets {{{ OPERATION }}}" />
+      {{% else %}}
       <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced"
       comment="Check /boot/loader/entries/*.conf files if they contain direct reference to {{{ ARG_NAME_VALUE }}} or if they contain $kernelopts" />
+      {{% endif %}}
       <criteria operator="OR"
       comment="Expressing implication">
         <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_at_least_one_entry_referenced" negate="true"
@@ -53,7 +128,7 @@
         {{%- endif %}}
         <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env"
         comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_boot_path }}}/grubenv" />
-      {{% if system_with_bios_and_uefi_support -%}}
+        {{% if system_with_bios_and_uefi_support -%}}
         <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env_uefi"
         comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_uefi_boot_path }}}/grubenv" />
         </criteria>
@@ -72,20 +147,20 @@
       </criteria>
       {{%- endif %}}
       {{% elif system_with_expanded_kernel_options_in_loader_entries -%}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
-                     comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the /boot/loader/entries/*.conf" />
+        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
+        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the /boot/loader/entries/*.conf" />
       {{%- endif %}}
       {{% if system_with_expanded_kernel_options_in_grub_cfg -%}}
-          {{% if system_with_bios_and_uefi_support -%}}
-          <criteria operator="OR">
-          {{%- endif %}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
-          comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
-          {{% if system_with_bios_and_uefi_support -%}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg_uefi"
-          comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_uefi_boot_path }}}/grub.cfg for all kernels" />
-          </criteria>
-          {{%- endif %}}
+        {{% if system_with_bios_and_uefi_support -%}}
+        <criteria operator="OR">
+        {{%- endif %}}
+        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
+        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
+        {{% if system_with_bios_and_uefi_support -%}}
+        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg_uefi"
+        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_uefi_boot_path }}}/grub.cfg for all kernels" />
+        </criteria>
+        {{%- endif %}}
       {{%- endif %}}
       {{% if system_with_kernel_options_in_etc_default_grub -%}}
         <criteria operator="OR">
@@ -121,7 +196,22 @@
     </criteria>
   </definition>
 
+{{#- 4. Tests, objects & helper states — per config location -#}}
+
+{{#- 4a. RHEL8 entries-or-grubenv (ol8, rhel8)
+     BLS entries may contain args expanded inline OR reference $kernelopts from grubenv.
+     Three tests handle this:
+       entries_expanded_or_referenced — every non-rescue entry has the arg OR $kernelopts
+       at_least_one_entry_referenced  — helper: does any entry use $kernelopts?
+       entries_numeric (numeric only) — integer value in expanded entries meets threshold -#}}
 {{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
+  {{#- Test "entries_expanded_or_referenced": each non-rescue *.conf must satisfy at least
+       one of two states (state_operator="OR"):
+         state_argument       — the arg is present in the captured options line
+         state_is_kernelopts  — the line contains $kernelopts (value lives in grubenv)
+       Not referenced in criteria in numeric mode — the narrow (\d+) capture can't do the
+       OR trick, so entries_numeric is used instead.  This test and its object are still
+       generated because at_least_one_entry_referenced reuses the object. -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced"
   comment="check all /boot/loader/entries/*.conf for expanded entries of  {{{ ARG_NAME_VALUE }}}. Leave out rescue boot entries. Accept also references to $kernelopts."
   state_operator="OR" check="all" check_existence="all_exist" version="1">
@@ -130,6 +220,9 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" />
   </ind:textfilecontent54_test>
 
+  {{#- Object "obj_entries_expanded_or_referenced": scans /boot/loader/entries/*.conf.
+       Regex: ^options (.*)$  →  group 1 = entire kernel command line after "options ".
+       Filter excludes *rescue.conf via the rescue state below. -#}}
   <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced" version="1">
     <ind:path>/boot/loader/entries/</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
@@ -138,20 +231,56 @@
     <filter action="exclude">state_grub2_rescue_entry_for_{{{ _RULE_ID }}}</filter>
   </ind:textfilecontent54_object>
 
+  {{#- Filter state: matches filenames ending in "rescue.conf".
+       Used by <filter action="exclude"> to skip rescue boot entries. -#}}
   <ind:textfilecontent54_state id="state_grub2_rescue_entry_for_{{{ _RULE_ID }}}" version="1">
     <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
   </ind:textfilecontent54_state>
 
+  {{#- Test "at_least_one_entry_referenced": checks if at least one non-rescue entry
+       contains $kernelopts.  Used with negate="true" in the criteria tree to build
+       the implication: "IF entries reference $kernelopts THEN grubenv must have the arg."
+       Reuses the same object as entries_expanded_or_referenced. -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_at_least_one_entry_referenced"
   comment="check all /boot/loader/entries/*.conf files if there is at least one entry referencing $kernelopts. Leave out rescue entries."
   check="all" check_existence="at_least_one_exists" version="1">
     <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" />
   </ind:textfilecontent54_test>
+
+  {{% if numeric_comparison %}}
+  {{#- Test "entries_numeric" (numeric mode only): for entries that have ARG_NAME=<digits>,
+       compare the captured integer against the threshold.
+       check_existence="any_exist" — entries using $kernelopts produce no match and
+       that's OK; the grubenv check covers those. -#}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_numeric"
+  comment="check {{{ ARG_NAME }}} value meets {{{ OPERATION }}} in /boot/loader/entries"
+  check="all" check_existence="any_exist" version="1">
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_numeric" />
+    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+  </ind:textfilecontent54_test>
+
+  {{#- Object "obj_entries_numeric": narrow capture — only the digits after ARG_NAME=.
+       Regex: ^options .*ESCAPED_ARG_NAME=(\d+)  →  group 1 = integer value.
+       Entries without the arg or using $kernelopts produce no item (invisible). -#}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_numeric"
+  version="1">
+    <ind:path>/boot/loader/entries/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^options .*{{{ ESCAPED_ARG_NAME }}}=(\d+)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_grub2_rescue_entry_for_{{{ _RULE_ID }}}</filter>
+  </ind:textfilecontent54_object>
+  {{%- endif %}}
 {{% endif %}}
 
 
+{{#- 4b. /etc/default/grub (all products)
+     Two GRUB variables to check: GRUB_CMDLINE_LINUX and GRUB_CMDLINE_LINUX_DEFAULT.
+     Pattern match regex: ^\s*GRUB_CMDLINE_LINUX="(.*)"$     →  group 1 = full quoted value
+     Numeric regex:       ^\s*GRUB_CMDLINE_LINUX=".*ARG=(\d+).*"$  →  group 1 = digits only -#}}
 {{%- if system_with_kernel_options_in_etc_default_grub %}}
+  {{#- Test "argument": GRUB_CMDLINE_LINUX in /etc/default/grub. -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX"
   check="all" check_existence="all_exist" version="1">
@@ -159,12 +288,21 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
+  {{#- Object "argument": captures from GRUB_CMDLINE_LINUX in /etc/default/grub.
+       Pattern match: ^\s*GRUB_CMDLINE_LINUX="(.*)"$  →  group 1 = everything inside quotes.
+       Numeric:       ^\s*GRUB_CMDLINE_LINUX=".*ESCAPED_ARG_NAME=(\d+).*"$  →  digits only. -#}}
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
     <ind:filepath>/etc/default/grub</ind:filepath>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX=".*{{{ ESCAPED_ARG_NAME }}}=(\d+).*"$</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  {{#- Test "argument_default": GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.
+       Used with GRUB_DISABLE_RECOVERY=true (criteria tree requires both). -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default"
   comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
   check="all" check_existence="all_exist" version="1">
@@ -172,15 +310,26 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
+  {{#- Object "argument_default": same patterns as above but for GRUB_CMDLINE_LINUX_DEFAULT. -#}}
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default"
   version="1">
     <ind:filepath>/etc/default/grub</ind:filepath>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=".*{{{ ESCAPED_ARG_NAME }}}=(\d+).*"$</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
+{{% endif %}}
 
+{{#- 4c. /etc/default/grub.d/*.cfg drop-in configs (Ubuntu only)
+     Filepath regex: /etc/default/grub.d/[^/]+\.cfg  ([^/]+ prevents crossing directories)
+     Same GRUB_CMDLINE_LINUX / _DEFAULT patterns as 4b.
+     Pattern match: captures everything inside the quotes.
+     Numeric:       captures only the digits after ARG_NAME=. -#}}
 {{% if system_with_kernel_options_in_etc_default_grub_d -%}}
+  {{#- Test "argument_configdir": GRUB_CMDLINE_LINUX in drop-in .cfg files. -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir"
   comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub.d/*cfg via GRUB_CMDLINE_LINUX"
   check="at least one" check_existence="all_exist" version="1">
@@ -188,6 +337,7 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
+  {{#- Test "argument_default_configdir": GRUB_CMDLINE_LINUX_DEFAULT in drop-in .cfg files. -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default_configdir"
   comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
   check="all" check_existence="all_exist" version="1">
@@ -195,22 +345,39 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
+  {{#- Object "argument_configdir": reads GRUB_CMDLINE_LINUX from drop-in .cfg files.
+       Pattern match: group 1 = everything inside the quotes.
+       Numeric:       group 1 = digits after ARG_NAME=, so the state can compare as int. -#}}
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir" version="1">
     <ind:filepath operation="pattern match">/etc/default/grub.d/[^/]+\.cfg</ind:filepath>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX=".*{{{ ESCAPED_ARG_NAME }}}=(\d+).*"$</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  {{#- Object "argument_default_configdir": same as above but for GRUB_CMDLINE_LINUX_DEFAULT. -#}}
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default_configdir"
   version="1">
     <ind:filepath>/etc/default/grub.d/*.cfg</ind:filepath>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=".*{{{ ESCAPED_ARG_NAME }}}=(\d+).*"$</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
+{{% endif %}}
 
-{{%- if system_with_kernel_options_in_grubenv or system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
-{{%- macro test_and_object_for_kernel_options_grub_env(base_name, path) %}}
+{{#- 4d. grubenv — GRUB environment block (rhel8, ol8)
+     Macro generates a test+object pair; called once for BIOS, optionally again for UEFI.
+     Pattern match: ^kernelopts=(.*)$             →  group 1 = full kernelopts value.
+     Numeric:       ^kernelopts=.*ARG_NAME=(\d+)  →  group 1 = digits only, no $ anchor. -#}}
+{{% if system_with_kernel_options_in_grubenv or system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
+  {{%- macro test_and_object_for_kernel_options_grub_env(base_name, path) %}}
+  {{#- Test: check kernelopts line in grubenv at the given path. -#}}
   <ind:textfilecontent54_test id="test_{{{ base_name }}}"
   comment="check for kernel command line parameters {{{ ARG_NAME_VALUE }}} in {{{ path }}} for all kernels"
   check="all" check_existence="all_exist" version="1">
@@ -218,43 +385,72 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
+  {{#- Object: reads grubenv's "kernelopts=" line.
+       Pattern match: ^kernelopts=(.*)$             →  captures everything after "kernelopts=".
+       Numeric:       ^kernelopts=.*ARG_NAME=(\d+)  →  captures digits only; no $ anchor
+                      because the arg may appear mid-line. -#}}
   <ind:textfilecontent54_object id="object_{{{ base_name }}}"
   version="1">
     <ind:filepath>{{{ path }}}</ind:filepath>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^kernelopts=.*{{{ ESCAPED_ARG_NAME }}}=(\d+)</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endmacro %}}
+  {{%- endmacro %}}
 
-{{{ test_and_object_for_kernel_options_grub_env("grub2_" ~ SANITIZED_ARG_NAME ~ "_argument_grub_env", grub2_boot_path ~ "/grubenv") }}}
-{{% if system_with_bios_and_uefi_support -%}}
-{{{ test_and_object_for_kernel_options_grub_env("grub2_" ~ SANITIZED_ARG_NAME ~ "_argument_grub_env_uefi", grub2_uefi_boot_path ~ "/grubenv") }}}
-{{%- endif %}}
-{{%- endif %}}
+  {{{- test_and_object_for_kernel_options_grub_env("grub2_" ~ SANITIZED_ARG_NAME ~ "_argument_grub_env", grub2_boot_path ~ "/grubenv") }}}
+  {{%- if system_with_bios_and_uefi_support -%}}
+  {{{- test_and_object_for_kernel_options_grub_env("grub2_" ~ SANITIZED_ARG_NAME ~ "_argument_grub_env_uefi", grub2_uefi_boot_path ~ "/grubenv") }}}
+  {{%- endif %}}
+{{% endif %}}
 
-{{%- if system_with_expanded_kernel_options_in_loader_entries %}}
-    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
-                                comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
-                                check="all" check_existence="all_exist" version="1">
-      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" />
-      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-    </ind:textfilecontent54_test>
+{{#- 4e. BLS entries — /boot/loader/entries/*.conf (rhel9, rhel10, fedora, ol9)
+     Modern BLS layout: each *.conf has an "options ..." line with kernel args.
+     check="all" + check_existence="all_exist" — every non-rescue entry must match.
+     Pattern match: ^options (.*)$             →  group 1 = entire kernel command line.
+     Numeric:       ^options .*ARG_NAME=(\d+)  →  group 1 = digits only. -#}}
+{{% if system_with_expanded_kernel_options_in_loader_entries %}}
+  {{#- Test "entries": every non-rescue BLS entry must pass the state check. -#}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
+  comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" />
+    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+  </ind:textfilecontent54_test>
 
+  {{#- Object "obj_entries": scans every *.conf in /boot/loader/entries/.
+       Pattern match: ^options (.*)$  →  wide capture; state checks for the arg token.
+       Numeric:       ^options .*ESCAPED_ARG_NAME=(\d+)  →  narrow capture; entries without
+                      the arg produce no item and are invisible to the test. -#}}
   <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" version="1">
     <ind:path>/boot/loader/entries/</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^options .*{{{ ESCAPED_ARG_NAME }}}=(\d+)</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     <filter action="exclude">state_grub2_rescue_entry_for_{{{ _RULE_ID }}}</filter>
   </ind:textfilecontent54_object>
 
+  {{#- Filter state: excludes filenames matching *rescue.conf from the object results. -#}}
   <ind:textfilecontent54_state id="state_grub2_rescue_entry_for_{{{ _RULE_ID }}}" version="1">
     <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
   </ind:textfilecontent54_state>
-{{%- endif %}}
+{{% endif %}}
 
-{{%- if system_with_expanded_kernel_options_in_grub_cfg %}}
-{{%- macro test_and_object_for_kernel_options_grub_cfg(base_name, path) %}}
+{{#- 4f. grub.cfg — legacy GRUB config (ol7, Ubuntu)
+     Macro generates test+object pair; called once for BIOS, optionally again for UEFI.
+     ol7/Ubuntu regex: ^.*/vmlinuz.*(root=.*)$  →  captures from "root=" onward.
+     ol7/Ubuntu numeric: ^.*/vmlinuz.*ARG_NAME=(\d+)  →  digits only.
+     Other: ^set default_kernelopts=(.*)$  (or numeric variant). -#}}
+{{% if system_with_expanded_kernel_options_in_grub_cfg %}}
+  {{%- macro test_and_object_for_kernel_options_grub_cfg(base_name, path) %}}
+  {{#- Test: check kernel boot line in grub.cfg at the given path. -#}}
   <ind:textfilecontent54_test id="test_{{{ base_name }}}"
   comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} in {{{ path }}} for all kernels"
   check="all" check_existence="all_exist" version="1">
@@ -262,24 +458,39 @@
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
+  {{#- Object: reads grub.cfg; pattern depends on product and comparison mode. -#}}
   <ind:textfilecontent54_object id="object_{{{ base_name }}}"
   version="1">
     <ind:filepath>{{{ path }}}</ind:filepath>
-    {{% if product in ["ol7"] or 'ubuntu' in product %}}
+  {{% if product in ["ol7"] or 'ubuntu' in product %}}
+    {{% if numeric_comparison %}}
+      <ind:pattern operation="pattern match">^.*/vmlinuz.*{{{ ESCAPED_ARG_NAME }}}=(\d+)</ind:pattern>
+    {{% else %}}
       <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
+    {{% endif %}}
+  {{% else %}}
+    {{% if numeric_comparison %}}
+      <ind:pattern operation="pattern match">^set default_kernelopts=.*{{{ ESCAPED_ARG_NAME }}}=(\d+)</ind:pattern>
     {{% else %}}
       <ind:pattern operation="pattern match">^set default_kernelopts=(.*)$</ind:pattern>
     {{% endif %}}
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endmacro %}}
+  {{%- endmacro %}}
 
-{{{ test_and_object_for_kernel_options_grub_cfg("grub2_" + SANITIZED_ARG_NAME + "_argument_grub_cfg", grub2_boot_path ~ "/grub.cfg") }}}
-{{% if system_with_bios_and_uefi_support -%}}
-{{{ test_and_object_for_kernel_options_grub_cfg("grub2_" + SANITIZED_ARG_NAME + "_argument_grub_cfg_uefi", grub2_uefi_boot_path ~ "/grub.cfg") }}}
-{{%- endif %}}
-{{%- endif %}}
+  {{{- test_and_object_for_kernel_options_grub_cfg("grub2_" + SANITIZED_ARG_NAME + "_argument_grub_cfg", grub2_boot_path ~ "/grub.cfg") }}}
+  {{%- if system_with_bios_and_uefi_support -%}}
+  {{{- test_and_object_for_kernel_options_grub_cfg("grub2_" + SANITIZED_ARG_NAME + "_argument_grub_cfg_uefi", grub2_uefi_boot_path ~ "/grub.cfg") }}}
+  {{%- endif %}}
+{{% endif %}}
 
+{{#- 4g. State "$kernelopts detection" (RHEL8 only): matches options lines containing
+     the $kernelopts variable reference — meaning the real args live in grubenv.
+     Regex: ^(?:.*\s)?\$kernelopts(?:\s.*)?$
+     (?:.*\s)?       — optional: preceding args + whitespace (word boundary)
+     \$kernelopts    — literal "$kernelopts" (the $ is regex-escaped)
+     (?:\s.*)?$      — optional: whitespace + trailing args -#}}
 {{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts"
   version="1">
@@ -287,11 +498,44 @@
   </ind:textfilecontent54_state>
 {{% endif %}}
 
-{{% if not ARG_VARIABLE %}}
+{{#- 5. Shared state & variables: branched by (numeric_comparison, ARG_VARIABLE).
+     All non-bootc tests reference the same state ID: state_grub2_{SANITIZED_ARG_NAME}_argument.
+     Each branch defines a state; some also declare external/local variables. -#}}
+
+{{#- 5a. State (numeric mode): captured (\d+) compared as integer.
+     With ARG_VARIABLE → var_ref (XCCDF variable injected at scan time via check-export).
+     With ARG_VALUE    → literal integer baked in.
+     external_variable declares the XCCDF variable so OVAL knows about it. -#}}
+{{% if numeric_comparison %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
+  version="1">
+  {{% if ARG_VARIABLE %}}
+    <ind:subexpression datatype="int" operation="{{{ OPERATION }}}"
+        var_ref="{{{ ARG_VARIABLE }}}" />
+  {{% else %}}
+    <ind:subexpression datatype="int" operation="{{{ OPERATION }}}">{{{ ARG_VALUE }}}</ind:subexpression>
+  {{% endif %}}
+  </ind:textfilecontent54_state>
+  {{% if ARG_VARIABLE %}}
+  <external_variable comment="Variable for {{{ ARG_NAME }}}"
+      datatype="int" id="{{{ ARG_VARIABLE }}}" version="1" />
+  {{% endif %}}
+{{#- 5b. State (pattern match, literal value): regex checks the arg is a
+     space-delimited token in the captured line.
+     Regex: ^(?:.*\s)?ESCAPED_ARG_NAME_VALUE(?:\s.*)?$
+     (?:.*\s)?  — optional preceding args + whitespace (acts as word boundary)
+     ARG=VALUE  — literal match (dots escaped)
+     (?:\s.*)?$ — optional trailing args -#}}
+{{% elif not ARG_VARIABLE %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
+{{#- 5c. State (pattern match, XCCDF variable): regex built at scan time via <concat>.
+     <literal_component> provides the regex skeleton; <variable_component> splices in
+     the variable's value.  IS_SUBSTRING="true" adds \S* pads around the value for
+     substring matching (e.g. slub_debug on ol8).
+     external_variable declares the XCCDF variable (datatype="string" here). -#}}
 {{% else %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   version="1">
@@ -303,13 +547,13 @@
   datatype="string" version="1">
     <concat>
       <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
-      {{% if IS_SUBSTRING == "true" %}}
+    {{% if IS_SUBSTRING == "true" %}}
       <literal_component>\S*</literal_component>
-      {{% endif %}}
+    {{% endif %}}
       <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
-      {{% if IS_SUBSTRING == "true" %}}
+    {{% if IS_SUBSTRING == "true" %}}
       <literal_component>\S*</literal_component>
-      {{% endif %}}
+    {{% endif %}}
       <literal_component>(?:\s.*)?$</literal_component>
     </concat>
   </local_variable>
@@ -317,24 +561,52 @@
   <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
 {{% endif %}}
 
+{{#- 6. bootc / RHEL Image Mode (rhel9, rhel10): /usr/lib/bootc/kargs.d/*.toml
+     TOML format: kargs = ["arg1=val1", "arg2=val2", ...]
+     Separate test, object, and state (IDs suffixed with _usr_lib_bootc_kargs_d).
+     The TOML double quotes around each arg act as natural word boundaries. -#}}
 {{% if bootable_containers_supported == "true" %}}
+  {{#- Test "bootc": at least one .toml file must contain the arg. -#}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
                               comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
                               check="at least one" check_existence="at_least_one_exists" version="1">
     <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
   </ind:textfilecontent54_test>
+  {{#- Object "bootc": scans *.toml files in /usr/lib/bootc/kargs.d/.
+       Pattern match: ^kargs = \[([^\]]+)\]$                     →  group 1 = bracketed content.
+       Numeric:       ^kargs = \[.*"ESCAPED_ARG_NAME=(\d+)".*\]$  →  group 1 = digits only.
+                      Quotes around the arg in TOML prevent substring false positives. -#}}
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
     <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
     <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
+  {{% if numeric_comparison %}}
+    <ind:pattern operation="pattern match">^kargs = \[.*"{{{ ESCAPED_ARG_NAME }}}=(\d+)".*\]$</ind:pattern>
+  {{% else %}}
     <ind:pattern operation="pattern match">^kargs = \[([^\]]+)\]$</ind:pattern>
+  {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{% if not ARG_VARIABLE %}}
+  {{#- bootc states: same three-way branch as section 5 but with bootc-specific IDs
+       and TOML-adapted patterns (values are wrapped in double quotes). -#}}
+  {{#- bootc state (numeric): compare captured (\d+) as integer. -#}}
+  {{%- if numeric_comparison %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
+    {{% if ARG_VARIABLE %}}
+    <ind:subexpression datatype="int" operation="{{{ OPERATION }}}"
+        var_ref="{{{ ARG_VARIABLE }}}" />
+    {{% else %}}
+    <ind:subexpression datatype="int" operation="{{{ OPERATION }}}">{{{ ARG_VALUE }}}</ind:subexpression>
+    {{% endif %}}
+  </ind:textfilecontent54_state>
+  {{#- bootc state (pattern match, literal): check "ARG_NAME_VALUE" appears in TOML array.
+       Regex: ^.*"ESCAPED_ARG_NAME_VALUE".*$  →  quotes provide word boundaries. -#}}
+  {{%- elif not ARG_VARIABLE %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
     <ind:subexpression operation="pattern match">^.*"{{{ ESCAPED_ARG_NAME_VALUE }}}".*$</ind:subexpression>
   </ind:textfilecontent54_state>
-{{% else %}}
+  {{#- bootc state (pattern match, variable): runtime regex via <concat> with TOML quotes. -#}}
+  {{%- else %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
     <ind:subexpression operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs" />
   </ind:textfilecontent54_state>
@@ -344,19 +616,19 @@
   datatype="string" version="1">
     <concat>
       <literal_component>^.*"{{{ ARG_NAME }}}=</literal_component>
-      {{% if IS_SUBSTRING == "true" %}}
+    {{% if IS_SUBSTRING == "true" %}}
       <literal_component>\S*</literal_component>
-      {{% endif %}}
+    {{% endif %}}
       <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
-      {{% if IS_SUBSTRING == "true" %}}
+    {{% if IS_SUBSTRING == "true" %}}
       <literal_component>\S*</literal_component>
-      {{% endif %}}
+    {{% endif %}}
       <literal_component>".*$</literal_component>
     </concat>
   </local_variable>
 
   <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
-{{% endif %}}
+  {{%- endif %}}
 {{% endif %}}
 
 </def-group>

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -1,305 +1,583 @@
 {{#-
-  We set defaults to "off", and products should enable relevant ones depending on how the product configures grub.
-   - /boot/loader/entries/* may not exist.
-   - If they exist, they can reference variables defined in grubenv, or they can contain literal args
-   - The grub cfg may either use those loader entries, or it can contain literal values as well
-   - Kernel opts can be stored in /etc/default/grub so they are persistent between kernel upgrades
+  grub2_bootloader_argument OVAL template
+  ========================================
+
+  Checks that a kernel boot argument (e.g. audit=1) is set across all
+  relevant grub configuration files for the given product.
+
+  LOCATIONS WHERE KERNEL ARGS LIVE (per product):
+  ================================================
+
+  Product         Boot entries                       Persistent config        Other
+  --------------- ---------------------------------- ------------------------ ---------------------------
+  RHEL 9+, Fedora /boot/loader/entries/*.conf        /etc/default/grub        (bootc: kargs.d/*.toml)
+                  (args inline on "options" line)
+  RHEL 8, OL8     /boot/loader/entries/*.conf        /etc/default/grub
+                  (args inline OR via $kernelopts)
+                  + /boot/grub2/grubenv (kernelopts=)
+  OL7             /boot/grub2/grub.cfg (vmlinuz)     /etc/default/grub
+  Ubuntu          /boot/grub2/grub.cfg (vmlinuz)     /etc/default/grub        /etc/default/grub.d/*.cfg
+
+  WHAT THIS TEMPLATE DOES:
+  ========================
+
+  Kernel boot arguments (e.g. audit=1, pti=on, audit_backlog_limit=8192) are
+  settings passed to the Linux kernel at boot time via the bootloader (grub2).
+  Security policies require certain arguments to be set so the kernel enables
+  specific security features (auditing, memory protections, CPU mitigations, etc).
+
+  The problem is that grub2 stores these arguments in DIFFERENT files depending
+  on the OS version and platform. This template generates an OVAL check that
+  verifies the argument is present in ALL the right places for the given product.
+
+  KEY CONCEPTS:
+  =============
+
+  --- Boot entries (what the system actually boots) ---
+
+  /boot/loader/entries/*.conf  (BLS = Boot Loader Specification entries)
+      One .conf file per installed kernel. Each has an "options" line with kernel args.
+      RHEL 9+/Fedora: args are always inline on the options line.
+      RHEL 8/OL8:     args can be inline OR the entry can say "$kernelopts",
+                       which grub expands from /boot/grub2/grubenv at boot time.
+
+  /boot/grub2/grubenv  (RHEL 8 / OL8 only)
+      grub environment file. Contains "kernelopts=..." with the actual kernel args.
+      Only relevant when boot entries reference $kernelopts instead of listing args inline.
+
+  $kernelopts  (RHEL 8 / OL8 only)
+      A grub environment variable. Boot entries can say "$kernelopts" on their options
+      line instead of listing args inline. grub expands it from grubenv at boot time.
+      On RHEL 9+ this indirection no longer exists -- args are always inline.
+
+  /boot/grub2/grub.cfg  (OL7, Ubuntu only)
+      Generated grub config. Contains "linux /vmlinuz-... root=... arg=val ..." lines.
+      These platforms dont use BLS entries -- grub.cfg IS the boot config.
+
+  --- Persistent config (survives grub2-mkconfig regeneration) ---
+
+  /etc/default/grub  (all products)
+      Persistent grub configuration. grub2-mkconfig reads this file and bakes the
+      values into grub.cfg or boot entries. Contains two relevant variables:
+        GRUB_CMDLINE_LINUX="..."          -- args passed to ALL boot entries
+        GRUB_CMDLINE_LINUX_DEFAULT="..."  -- args passed to non-recovery entries ONLY
+      If GRUB_DISABLE_RECOVERY=true is also set, there are no recovery entries,
+      so _DEFAULT effectively applies to all entries too.
+
+  /etc/default/grub.d/*.cfg  (Ubuntu only)
+      Drop-in override files for /etc/default/grub. Same variables, same semantics.
+      Checked in addition to /etc/default/grub on Ubuntu.
+
+  --- bootc / RHEL Image Mode ---
+
+  bootc (RHEL Image Mode) is a way to run RHEL as an immutable container-based OS.
+  The root filesystem is a container image. There is no traditional grub config --
+  the bootloader is managed by bootc itself. Kernel args are defined in TOML files
+  shipped inside the image.
+
+  /usr/lib/bootc/kargs.d/*.toml
+      TOML files with kargs = ["arg=val", "arg2=val2"].
+      On bootc systems, grub files (/boot/loader/entries, grubenv, grub.cfg, etc.)
+      do NOT exist. Kernel args live here instead.
+      The OVAL definition has two mutually exclusive branches: one for bootc systems
+      (checks kargs.d) and one for normal grub systems (checks grub files).
+
+  CRITERIA TREE (what must pass for the definition to be compliant):
+  ==================================================================
+
+  definition (OR)
+  |
+  +-- [bootc] AND
+  |   +-- extend_definition: IS bootc
+  |   +-- test: kargs.d/*.toml has arg=value
+  |
+  +-- [normal grub] AND
+      +-- extend_definition: NOT bootc (if bootc supported)
+      |
+      +-- [RHEL 8 / OL8] entries check:
+      |   +-- test: EACH /boot/loader/entries/*.conf has arg=value inline OR $kernelopts
+      |   +-- (OR)
+      |       +-- NO entry uses $kernelopts (skip grubenv)
+      |       +-- grubenv has arg=value (BIOS or UEFI path)
+      |
+      +-- [RHEL 9+ / Fedora] entries check:
+      |   +-- test: EACH /boot/loader/entries/*.conf has arg=value inline
+      |
+      +-- [OL7 / Ubuntu] grub.cfg check:
+      |   +-- (OR) grub.cfg has arg=value (BIOS or UEFI path)
+      |
+      +-- [all products] /etc/default/grub check:
+          +-- (OR)
+              +-- GRUB_CMDLINE_LINUX has arg=value
+              |   (+ grub.d drop-in on Ubuntu)
+              +-- AND
+                  +-- GRUB_CMDLINE_LINUX_DEFAULT has arg=value
+                  |   (+ grub.d drop-in on Ubuntu)
+                  +-- GRUB_DISABLE_RECOVERY=true
+
+  DATA FLOW (current -- will change in the rewrite):
+  ====================================================
+
+  Currently, objects extract the FULL options/cmdline line, and the shared
+  state uses a regex to check if arg=value appears as a word in that line.
+  This means all comparisons are "pattern match" on "string" datatype.
+
+       Object (extracts full line)          State (regex checks arg=value in line)
+       ┌─────────────────────────┐         ┌────────────────────────────────────┐
+       │ /boot/loader/entries/   │         │ subexpression ~ "pattern match"    │
+       │   ^options (.*)$        │────────>│ ^(?:.*\s)?arg=value(?:\s.*)?$     │
+       │                         │         │                                    │
+       │ /boot/grub2/grubenv    │         │ (same state, shared by all tests)  │
+       │   ^kernelopts=(.*)$     │────────>│                                    │
+       │                         │         └────────────────────────────────────┘
+       │ /etc/default/grub       │                        │
+       │   ^GRUB_CMDLINE_LINUX=  │────────────────────────┘
+       │     "(.*)"$             │
+       └─────────────────────────┘
+
+  TARGET (after rewrite -- sysctl-style extract-then-compare):
+
+       Object (extracts JUST the value)    State (native OVAL comparison)
+       ┌─────────────────────────┐         ┌────────────────────────────────────┐
+       │ /boot/loader/entries/   │         │ subexpression                      │
+       │   ^options.*arg=(\S+)   │────────>│   operation="equals"               │
+       │                         │         │   datatype="int"                   │
+       │ /boot/grub2/grubenv    │         │   value=8192                       │
+       │   ^kernelopts.*arg=     │────────>│                                    │
+       │     (\S+)               │         │ (same state, shared by all tests)  │
+       │                         │         └────────────────────────────────────┘
+       │ /etc/default/grub       │                        │
+       │   ^GRUB_CMDLINE_LINUX=  │────────────────────────┘
+       │     ".*arg=(\S+).*"$    │
+       └─────────────────────────┘
+
+  The check_* flags below control which locations are verified per product.
 -#}}
-{{% set system_with_expanded_kernel_options_in_loader_entries = false -%}}
-{{% set system_with_kernel_options_in_grubenv = false -%}}
-{{% set system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv = false -%}}
-{{% set system_with_kernel_options_in_etc_default_grub = true -%}}
-{{% set system_with_kernel_options_in_etc_default_grub_d = false -%}}
-{{% set system_with_expanded_kernel_options_in_grub_cfg = false -%}}
-{{% set system_with_bios_and_uefi_support = false -%}}
 
-{{% if product in ["fedora", "ol9", "rhel9", "rhel10"] -%}}
-{{% set system_with_expanded_kernel_options_in_loader_entries = true %}}
-{{%- endif -%}}
+{{% set check_boot_loader_entries              = product in ["fedora", "ol9", "rhel9", "rhel10"] %}}
+{{% set check_boot_loader_entries_or_grubenv   = product in ["ol8", "rhel8"] %}}
+{{% set check_etc_default_grub                 = true %}}
+{{% set check_etc_default_grub_d               = 'ubuntu' in product %}}
+{{% set check_grub_cfg                         = product in ["ol7"] or 'ubuntu' in product %}}
+{{% set has_separate_bios_and_uefi             = grub2_uefi_boot_path and grub2_uefi_boot_path != grub2_boot_path %}}
 
-{{% if product in ["ol8", "rhel8"] -%}}
-{{% set system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv = true -%}}
-{{%- endif -%}}
-
-{{% if product in ["ol7"] or 'ubuntu' in product -%}}
-{{% set system_with_expanded_kernel_options_in_grub_cfg = true %}}
-{{%- endif -%}}
-
-{{% if 'ubuntu' in product -%}}
-{{% set system_with_kernel_options_in_etc_default_grub_d = true -%}}
-{{%- endif -%}}
-
-{{% if grub2_uefi_boot_path and grub2_uefi_boot_path != grub2_boot_path -%}}
-{{% set system_with_bios_and_uefi_support = true %}}
-{{%- endif -%}}
-
+{{# DEFINITION: {{{ _RULE_ID }}}
+     Class: compliance
+     Purpose: ensure the kernel boot argument {{{ ARG_NAME_VALUE }}} is set in all
+              relevant grub configuration files for this product.
+     Top-level OR: bootc branch vs normal grub branch.
+     Only one branch can be true at runtime (bootc XOR normal grub).
+     See the ASCII art criteria tree at the top of this file for the full picture. #}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
-    {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is configured in the kernel line in /etc/default/grub.", rule_title=rule_title) }}}
+    {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is set as a kernel boot argument.", rule_title=rule_title) }}}
     <criteria operator="OR">
-    <criteria operator="AND">
-      {{% if bootable_containers_supported == "true" %}}
-        <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" negate="true" />
-      {{% endif %}}
-      {{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
-      <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced"
-      comment="Check /boot/loader/entries/*.conf files if they contain direct reference to {{{ ARG_NAME_VALUE }}} or if they contain $kernelopts" />
-      <criteria operator="OR"
-      comment="Expressing implication">
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_at_least_one_entry_referenced" negate="true"
-        comment="Negate the result of the test if there exists at least one $kernelopts in /boot/loader/entries" />
-        {{% if system_with_bios_and_uefi_support -%}}
-        <criteria operator="OR">
+
+      {{%- if bootable_containers_supported == "true" %}}
+      {{# CRITERIA BRANCH: bootc / RHEL Image Mode
+           Platforms: RHEL 9+, RHEL 10 with bootc support (bootable_containers_supported)
+           The system must be bootc AND kargs.d/*.toml must contain {{{ ARG_NAME_VALUE }}}.
+           On non-bootc systems, the extend_definition fails and this whole branch is skipped. #}}
+      <criteria operator="AND">
+        <extend_definition comment="Verify system is in RHEL Image Mode (bootc)" definition_ref="bootc" />
+        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
+                   comment="Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}}" />
+      </criteria>
+      {{%- endif %}}
+
+      {{# CRITERIA BRANCH: normal grub (non-bootc)
+           Platforms: all products
+           All sub-checks must pass: bootc guard, boot entries, and /etc/default/grub.
+           The specific sub-checks emitted depend on the check_* flags set per product. #}}
+      <criteria operator="AND">
+
+        {{%- if bootable_containers_supported == "true" %}}
+        {{# EXTEND_DEFINITION: NOT bootc guard
+             Platforms: RHEL 9+, RHEL 10 with bootc support (bootable_containers_supported)
+             Fails this "normal grub" branch on bootc systems where grub files do not exist.
+             negate="true" -- passes only if the system is NOT bootc. #}}
+        <extend_definition comment="Verify system is NOT in RHEL Image Mode (bootc)" definition_ref="bootc" negate="true" />
         {{%- endif %}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_boot_path }}}/grubenv" />
-      {{% if system_with_bios_and_uefi_support -%}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env_uefi"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_uefi_boot_path }}}/grubenv" />
+
+        {{%- if check_boot_loader_entries_or_grubenv %}}
+        {{# CRITERIA BRANCH: RHEL 8 / OL8 boot loader entries + $kernelopts + grubenv
+             Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
+             Two-part check:
+               1. EACH /boot/loader/entries/*.conf (omit rescue) has {{{ ARG_NAME_VALUE }}}
+                  inline on the options line OR contains $kernelopts.
+               2. If any entry uses $kernelopts, then grubenv must also have {{{ ARG_NAME_VALUE }}}.
+             The $kernelopts indirection is an RHEL 8 mechanism: entries say "$kernelopts" and
+             grub expands it from /boot/grub2/grubenv at boot time. #}}
+        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf"
+                   comment="Check each /boot/loader/entries/*.conf for {{{ ARG_NAME_VALUE }}} on options line or $kernelopts reference" />
+
+        {{# CRITERIA: $kernelopts grubenv gate
+             Passes if no entry uses $kernelopts (all args on options line, grubenv irrelevant)
+             OR grubenv has {{{ ARG_NAME_VALUE }}} (BIOS or UEFI path). #}}
+        <criteria operator="OR"
+                  comment="Verify no entry uses $kernelopts, or check grubenv for {{{ ARG_NAME_VALUE }}}">
+
+          {{# CRITERION: no $kernelopts in any entry (negated)
+               If no entry uses $kernelopts, all args are on the options line and grubenv is irrelevant. #}}
+          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_kernelopts_in_any_boot_loader_entry" negate="true"
+                     comment="Verify no entry references $kernelopts (all args on options line)" />
+
+          {{# CRITERIA: grubenv has arg=value
+               BIOS: {grub2_boot_path}/grubenv          (e.g. /boot/grub2/grubenv)
+               UEFI: {grub2_uefi_boot_path}/grubenv      (e.g. /boot/efi/EFI/redhat/grubenv)
+               UEFI criterion only emitted when has_separate_bios_and_uefi is true. #}}
+          <criteria operator="OR">
+            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grubenv"
+                       comment="Check {{{ grub2_boot_path }}}/grubenv for {{{ ARG_NAME_VALUE }}}" />
+          {{%- if has_separate_bios_and_uefi %}}
+            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grubenv_uefi"
+                       comment="Check {{{ grub2_uefi_boot_path }}}/grubenv for {{{ ARG_NAME_VALUE }}}" />
+          {{%- endif %}}
+          </criteria>
         </criteria>
         {{%- endif %}}
-      </criteria>
-      {{% elif system_with_kernel_options_in_grubenv -%}}
-        <extend_definition comment="check kernel command line parameters for referenced boot entries reference the $kernelopts variable" definition_ref="grub2_entries_reference_kernelopts" />
-      {{% if system_with_bios_and_uefi_support -%}}
-      <criteria operator="OR">
-      {{%- endif %}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_boot_path }}}/grubenv" />
-      {{% if system_with_bios_and_uefi_support -%}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env_uefi"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_uefi_boot_path }}}/grubenv" />
-      </criteria>
-      {{%- endif %}}
-      {{% elif system_with_expanded_kernel_options_in_loader_entries -%}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
-                     comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the /boot/loader/entries/*.conf" />
-      {{%- endif %}}
-      {{% if system_with_expanded_kernel_options_in_grub_cfg -%}}
-          {{% if system_with_bios_and_uefi_support -%}}
-          <criteria operator="OR">
-          {{%- endif %}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
-          comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
-          {{% if system_with_bios_and_uefi_support -%}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg_uefi"
-          comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_uefi_boot_path }}}/grub.cfg for all kernels" />
-          </criteria>
-          {{%- endif %}}
-      {{%- endif %}}
-      {{% if system_with_kernel_options_in_etc_default_grub -%}}
+
+        {{%- if check_boot_loader_entries %}}
+        {{# CRITERION: RHEL 9+ / Fedora / OL9 boot loader entries
+             Platforms: RHEL 9+, Fedora, OL9 (check_boot_loader_entries)
+             Checks: EACH /boot/loader/entries/*.conf (omit rescue) has {{{ ARG_NAME_VALUE }}}
+                     directly on the options line. No $kernelopts indirection on these platforms. #}}
+        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
+                   comment="Check each /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}}" />
+        {{%- endif %}}
+
+        {{%- if check_grub_cfg %}}
+        {{# CRITERIA: OL7 / Ubuntu grub.cfg
+             Platforms: OL7, Ubuntu (check_grub_cfg)
+             BIOS: {grub2_boot_path}/grub.cfg          (e.g. /boot/grub2/grub.cfg)
+             UEFI: {grub2_uefi_boot_path}/grub.cfg      (e.g. /boot/efi/EFI/redhat/grub.cfg)
+             UEFI criterion only emitted when has_separate_bios_and_uefi is true. #}}
         <criteria operator="OR">
+          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grub_cfg"
+                      comment="Check {{{ grub2_boot_path }}}/grub.cfg for {{{ ARG_NAME_VALUE }}}" />
+          {{%- if has_separate_bios_and_uefi %}}
+          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grub_cfg_uefi"
+                      comment="Check {{{ grub2_uefi_boot_path }}}/grub.cfg for {{{ ARG_NAME_VALUE }}}" />
+          {{%- endif %}}
+        </criteria>
+        {{%- endif %}}
+
+      {{% if check_etc_default_grub %}}
+        {{# CRITERIA: /etc/default/grub persistent configuration
+             Platforms: all (check_etc_default_grub = true)
+             Passes if GRUB_CMDLINE_LINUX has {{{ ARG_NAME_VALUE }}} (applies to all entries),
+             OR GRUB_CMDLINE_LINUX_DEFAULT has it + GRUB_DISABLE_RECOVERY=true.
+             _DEFAULT only covers non-recovery boots, so disabling recovery ensures coverage. #}}
+        <criteria operator="OR">
+
+          {{# CRITERIA: GRUB_CMDLINE_LINUX (applies to all entries)
+               Checks /etc/default/grub, plus grub.d drop-ins on Ubuntu. #}}
           <criteria operator="OR">
-            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
-            comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX" />
-            {{% if system_with_kernel_options_in_etc_default_grub_d -%}}
-            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir"
-            comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub.d/*cfg via GRUB_CMDLINE_LINUX" />
-            {{%- endif %}}
+            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux"
+                       comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub for {{{ ARG_NAME_VALUE }}}" />
+          {{% if check_etc_default_grub_d %}}
+            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d"
+                       comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}" />
+          {{% endif %}}
           </criteria>
+
+          {{# CRITERIA: GRUB_CMDLINE_LINUX_DEFAULT + GRUB_DISABLE_RECOVERY=true
+               _DEFAULT only applies to non-recovery entries, so recovery must be disabled
+               to ensure the arg is on ALL boot entries. Checks /etc/default/grub,
+               plus grub.d drop-ins on Ubuntu. #}}
           <criteria operator="AND">
             <criteria operator="OR">
-              <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default"
-              comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
-              {{% if system_with_kernel_options_in_etc_default_grub_d -%}}
-              <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default_configdir"
-              comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub.d/*cfg via GRUB_CMDLINE_LINUX_DEFAULT" />
-              {{%- endif %}}
+              <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default"
+                         comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub for {{{ ARG_NAME_VALUE }}}" />
+            {{% if check_etc_default_grub_d %}}
+              <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d"
+                         comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}" />
+            {{% endif %}}
             </criteria>
             <extend_definition definition_ref="bootloader_disable_recovery_set_to_true"
-            comment="Check GRUB_DISABLE_RECOVERY=true in /etc/default/grub" />
+                               comment="Verify GRUB_DISABLE_RECOVERY=true in /etc/default/grub" />
           </criteria>
         </criteria>
-      {{%- endif %}}
-    </criteria>
-    {{% if bootable_containers_supported == "true" %}}
-      <criteria operator="AND">
-        <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" />
-        <criterion comment="The {{{ ARG_NAME_VALUE }}} is present in the /usr/lib/bootc/kargs.d/*.toml files"  test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
+      {{% endif %}}
+
       </criteria>
-    {{% endif %}}
+
     </criteria>
   </definition>
 
-{{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced"
-  comment="check all /boot/loader/entries/*.conf for expanded entries of  {{{ ARG_NAME_VALUE }}}. Leave out rescue boot entries. Accept also references to $kernelopts."
+
+
+
+{{# TESTS #}}
+{{% if check_boot_loader_entries_or_grubenv %}}
+  {{# Check that EACH /boot/loader/entries/*.conf (omit rescue) has {{{ ARG_NAME_VALUE }}}
+       on the options line OR references $kernelopts (grub env variable).
+       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
+       Extracts the full "options" line as subexpression.
+       state_operator="OR" because entries may have args on options line or via $kernelopts. #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf"
+  comment="Check each /boot/loader/entries/*.conf for {{{ ARG_NAME_VALUE }}} on options line or $kernelopts reference"
   state_operator="OR" check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced" />
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced" version="1">
+  {{# Collect the "options" line from each /boot/loader/entries/*.conf.
+       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
+       Each .conf file produces one collected item. Rescue entries (*rescue.conf) excluded.
+       Shared by two tests: the arg-or-$kernelopts check and the $kernelopts-presence check. #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf" version="1"
+  comment="Collect options line from each /boot/loader/entries/*.conf (exclude rescue)">
     <ind:path>/boot/loader/entries/</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{# regex: ^options (.*)$  -- captures the full space-separated arg list after "options " #}}
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    <filter action="exclude">state_grub2_rescue_entry_for_{{{ _RULE_ID }}}</filter>
+    <filter action="exclude">state_grub2_{{{ _RULE_ID }}}_is_rescue_entry</filter>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_grub2_rescue_entry_for_{{{ _RULE_ID }}}" version="1">
+  {{# Exclude filter: matches filenames ending in "rescue.conf".
+       Used by boot entry objects to skip rescue entries -- we only care about normal entries. #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ _RULE_ID }}}_is_rescue_entry" version="1"
+  comment="Match rescue entry filenames for exclusion">
+    {{# regex: .*rescue\.conf$  -- matches rescue entry filenames to exclude them #}}
     <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
   </ind:textfilecontent54_state>
 
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_at_least_one_entry_referenced"
-  comment="check all /boot/loader/entries/*.conf files if there is at least one entry referencing $kernelopts. Leave out rescue entries."
+  {{# Check if at least one /boot/loader/entries/*.conf references $kernelopts.
+       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
+       Uses the same object as above. Used negated in criteria: if NO entry has $kernelopts,
+       all args are on the options line and the grubenv check is skipped. #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_kernelopts_in_any_boot_loader_entry"
+  comment="Check if any /boot/loader/entries/*.conf references $kernelopts"
   check="all" check_existence="at_least_one_exists" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced" />
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" />
   </ind:textfilecontent54_test>
 {{% endif %}}
 
-
-{{%- if system_with_kernel_options_in_etc_default_grub %}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
-  comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX"
+{{%- if check_etc_default_grub %}}
+  {{# Check GRUB_CMDLINE_LINUX in /etc/default/grub for {{{ ARG_NAME_VALUE }}}.
+       Platforms: all (check_etc_default_grub = true)
+       GRUB_CMDLINE_LINUX is passed to ALL boot entries by grub2-mkconfig. #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux"
+  comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub for {{{ ARG_NAME_VALUE }}}"
   check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
+  {{# Collect GRUB_CMDLINE_LINUX="..." from /etc/default/grub.
+       Platforms: all (check_etc_default_grub = true)
+       Extracts everything between the double quotes as subexpression. #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux" version="1"
+  comment="Collect GRUB_CMDLINE_LINUX value from /etc/default/grub">
     <ind:filepath>/etc/default/grub</ind:filepath>
+    {{# regex: ^\s*GRUB_CMDLINE_LINUX="(.*)"$  -- captures everything between the quotes #}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default"
-  comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  {{# Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub for {{{ ARG_NAME_VALUE }}}.
+       Platforms: all (check_etc_default_grub = true)
+       _DEFAULT only applies to non-recovery entries, so criteria requires
+       GRUB_DISABLE_RECOVERY=true alongside this test. #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default"
+  comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub for {{{ ARG_NAME_VALUE }}}"
   check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default" />
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default"
-  version="1">
+  {{# Collect GRUB_CMDLINE_LINUX_DEFAULT="..." from /etc/default/grub.
+       Platforms: all (check_etc_default_grub = true)
+       Extracts everything between the double quotes as subexpression.
+       Only passed to non-recovery boot entries by grub2-mkconfig. #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default" version="1"
+  comment="Collect GRUB_CMDLINE_LINUX_DEFAULT value from /etc/default/grub">
     <ind:filepath>/etc/default/grub</ind:filepath>
+    {{# regex: ^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$  -- captures everything between the quotes #}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{%- endif %}}
 
-{{% if system_with_kernel_options_in_etc_default_grub_d -%}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir"
-  comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub.d/*cfg via GRUB_CMDLINE_LINUX"
-  check="at least one" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-  </ind:textfilecontent54_test>
+{{%- if check_etc_default_grub_d %}}
+    {{# Check GRUB_CMDLINE_LINUX in /etc/default/grub.d/*.cfg drop-ins for {{{ ARG_NAME_VALUE }}}.
+         Platforms: Ubuntu (check_etc_default_grub_d)
+         Same as the /etc/default/grub check but from drop-in config files.
+         Passes if at least one drop-in has it (check="at least one"). #}}
+    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d"
+    comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}"
+    check="at least one" check_existence="all_exist" version="1">
+      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d" />
+      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+    </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default_configdir"
-  comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
-  check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default_configdir" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-  </ind:textfilecontent54_test>
+    {{# Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.d/*.cfg drop-ins for {{{ ARG_NAME_VALUE }}}.
+         Platforms: Ubuntu (check_etc_default_grub_d)
+         Same as the /etc/default/grub check but from drop-in config files.
+         Requires GRUB_DISABLE_RECOVERY=true (same as the non-drop-in variant). #}}
+    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d"
+    comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}"
+    check="all" check_existence="all_exist" version="1">
+      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d" />
+      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+    </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir" version="1">
-    <ind:filepath operation="pattern match">/etc/default/grub.d/[^/]+\.cfg</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
+    {{# Collect GRUB_CMDLINE_LINUX="..." from /etc/default/grub.d/*.cfg drop-in files.
+         Platforms: Ubuntu (check_etc_default_grub_d)
+         Same regex as the /etc/default/grub object, but iterates over all .cfg drop-ins. #}}
+    <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d" version="1"
+    comment="Collect GRUB_CMDLINE_LINUX value from /etc/default/grub.d/*.cfg">
+      {{# regex: /etc/default/grub.d/[^/]+\.cfg  -- match .cfg drop-in files (Ubuntu) #}}
+      <ind:filepath operation="pattern match">/etc/default/grub.d/[^/]+\.cfg</ind:filepath>
+      {{# regex: same as /etc/default/grub -- captures everything between the quotes #}}
+      <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default_configdir"
-  version="1">
-    <ind:filepath>/etc/default/grub.d/*.cfg</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
+    {{# Collect GRUB_CMDLINE_LINUX_DEFAULT="..." from /etc/default/grub.d/*.cfg drop-in files.
+         Platforms: Ubuntu (check_etc_default_grub_d)
+         Same regex as the /etc/default/grub object, but iterates over all .cfg drop-ins.
+         Only applies to non-recovery entries (same as GRUB_CMDLINE_LINUX_DEFAULT). #}}
+    <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d" version="1"
+    comment="Collect GRUB_CMDLINE_LINUX_DEFAULT value from /etc/default/grub.d/*.cfg">
+      <ind:filepath>/etc/default/grub.d/*.cfg</ind:filepath>
+      {{# regex: same as /etc/default/grub -- captures everything between the quotes #}}
+      <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
 {{%- endif %}}
 
-{{%- if system_with_kernel_options_in_grubenv or system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
-{{%- macro test_and_object_for_kernel_options_grub_env(base_name, path) %}}
-  <ind:textfilecontent54_test id="test_{{{ base_name }}}"
-  comment="check for kernel command line parameters {{{ ARG_NAME_VALUE }}} in {{{ path }}} for all kernels"
+{{%- if check_boot_loader_entries_or_grubenv %}}
+  {{# Check grubenv for {{{ ARG_NAME_VALUE }}} in the kernelopts= line.
+       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
+       BIOS: {grub2_boot_path}/grubenv          (e.g. /boot/grub2/grubenv)
+       UEFI: {grub2_uefi_boot_path}/grubenv      (e.g. /boot/efi/EFI/redhat/grubenv)
+       UEFI variant only emitted when has_separate_bios_and_uefi is true.
+       Used when boot loader entries reference $kernelopts instead of listing args on options line. #}}
+  {{%- macro test_and_object_for_grubenv(variant="") %}}
+    {{%- set path = (grub2_uefi_boot_path if variant == "uefi" else grub2_boot_path) ~ "/grubenv" -%}}
+    {{%- set name = "grub2_" ~ SANITIZED_ARG_NAME ~ "_in_grubenv" ~ ("_uefi" if variant == "uefi" else "") -%}}
+  <ind:textfilecontent54_test id="test_{{{ name }}}"
+  comment="Check {{{ path }}} for {{{ ARG_NAME_VALUE }}}"
   check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_{{{ base_name }}}" />
+    <ind:object object_ref="obj_{{{ name }}}" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_{{{ base_name }}}"
-  version="1">
+  {{# Collect kernelopts=... from grubenv (everything after "kernelopts=").
+       This is the grub environment variable that boot entries expand via $kernelopts. #}}
+  <ind:textfilecontent54_object id="obj_{{{ name }}}" version="1"
+  comment="Collect kernelopts value from {{{ path }}}">
     <ind:filepath>{{{ path }}}</ind:filepath>
+    {{# regex: ^kernelopts=(.*)$  -- captures the full space-separated arg list from kernelopts #}}
     <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endmacro %}}
+  {{%- endmacro %}}
 
-{{{ test_and_object_for_kernel_options_grub_env("grub2_" ~ SANITIZED_ARG_NAME ~ "_argument_grub_env", grub2_boot_path ~ "/grubenv") }}}
-{{% if system_with_bios_and_uefi_support -%}}
-{{{ test_and_object_for_kernel_options_grub_env("grub2_" ~ SANITIZED_ARG_NAME ~ "_argument_grub_env_uefi", grub2_uefi_boot_path ~ "/grubenv") }}}
-{{%- endif %}}
+  {{{- test_and_object_for_grubenv() }}}
+  {{%- if has_separate_bios_and_uefi -%}}
+    {{{- test_and_object_for_grubenv(variant="uefi") }}}
+  {{%- endif %}}
 {{%- endif %}}
 
-{{%- if system_with_expanded_kernel_options_in_loader_entries %}}
+{{%- if check_boot_loader_entries %}}
+    {{# Check EACH /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}} on options line.
+         Platforms: RHEL 9+, Fedora, OL9 (check_boot_loader_entries)
+         No $kernelopts indirection -- RHEL 9+ has all kernel args on the options line. #}}
     <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
-                                comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
+                                comment="Check each /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}}"
                                 check="all" check_existence="all_exist" version="1">
       <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" />
       <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
     </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" version="1">
+  {{# Collect the "options" line from each /boot/loader/entries/*.conf.
+       Platforms: RHEL 9+, Fedora, OL9 (check_boot_loader_entries)
+       Each .conf file produces one collected item. Rescue entries (*rescue.conf) excluded.
+       Unlike the RHEL 8 variant, no $kernelopts indirection -- args are always on the options line. #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" version="1"
+  comment="Collect options line from each /boot/loader/entries/*.conf (exclude rescue)">
     <ind:path>/boot/loader/entries/</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{# regex: ^options (.*)$  -- captures the full space-separated arg list after "options " #}}
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    <filter action="exclude">state_grub2_rescue_entry_for_{{{ _RULE_ID }}}</filter>
+    <filter action="exclude">state_grub2_{{{ _RULE_ID }}}_is_rescue_entry</filter>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_grub2_rescue_entry_for_{{{ _RULE_ID }}}" version="1">
+  {{# Exclude filter: matches filenames ending in "rescue.conf" (same as above). #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ _RULE_ID }}}_is_rescue_entry" version="1"
+  comment="Match rescue entry filenames for exclusion">
+    {{# regex: .*rescue\.conf$  -- matches rescue entry filenames to exclude them #}}
     <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
   </ind:textfilecontent54_state>
 {{%- endif %}}
 
-{{%- if system_with_expanded_kernel_options_in_grub_cfg %}}
-{{%- macro test_and_object_for_kernel_options_grub_cfg(base_name, path) %}}
-  <ind:textfilecontent54_test id="test_{{{ base_name }}}"
-  comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} in {{{ path }}} for all kernels"
+{{%- if check_grub_cfg %}}
+  {{# Check grub.cfg vmlinuz lines for {{{ ARG_NAME_VALUE }}} in the kernel command line.
+       Platforms: OL7, Ubuntu (check_grub_cfg)
+       BIOS: {grub2_boot_path}/grub.cfg          (e.g. /boot/grub2/grub.cfg)
+       UEFI: {grub2_uefi_boot_path}/grub.cfg      (e.g. /boot/efi/EFI/redhat/grub.cfg)
+       UEFI variant only emitted when has_separate_bios_and_uefi is true. #}}
+  {{%- macro test_and_object_for_grub_cfg(variant, path) %}}
+    {{% set name = "grub2_" ~ SANITIZED_ARG_NAME ~ "_in_grub_cfg" ~ ("_uefi" if variant == "uefi" else "") -%}}
+  <ind:textfilecontent54_test id="test_{{{ name }}}"
+  comment="Check {{{ path }}} for {{{ ARG_NAME_VALUE }}}"
   check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_{{{ base_name }}}" />
+    <ind:object object_ref="obj_{{{ name }}}" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_{{{ base_name }}}"
-  version="1">
+  {{# Collect kernel command line from vmlinuz lines in grub.cfg.
+       Captures from "root=" onwards, which includes all kernel args.
+       Each vmlinuz line corresponds to one boot entry. #}}
+  <ind:textfilecontent54_object id="obj_{{{ name }}}" version="1"
+  comment="Collect kernel command line from {{{ path }}}">
     <ind:filepath>{{{ path }}}</ind:filepath>
-    {{% if product in ["ol7"] or 'ubuntu' in product %}}
-      <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
-    {{% else %}}
-      <ind:pattern operation="pattern match">^set default_kernelopts=(.*)$</ind:pattern>
-    {{% endif %}}
+    {{# regex: ^.*/vmlinuz.*(root=.*)$  -- captures from "root=" onwards on vmlinuz lines (OL7, Ubuntu) #}}
+    <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endmacro %}}
+  {{%- endmacro %}}
 
-{{{ test_and_object_for_kernel_options_grub_cfg("grub2_" + SANITIZED_ARG_NAME + "_argument_grub_cfg", grub2_boot_path ~ "/grub.cfg") }}}
-{{% if system_with_bios_and_uefi_support -%}}
-{{{ test_and_object_for_kernel_options_grub_cfg("grub2_" + SANITIZED_ARG_NAME + "_argument_grub_cfg_uefi", grub2_uefi_boot_path ~ "/grub.cfg") }}}
-{{%- endif %}}
+  {{{ test_and_object_for_grub_cfg("bios", grub2_boot_path ~ "/grub.cfg") }}}
+  {{%- if has_separate_bios_and_uefi -%}}
+    {{{- test_and_object_for_grub_cfg("uefi", grub2_uefi_boot_path ~ "/grub.cfg") }}}
+  {{%- endif %}}
 {{%- endif %}}
 
-{{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts"
-  version="1">
+{{% if check_boot_loader_entries_or_grubenv %}}
+  {{# Match "$kernelopts" as a whole word in the captured "options" line.
+       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
+       $kernelopts is a grub env variable expanded at boot time from grubenv. #}}
+  {{# regex: ^(?:.*\s)?\$kernelopts(?:\s.*)?$  -- checks if $kernelopts appears as a word in the options line (RHEL 8 indirection) #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?\$kernelopts(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
 {{% endif %}}
 
-{{% if not ARG_VARIABLE %}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
-  version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
-  </ind:textfilecontent54_state>
-{{% else %}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
-  version="1">
+{{# Match {{{ ARG_NAME_VALUE }}} as a whole word in the captured options/kernelopts/cmdline line.
+     Shared by ALL grub-location tests (except bootc kargs.d which has its own state).
+     If ARG_VARIABLE is set, the regex is built at scan time from an XCCDF variable.
+     Otherwise, the expected value is hardcoded into the regex at build time.
+     NOTE: in the rewrite, this entire state + local_variable goes away --
+           objects will extract just the value, and the state will use operation+datatype natively. #}}
+{{% if ARG_VARIABLE %}}
+  {{# Value comes from XCCDF variable {{{ ARG_VARIABLE }}} -- regex built at scan time. #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
+    {{# regex built at scan time via local_variable concat -- checks "arg=<XCCDF_VALUE>" as a word in the line #}}
     <ind:subexpression datatype="string" operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}" />
   </ind:textfilecontent54_state>
 
+  {{# Build regex: ^(?:.*\s)?{ARG_NAME}=<XCCDF_VALUE>(?:\s.*)?$
+       Matches arg=value as a whole word. IS_SUBSTRING wraps value with \S* (partial match). #}}
   <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}"
-  comment="Regex that matches {{{ ARG_NAME }}} with value {{{ ARG_VARIABLE }}}"
+  comment="Build regex to match {{{ ARG_NAME }}}={{{ ARG_VARIABLE }}} as a whole word"
   datatype="string" version="1">
     <concat>
       <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
@@ -314,31 +592,48 @@
     </concat>
   </local_variable>
 
-  <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
+  {{# Expected value of {{{ ARG_NAME }}}, provided by XCCDF benchmark at scan time. #}}
+  <external_variable comment="Expect {{{ ARG_NAME }}} value from XCCDF variable {{{ ARG_VARIABLE }}}" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
+{{% else %}}
+  {{# Expected value hardcoded at build time: {{{ ESCAPED_ARG_NAME_VALUE }}} #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
+    {{# regex: ^(?:.*\s)?{ARG_NAME_VALUE}(?:\s.*)?$  -- checks "arg=value" appears as a whole word in the full options line #}}
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
 {{% endif %}}
 
-{{% if bootable_containers_supported == "true" %}}
+{{# Bootc / RHEL Image Mode: kernel args live in /usr/lib/bootc/kargs.d/*.toml instead of grub. #}}
+{{%- if bootable_containers_supported == "true" %}}
+  {{# Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}} in the kargs array.
+       Platforms: RHEL 9+, RHEL 10 with bootc support (bootable_containers_supported)
+       Passes if at least one .toml file has it (check="at least one").
+       Has its own state (not shared) because TOML wraps values in quotes. #}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
-                              comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
+                              comment="Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}}"
                               check="at least one" check_existence="at_least_one_exists" version="1">
-    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
+    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
+  {{# Collect kargs array from /usr/lib/bootc/kargs.d/*.toml.
+       Captures everything between the square brackets: kargs = ["arg=val", "arg2=val2"] #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1"
+  comment="Collect kargs array from /usr/lib/bootc/kargs.d/*.toml">
     <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
     <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
+    {{# regex: ^kargs = \[([^\]]+)\]$  -- captures contents of the TOML kargs array, e.g. "arg=val", "arg2=val2" #}}
     <ind:pattern operation="pattern match">^kargs = \[([^\]]+)\]$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{% if not ARG_VARIABLE %}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
-    <ind:subexpression operation="pattern match">^.*"{{{ ESCAPED_ARG_NAME_VALUE }}}".*$</ind:subexpression>
-  </ind:textfilecontent54_state>
-{{% else %}}
+  {{# Match {{{ ARG_NAME_VALUE }}} as a quoted string in the TOML kargs array (e.g. "arg=val").
+       Separate from state_argument because TOML wraps values in double quotes.
+       Same ARG_VARIABLE / hardcoded split as state_argument. #}}
+  {{%- if ARG_VARIABLE %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
     <ind:subexpression operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs" />
   </ind:textfilecontent54_state>
 
+  {{# Build regex: ^.*"{ARG_NAME}=<XCCDF_VALUE>".*$
+       Matches "arg=value" as a quoted string in TOML. IS_SUBSTRING wraps value with \S*. #}}
   <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs"
   comment="Regex that matches {{{ ARG_NAME }}} with value {{{ ARG_VARIABLE }}}"
   datatype="string" version="1">
@@ -355,8 +650,14 @@
     </concat>
   </local_variable>
 
-  <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
-{{% endif %}}
+  {{# Expected value of {{{ ARG_NAME }}}, same XCCDF variable as above. #}}
+  <external_variable comment="Expect {{{ ARG_NAME }}} value from XCCDF variable {{{ ARG_VARIABLE }}}" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
+  {{%- else %}}
+  {{# Expected value hardcoded at build time, with surrounding quotes for TOML format. #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
+    <ind:subexpression operation="pattern match">^.*"{{{ ESCAPED_ARG_NAME_VALUE }}}".*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+  {{%- endif %}}
 {{% endif %}}
 
 </def-group>

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -86,20 +86,6 @@
       Only relevant when `BLS` entries use `$kernelopts` on their `options` line
       instead of listing kernel args directly.
 
-  `$kernelopts`  (RHEL 8 / OL8 only, `/boot/loader/entries/*.conf` only)
-      `grub` can store named variables in `/boot/grub2/grubenv` (a `key=value` file on disk).
-      A `/boot/loader/entries/*.conf` file can reference a variable with `$name` on its
-      `options` line, and `grub` substitutes the stored value at boot time -- similar to
-      shell variable expansion.
-      On RHEL 8, the variable `$kernelopts` holds the kernel args. So a
-      `/boot/loader/entries/*.conf` file might say:
-        options $kernelopts
-      and `grub` replaces `$kernelopts` with the `kernelopts=...` value from
-      `/boot/grub2/grubenv`.
-      On RHEL 9+, this indirection no longer exists -- args are always listed directly.
-      This mechanism only exists in BLS entries (`/boot/loader/entries/*.conf`). Legacy
-      `grub.cfg` on OL7/Ubuntu does not use `$kernelopts`.
-
   PRECEDENCE (what overrides what):
 
       `/etc/default/grub` is the persistent source -- survives `grub2-mkconfig` regeneration.
@@ -107,7 +93,7 @@
         `$kernelopts` expansion, but does not survive regeneration.
       `/boot/loader/entries/*.conf` `options` line (BLS) or `/boot/grub2/grub.cfg`
         `linux /vmlinuz...` line (legacy) is what the kernel actually boots with.
-      `/usr/lib/bootc/kargs.d/*.toml` (in RHEL Image mode (ootc)) replaces everything above.
+      `/usr/lib/bootc/kargs.d/*.toml` (in RHEL Image mode (bootc)) replaces everything above.
 
       The OVAL check verifies ALL layers because:
         - If only `/etc/default/grub` is correct but boot entries are wrong, the system

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -1,296 +1,429 @@
 {{#-
-  grub2_bootloader_argument OVAL template
+  `grub2_bootloader_argument` `OVAL` template
   ========================================
 
-  Checks that a kernel boot argument (e.g. audit=1) is set across all
-  relevant grub configuration files for the given product.
+  Checks that a kernel boot argument (e.g. `audit=1`) is set across all
+  relevant `grub` configuration files for the given product.
 
   LOCATIONS WHERE KERNEL ARGS LIVE (per product):
   ================================================
 
-  Product         Boot entries                       Persistent config        Other
-  --------------- ---------------------------------- ------------------------ ---------------------------
-  RHEL 9+, Fedora /boot/loader/entries/*.conf        /etc/default/grub        (bootc: kargs.d/*.toml)
-                  (args inline on "options" line)
-  RHEL 8, OL8     /boot/loader/entries/*.conf        /etc/default/grub
-                  (args inline OR via $kernelopts)
-                  + /boot/grub2/grubenv (kernelopts=)
-  OL7             /boot/grub2/grub.cfg (vmlinuz)     /etc/default/grub
-  Ubuntu          /boot/grub2/grub.cfg (vmlinuz)     /etc/default/grub        /etc/default/grub.d/*.cfg
+  [VISUAL TABLE: products vs. config file locations, aligned in columns.]
+
+  Product         Flags                              Boot entries                       Persistent config        Other
+  --------------- ---------------------------------- ---------------------------------- ------------------------ ---------------------------
+  RHEL 9+, Fedora `uses_boot_loader_entries`        `/boot/loader/entries/*.conf`       `/etc/default/grub`     (`bootc`: `/usr/lib/bootc/kargs.d/*.toml`)
+                                                     (args on `options` line)
+  RHEL 8, OL8     `uses_boot_loader_entries`        `/boot/loader/entries/*.conf`       `/etc/default/grub`
+                  `uses_kernelopts`                   (args on `options` line or via
+                                                     `$kernelopts` from `grubenv`)
+                                                     + `/boot/grub2/grubenv`
+  OL7             `uses_grub_cfg`                    `/boot/grub2/grub.cfg`              `/etc/default/grub`
+                                                     (args on `vmlinuz` lines)
+  Ubuntu          `uses_grub_cfg`                    `/boot/grub/grub.cfg`               `/etc/default/grub`     `/etc/default/grub.d/*.cfg`
+                  `uses_etc_default_grub_d`          (args on `vmlinuz` lines)
+
+  LONG DESCRIPTION (text equivalent of the table):
+
+    RHEL 9+, Fedora:
+      Flags: `uses_boot_loader_entries`
+      Boot entries: `/boot/loader/entries/*.conf` (args on `options` line)
+      Persistent config: `/etc/default/grub`
+      Other: `bootc` systems use `/usr/lib/bootc/kargs.d/*.toml` instead
+
+    RHEL 8, OL8:
+      Flags: `uses_boot_loader_entries`, `uses_kernelopts`
+      Boot entries: `/boot/loader/entries/*.conf` (args on `options` line or via
+        `$kernelopts` indirection from `/boot/grub2/grubenv`)
+      Persistent config: `/etc/default/grub`
+
+    OL7:
+      Flags: `uses_grub_cfg`
+      Boot entries: `/boot/grub2/grub.cfg` (args on `vmlinuz` lines)
+      Persistent config: `/etc/default/grub`
+
+    Ubuntu:
+      Flags: `uses_grub_cfg`, `uses_etc_default_grub_d`
+      Boot entries: `/boot/grub/grub.cfg` (args on `vmlinuz` lines)
+      Persistent config: `/etc/default/grub`
+      Other: `/etc/default/grub.d/*.cfg` (drop-in config files)
 
   WHAT THIS TEMPLATE DOES:
   ========================
 
-  Kernel boot arguments (e.g. audit=1, pti=on, audit_backlog_limit=8192) are
-  settings passed to the Linux kernel at boot time via the bootloader (grub2).
+  Kernel boot arguments (e.g. `audit=1`, `pti=on`, `audit_backlog_limit=8192`) are
+  settings passed to the Linux kernel at boot time via the bootloader (`grub2`).
   Security policies require certain arguments to be set so the kernel enables
-  specific security features (auditing, memory protections, CPU mitigations, etc).
+  specific security features (auditing, memory protections, CPU mitigations, etc.).
 
-  The problem is that grub2 stores these arguments in DIFFERENT files depending
-  on the OS version and platform. This template generates an OVAL check that
-  verifies the argument is present in ALL the right places for the given product.
+  The problem is that `grub2` stores these arguments in different files depending
+  on the OS version and platform. This template generates an `OVAL` check that
+  verifies the argument is present in all the right places for the given product.
 
   KEY CONCEPTS:
   =============
 
   --- Boot entries (what the system actually boots) ---
 
-  /boot/loader/entries/*.conf  (BLS = Boot Loader Specification entries)
-      One .conf file per installed kernel. Each has an "options" line with kernel args.
-      RHEL 9+/Fedora: args are always inline on the options line.
-      RHEL 8/OL8:     args can be inline OR the entry can say "$kernelopts",
-                       which grub expands from /boot/grub2/grubenv at boot time.
+  `/boot/loader/entries/*.conf`  (`BLS` = Boot Loader Specification entries)
+      `BLS` is a freedesktop.org standard: instead of one monolithic `grub.cfg` listing all
+      kernels, each installed kernel gets its own small `.conf` file with key-value lines
+      (`title`, `linux`, `initrd`, `options`), e.g.:
+        title Red Hat Enterprise Linux 9.3
+        linux /vmlinuz-5.14.0-362.el9.x86_64
+        initrd /initramfs-5.14.0-362.el9.x86_64.img
+        options root=/dev/mapper/rhel-root ro audit=1 pti=on
+      The `options` line is a space-separated list of kernel boot arguments passed
+      to the kernel at boot time. This is the line this template checks.
+      RHEL 9+/Fedora: kernel args are listed directly on the `options` line.
+      RHEL 8/OL8:     kernel args are listed directly on the `options` line,
+                       OR the `options` line contains `$kernelopts` -- a `grub` variable
+                       that `grub` expands from `/boot/grub2/grubenv` at boot time.
 
-  /boot/grub2/grubenv  (RHEL 8 / OL8 only)
-      grub environment file. Contains "kernelopts=..." with the actual kernel args.
-      Only relevant when boot entries reference $kernelopts instead of listing args inline.
+  `/boot/grub2/grubenv`  (RHEL 8 / OL8 only)
+      Grub environment file. Contains a line like:
+        kernelopts=root=/dev/mapper/rhel-root ro audit=1 pti=on
+      Only relevant when `BLS` entries use `$kernelopts` on their `options` line
+      instead of listing kernel args directly.
 
-  $kernelopts  (RHEL 8 / OL8 only)
-      A grub environment variable. Boot entries can say "$kernelopts" on their options
-      line instead of listing args inline. grub expands it from grubenv at boot time.
-      On RHEL 9+ this indirection no longer exists -- args are always inline.
+  `$kernelopts`  (RHEL 8 / OL8 only, `/boot/loader/entries/*.conf` only)
+      `grub` can store named variables in `/boot/grub2/grubenv` (a `key=value` file on disk).
+      A `/boot/loader/entries/*.conf` file can reference a variable with `$name` on its
+      `options` line, and `grub` substitutes the stored value at boot time -- similar to
+      shell variable expansion.
+      On RHEL 8, the variable `$kernelopts` holds the kernel args. So a
+      `/boot/loader/entries/*.conf` file might say:
+        options $kernelopts
+      and `grub` replaces `$kernelopts` with the `kernelopts=...` value from
+      `/boot/grub2/grubenv`.
+      On RHEL 9+, this indirection no longer exists -- args are always listed directly.
+      This mechanism only exists in BLS entries (`/boot/loader/entries/*.conf`). Legacy
+      `grub.cfg` on OL7/Ubuntu does not use `$kernelopts`.
 
-  /boot/grub2/grub.cfg  (OL7, Ubuntu only)
-      Generated grub config. Contains "linux /vmlinuz-... root=... arg=val ..." lines.
-      These platforms dont use BLS entries -- grub.cfg IS the boot config.
+  PRECEDENCE (what overrides what):
 
-  --- Persistent config (survives grub2-mkconfig regeneration) ---
+      `/etc/default/grub` is the persistent source -- survives `grub2-mkconfig` regeneration.
+      `/boot/grub2/grubenv` (RHEL 8) is intermediate -- affects the current boot via
+        `$kernelopts` expansion, but does not survive regeneration.
+      `/boot/loader/entries/*.conf` `options` line (BLS) or `/boot/grub2/grub.cfg`
+        `linux /vmlinuz...` line (legacy) is what the kernel actually boots with.
+      `/usr/lib/bootc/kargs.d/*.toml` (in RHEL Image mode (ootc)) replaces everything above.
 
-  /etc/default/grub  (all products)
-      Persistent grub configuration. grub2-mkconfig reads this file and bakes the
-      values into grub.cfg or boot entries. Contains two relevant variables:
-        GRUB_CMDLINE_LINUX="..."          -- args passed to ALL boot entries
-        GRUB_CMDLINE_LINUX_DEFAULT="..."  -- args passed to non-recovery entries ONLY
-      If GRUB_DISABLE_RECOVERY=true is also set, there are no recovery entries,
-      so _DEFAULT effectively applies to all entries too.
+      The OVAL check verifies ALL layers because:
+        - If only `/etc/default/grub` is correct but boot entries are wrong, the system
+          is vulnerable .
+        - If only boot entries are correct but `/etc/default/grub` is wrong, the next
+          kernel update or `grub2-mkconfig` regeneration will break it.
 
-  /etc/default/grub.d/*.cfg  (Ubuntu only)
-      Drop-in override files for /etc/default/grub. Same variables, same semantics.
-      Checked in addition to /etc/default/grub on Ubuntu.
+  `/boot/grub2/grub.cfg`  (exists on all platforms, but content differs)
+      Generated by `grub2-mkconfig` from `/etc/default/grub`.
+      On OL7 and Ubuntu (non-`BLS` platforms), `grub.cfg` contains the actual kernel
+      boot lines with one `linux /vmlinuz-...` line per installed kernel, e.g.:
+        linux /vmlinuz-5.4.0-150-generic root=/dev/mapper/ubuntu-root ro audit=1
+      This template checks these `vmlinuz` lines for the required kernel argument.
+      On `BLS` platforms (RHEL 8+, Fedora), `grub.cfg` just contains a `blscfg`
+      directive that tells `grub` to load `BLS` entries from `/boot/loader/entries/`.
+      The kernel args are NOT in `grub.cfg` -- so this template does not check it.
 
-  --- bootc / RHEL Image Mode ---
+  --- Persistent config (survives `grub2-mkconfig` regeneration) ---
 
-  bootc (RHEL Image Mode) is a way to run RHEL as an immutable container-based OS.
-  The root filesystem is a container image. There is no traditional grub config --
-  the bootloader is managed by bootc itself. Kernel args are defined in TOML files
+  `/etc/default/grub`  (all products)
+      Persistent `grub` configuration. When `grub2-mkconfig` runs (e.g. after kernel
+      install or `grub` update), it reads this file and writes the values into `grub.cfg`
+      or `BLS` boot entries. Contains two relevant shell variables:
+        GRUB_CMDLINE_LINUX="audit=1 pti=on"          -- args added to ALL boot entries
+        GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"     -- args added to non-recovery entries ONLY
+      If `GRUB_DISABLE_RECOVERY=true` is also set, there are no recovery entries,
+      so `_DEFAULT` effectively applies to all entries too.
+
+  `/etc/default/grub.d/*.cfg`  (Ubuntu only)
+      Drop-in config files that supplement `/etc/default/grub`. Can also set
+      `GRUB_CMDLINE_LINUX` and `GRUB_CMDLINE_LINUX_DEFAULT`. `grub2-mkconfig`
+      reads these in addition to `/etc/default/grub`.
+
+  --- `bootc` / RHEL Image Mode ---
+
+  `bootc` (RHEL Image Mode) is a way to run RHEL as an immutable container-based OS.
+  The root filesystem is a container image. There is no traditional `grub` config --
+  the bootloader is managed by `bootc` itself. Kernel args are defined in `TOML` files
   shipped inside the image.
 
-  /usr/lib/bootc/kargs.d/*.toml
-      TOML files with kargs = ["arg=val", "arg2=val2"].
-      On bootc systems, grub files (/boot/loader/entries, grubenv, grub.cfg, etc.)
+  `/usr/lib/bootc/kargs.d/*.toml`
+      `TOML` files with `kargs = ["arg=val", "arg2=val2"]`.
+      On `bootc` systems, `grub` files (`/boot/loader/entries`, `grubenv`, `grub.cfg`, etc.)
       do NOT exist. Kernel args live here instead.
-      The OVAL definition has two mutually exclusive branches: one for bootc systems
-      (checks kargs.d) and one for normal grub systems (checks grub files).
+      The `OVAL` definition has two mutually exclusive branches: one for `bootc` systems
+      (checks `/usr/lib/bootc/kargs.d/*.toml`) and one for normal `grub` systems (checks `grub` files).
 
   CRITERIA TREE (what must pass for the definition to be compliant):
   ==================================================================
 
-  definition (OR)
+  Products that support both Image Mode (`bootc`) and normal `grub` (e.g. RHEL 9+, RHEL 10)
+  emit BOTH branches. `oscap` evaluates both, but only one can pass -- the guards
+  (`IS bootc` / `NOT bootc`) ensure the wrong branch always fails.
+  Products without `bootc` support emit only the normal `grub` branch.
+
+  [VISUAL TREE: indented AND/OR hierarchy showing the two branches (Image Mode vs.
+  normal grub) and all sub-checks within the normal grub branch.]
+
+  definition (OR) -- passes if EITHER branch matches the system
   |
-  +-- [bootc] AND
-  |   +-- extend_definition: IS bootc
-  |   +-- test: kargs.d/*.toml has arg=value
+  +-- [Image Mode] AND (bootable_containers_supported)
+  |   +-- extend_definition: system IS `bootc`
+  |   +-- test: `/usr/lib/bootc/kargs.d/*.toml` has arg=value
   |
   +-- [normal grub] AND
-      +-- extend_definition: NOT bootc (if bootc supported)
+      +-- extend_definition: system is NOT `bootc` (bootable_containers_supported)
       |
-      +-- [RHEL 8 / OL8] entries check:
-      |   +-- test: EACH /boot/loader/entries/*.conf has arg=value inline OR $kernelopts
+      +-- [RHEL 8 / OL8] `/boot/loader/entries/*.conf` check (uses_kernelopts):
+      |   +-- test: EACH `/boot/loader/entries/*.conf` has arg=value on `options` line
+      |   |         OR contains `$kernelopts`
       |   +-- (OR)
-      |       +-- NO entry uses $kernelopts (skip grubenv)
-      |       +-- grubenv has arg=value (BIOS or UEFI path)
+      |       +-- NO `/boot/loader/entries/*.conf` uses `$kernelopts` (skip `/boot/grub2/grubenv`)
+      |       +-- `/boot/grub2/grubenv` has arg=value (BIOS or UEFI path)
       |
-      +-- [RHEL 9+ / Fedora] entries check:
-      |   +-- test: EACH /boot/loader/entries/*.conf has arg=value inline
+      +-- [RHEL 9+ / Fedora] `/boot/loader/entries/*.conf` check (uses_boot_loader_entries, !uses_kernelopts):
+      |   +-- test: EACH `/boot/loader/entries/*.conf` has arg=value on `options` line
       |
-      +-- [OL7 / Ubuntu] grub.cfg check:
-      |   +-- (OR) grub.cfg has arg=value (BIOS or UEFI path)
+      +-- [OL7 / Ubuntu] `/boot/grub2/grub.cfg` or `/boot/grub/grub.cfg` check (uses_grub_cfg):
+      |   +-- (OR) BIOS or UEFI path has arg=value
       |
-      +-- [all products] /etc/default/grub check:
+      +-- [all products] `/etc/default/grub` check:
           +-- (OR)
-              +-- GRUB_CMDLINE_LINUX has arg=value
-              |   (+ grub.d drop-in on Ubuntu)
+              +-- `GRUB_CMDLINE_LINUX` in `/etc/default/grub` has arg=value
+              |   (+ `/etc/default/grub.d/*.cfg` drop-in on Ubuntu)
               +-- AND
-                  +-- GRUB_CMDLINE_LINUX_DEFAULT has arg=value
-                  |   (+ grub.d drop-in on Ubuntu)
-                  +-- GRUB_DISABLE_RECOVERY=true
+                  +-- `GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub` has arg=value
+                  |   (+ `/etc/default/grub.d/*.cfg` drop-in on Ubuntu)
+                  +-- `GRUB_DISABLE_RECOVERY=true` in `/etc/default/grub`
 
-  DATA FLOW (current -- will change in the rewrite):
-  ====================================================
+  LONG DESCRIPTION (text equivalent of the criteria tree):
 
-  Currently, objects extract the FULL options/cmdline line, and the shared
-  state uses a regex to check if arg=value appears as a word in that line.
-  This means all comparisons are "pattern match" on "string" datatype.
+    The definition passes (compliant) if EITHER of two branches is true:
 
-       Object (extracts full line)          State (regex checks arg=value in line)
-       ┌─────────────────────────┐         ┌────────────────────────────────────┐
-       │ /boot/loader/entries/   │         │ subexpression ~ "pattern match"    │
-       │   ^options (.*)$        │────────>│ ^(?:.*\s)?arg=value(?:\s.*)?$     │
-       │                         │         │                                    │
-       │ /boot/grub2/grubenv    │         │ (same state, shared by all tests)  │
-       │   ^kernelopts=(.*)$     │────────>│                                    │
-       │                         │         └────────────────────────────────────┘
-       │ /etc/default/grub       │                        │
-       │   ^GRUB_CMDLINE_LINUX=  │────────────────────────┘
-       │     "(.*)"$             │
-       └─────────────────────────┘
+    Branch 1 -- Image Mode (only emitted when `bootable_containers_supported`):
+      Both must be true:
+        - The system IS a `bootc` deployment.
+        - `/usr/lib/bootc/kargs.d/*.toml` contains `arg=value`.
 
-  TARGET (after rewrite -- sysctl-style extract-then-compare):
+    Branch 2 -- normal grub:
+      All of the following must be true:
+        - The system is NOT a `bootc` deployment (guard; only when `bootable_containers_supported`).
+        - [RHEL 8 / OL8, `uses_kernelopts`]:
+            EACH `/boot/loader/entries/*.conf` (excluding rescue) has `arg=value`
+            on its `options` line, OR contains `$kernelopts`.
+            AND EITHER no `/boot/loader/entries/*.conf` references `$kernelopts`
+            (so `/boot/grub2/grubenv` is irrelevant),
+            OR `/boot/grub2/grubenv` contains `arg=value`.
+        - [RHEL 9+ / Fedora, `uses_boot_loader_entries` without `uses_kernelopts`]:
+            EACH `/boot/loader/entries/*.conf` (excluding rescue) has `arg=value`
+            on its `options` line.
+        - [OL7 / Ubuntu, `uses_grub_cfg`]:
+            `/boot/grub2/grub.cfg` or `/boot/grub/grub.cfg` has `arg=value`
+            (BIOS path, or UEFI path if separate).
+        - [all products]:
+            EITHER `GRUB_CMDLINE_LINUX` in `/etc/default/grub` has `arg=value`
+              (plus `/etc/default/grub.d/*.cfg` drop-in on Ubuntu),
+            OR BOTH `GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub` has `arg=value`
+              (plus `/etc/default/grub.d/*.cfg` drop-in on Ubuntu)
+              AND `GRUB_DISABLE_RECOVERY=true` in `/etc/default/grub`.
 
-       Object (extracts JUST the value)    State (native OVAL comparison)
-       ┌─────────────────────────┐         ┌────────────────────────────────────┐
-       │ /boot/loader/entries/   │         │ subexpression                      │
-       │   ^options.*arg=(\S+)   │────────>│   operation="equals"               │
-       │                         │         │   datatype="int"                   │
-       │ /boot/grub2/grubenv    │         │   value=8192                       │
-       │   ^kernelopts.*arg=     │────────>│                                    │
-       │     (\S+)               │         │ (same state, shared by all tests)  │
-       │                         │         └────────────────────────────────────┘
-       │ /etc/default/grub       │                        │
-       │   ^GRUB_CMDLINE_LINUX=  │────────────────────────┘
-       │     ".*arg=(\S+).*"$    │
-       └─────────────────────────┘
+    Only the sub-checks relevant to the product (controlled by `uses_*` flags) are emitted.
+    Branches 1 and 2 are mutually exclusive at runtime due to the `IS bootc` / `NOT bootc` guards.
 
-  The check_* flags below control which locations are verified per product.
+  DATA FLOW:
+  ==========
+
+  Each object extracts ONLY THE ARGUMENT VALUE via a capturing group.
+  Each state compares that value using OVAL-native operation and datatype
+  (equals, greater than or equal, pattern match; string or int).
+  No local_variable, no concat, no runtime regex assembly.
+  All grub-location tests share one state; bootc shares it too (value
+  extracted from TOML quotes in the object pattern).
+
+  Exception: the RHEL 8 coverage path still captures the full options
+  line and checks for the argument name via pattern match (needed to
+  verify coverage across entries that may use $kernelopts).
+
+  OBJECTS -- each extracts the value after {ARG_NAME}= from a config file:
+
+    A. /boot/loader/entries/*.conf (RHEL 8/9/10, Fedora, OL8/9)
+       Pattern: ^options\s+(?:.*\s)?{ARG_NAME}=(\S+)
+       Captures: just the value (e.g. 8192)
+
+    B. {grub2_boot_path}/grubenv (RHEL 8, OL8)
+       Pattern: ^kernelopts=(?:.*\s)?{ARG_NAME}=(\S+)
+       Captures: just the value
+
+    C. {grub2_boot_path}/grub.cfg (OL7, Ubuntu)
+       Pattern: ^.*/vmlinuz.*\s{ARG_NAME}=(\S+)
+       Captures: just the value
+
+    D. /etc/default/grub (all products)
+       Pattern: ^\s*GRUB_CMDLINE_LINUX="(?:.*\s)?{ARG_NAME}=([^\s"]+)
+       Captures: just the value (stops at whitespace or closing quote)
+
+    E. /etc/default/grub.d/*.cfg (Ubuntu)
+       Same patterns as D.
+
+    F. /usr/lib/bootc/kargs.d/*.toml (RHEL 9+, RHEL 10 — bootc)
+       Pattern: ^kargs\s*=\s*\[.*"{ARG_NAME}=([^"]+)".*\]$
+       Captures: just the value (from within TOML quotes)
+
+  For no-value arguments (e.g. nousb), patterns check presence only
+  (no capturing group, no state).
+
+  STATES -- compare the captured value:
+
+    1. state_grub2_{ARG}_argument (shared by all objects)
+       Uses operation and datatype from rule.yml.
+       arg_value rules: literal comparison (e.g. equals "1")
+       arg_variable rules: var_ref to XCCDF variable (resolved at scan time)
+
+    2. state_grub2_{ARG}_argument_is_kernelopts (RHEL 8, OL8 only)
+       Pattern match: checks if $kernelopts appears in the full options line.
+       Used by the RHEL 8 coverage test with state_operator="OR".
+
+  The uses_* flags control which locations are verified per product.
 -#}}
 
-{{% set check_boot_loader_entries              = product in ["fedora", "ol9", "rhel9", "rhel10"] %}}
-{{% set check_boot_loader_entries_or_grubenv   = product in ["ol8", "rhel8"] %}}
-{{% set check_etc_default_grub                 = true %}}
-{{% set check_etc_default_grub_d               = 'ubuntu' in product %}}
-{{% set check_grub_cfg                         = product in ["ol7"] or 'ubuntu' in product %}}
-{{% set has_separate_bios_and_uefi             = grub2_uefi_boot_path and grub2_uefi_boot_path != grub2_boot_path %}}
+{{% set uses_boot_loader_entries   = product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhel10"] %}}
+{{% set uses_kernelopts            = product in ["ol8", "rhel8"] %}}
+{{% set uses_etc_default_grub_d    = 'ubuntu' in product %}}
+{{% set uses_grub_cfg              = product in ["ol7"] or 'ubuntu' in product %}}
+{{% set has_separate_bios_and_uefi = grub2_uefi_boot_path and grub2_uefi_boot_path != grub2_boot_path %}}
+{{% set has_value                  = ARG_VALUE or ARG_VARIABLE %}}
 
-{{# DEFINITION: {{{ _RULE_ID }}}
-     Class: compliance
-     Purpose: ensure the kernel boot argument {{{ ARG_NAME_VALUE }}} is set in all
-              relevant grub configuration files for this product.
-     Top-level OR: bootc branch vs normal grub branch.
-     Only one branch can be true at runtime (bootc XOR normal grub).
-     See the ASCII art criteria tree at the top of this file for the full picture. #}}
+{{# DEFINITION: `{{{ _RULE_ID }}}`
+     Ensure the kernel boot argument {{{ ARG_NAME_VALUE }}} is set in all
+     relevant `grub` configuration files for this product.
+     See the ASCII-art criteria tree at the top of this file for the full picture. #}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is set as a kernel boot argument.", rule_title=rule_title) }}}
     <criteria operator="OR">
 
       {{%- if bootable_containers_supported == "true" %}}
-      {{# CRITERIA BRANCH: bootc / RHEL Image Mode
-           Platforms: RHEL 9+, RHEL 10 with bootc support (bootable_containers_supported)
-           The system must be bootc AND kargs.d/*.toml must contain {{{ ARG_NAME_VALUE }}}.
-           On non-bootc systems, the extend_definition fails and this whole branch is skipped. #}}
+      {{# `bootc` / RHEL Image Mode systems
+           System must be `bootc` AND `/usr/lib/bootc/kargs.d/*.toml` must contain {{{ ARG_NAME_VALUE }}}.
+           On non-`bootc` systems the `extend_definition` fails and this branch is skipped. #}}
       <criteria operator="AND">
         <extend_definition comment="Verify system is in RHEL Image Mode (bootc)" definition_ref="bootc" />
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
+        <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_usr_lib_bootc_kargs_d"
                    comment="Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}}" />
       </criteria>
       {{%- endif %}}
 
-      {{# CRITERIA BRANCH: normal grub (non-bootc)
-           Platforms: all products
-           All sub-checks must pass: bootc guard, boot entries, and /etc/default/grub.
-           The specific sub-checks emitted depend on the check_* flags set per product. #}}
+      {{# Non-`bootc` systems (normal `grub` configuration) #}}
       <criteria operator="AND">
 
         {{%- if bootable_containers_supported == "true" %}}
-        {{# EXTEND_DEFINITION: NOT bootc guard
-             Platforms: RHEL 9+, RHEL 10 with bootc support (bootable_containers_supported)
-             Fails this "normal grub" branch on bootc systems where grub files do not exist.
-             negate="true" -- passes only if the system is NOT bootc. #}}
+        {{# Guard: passes only if the system is NOT `bootc` (negate is true).
+            On `bootc` systems the negated `extend_definition` fails and this branch is skipped.
+            Without this, `bootc` systems would fail sub-checks because `grub` files do not exist. #}}
         <extend_definition comment="Verify system is NOT in RHEL Image Mode (bootc)" definition_ref="bootc" negate="true" />
         {{%- endif %}}
 
-        {{%- if check_boot_loader_entries_or_grubenv %}}
-        {{# CRITERIA BRANCH: RHEL 8 / OL8 boot loader entries + $kernelopts + grubenv
-             Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
-             Two-part check:
-               1. EACH /boot/loader/entries/*.conf (omit rescue) has {{{ ARG_NAME_VALUE }}}
-                  inline on the options line OR contains $kernelopts.
-               2. If any entry uses $kernelopts, then grubenv must also have {{{ ARG_NAME_VALUE }}}.
-             The $kernelopts indirection is an RHEL 8 mechanism: entries say "$kernelopts" and
-             grub expands it from /boot/grub2/grubenv at boot time. #}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf"
-                   comment="Check each /boot/loader/entries/*.conf for {{{ ARG_NAME_VALUE }}} on options line or $kernelopts reference" />
+        {{%- if uses_kernelopts %}}
+        {{# RHEL 8 / OL8 BLS check — two criteria:
+             1. Every `/boot/loader/entries/*.conf` has {{{ ARG_NAME }}} on the `options` line
+                OR contains `$kernelopts` (coverage — no entry is left unchecked).
+             2. Entries that list {{{ ARG_NAME }}} directly (not via `$kernelopts`) have the
+                correct value (`check_existence=any_exist` — passes when all entries delegate
+                to `$kernelopts` and none have the arg directly). #}}
+        <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_coverage"
+                   comment="Check each /boot/loader/entries/*.conf has {{{ ARG_NAME }}} or $kernelopts" />
+        {{%- if has_value %}}
+        <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_value"
+                   comment="Check /boot/loader/entries/*.conf value of {{{ ARG_NAME }}}" />
+        {{%- endif %}}
 
-        {{# CRITERIA: $kernelopts grubenv gate
-             Passes if no entry uses $kernelopts (all args on options line, grubenv irrelevant)
-             OR grubenv has {{{ ARG_NAME_VALUE }}} (BIOS or UEFI path). #}}
+        {{# `$kernelopts` / `{grub2_boot_path}/grubenv` gate
+             On RHEL 8, `/boot/loader/entries/*.conf` files can either list kernel args directly
+             on the `options` line, or say `$kernelopts` which means: look up the actual args
+             in `{grub2_boot_path}/grubenv` at boot time.
+             If NO `/boot/loader/entries/*.conf` says `$kernelopts`, all args are already on
+             the `options` lines and there is no need to check `{grub2_boot_path}/grubenv`
+             at all (first branch of this `OR` satisfies it).
+             If ANY `/boot/loader/entries/*.conf` says `$kernelopts`, we fall through to the
+             second branch and check that `{grub2_boot_path}/grubenv` contains
+             {{{ ARG_NAME_VALUE }}} (BIOS or UEFI path). #}}
         <criteria operator="OR"
-                  comment="Verify no entry uses $kernelopts, or check grubenv for {{{ ARG_NAME_VALUE }}}">
+                  comment="Verify no /boot/loader/entries/*.conf uses $kernelopts, or check {{{ grub2_boot_path }}}/grubenv for {{{ ARG_NAME_VALUE }}}">
 
-          {{# CRITERION: no $kernelopts in any entry (negated)
-               If no entry uses $kernelopts, all args are on the options line and grubenv is irrelevant. #}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_kernelopts_in_any_boot_loader_entry" negate="true"
-                     comment="Verify no entry references $kernelopts (all args on options line)" />
+          {{# No `$kernelopts` in any `/boot/loader/entries/*.conf` (negated).
+               If no `/boot/loader/entries/*.conf` uses `$kernelopts`, all args are on the `options`
+               line and `{grub2_boot_path}/grubenv` is skipped. #}}
+          <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_kernelopts_in_any_boot_loader_entry" negate="true"
+                     comment="Verify no /boot/loader/entries/*.conf references $kernelopts (all args on options line)" />
 
-          {{# CRITERIA: grubenv has arg=value
-               BIOS: {grub2_boot_path}/grubenv          (e.g. /boot/grub2/grubenv)
-               UEFI: {grub2_uefi_boot_path}/grubenv      (e.g. /boot/efi/EFI/redhat/grubenv)
-               UEFI criterion only emitted when has_separate_bios_and_uefi is true. #}}
+          {{# `{grub2_boot_path}/grubenv` has {{{ ARG_NAME_VALUE }}}.
+               BIOS: `{grub2_boot_path}/grubenv`          (e.g. `/boot/grub2/grubenv`)
+               UEFI: `{grub2_uefi_boot_path}/grubenv`  (e.g. `/boot/efi/EFI/redhat/grubenv`)
+          #}}
           <criteria operator="OR">
-            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grubenv"
+            <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_in_grubenv"
                        comment="Check {{{ grub2_boot_path }}}/grubenv for {{{ ARG_NAME_VALUE }}}" />
           {{%- if has_separate_bios_and_uefi %}}
-            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grubenv_uefi"
+            <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_in_grubenv_uefi"
                        comment="Check {{{ grub2_uefi_boot_path }}}/grubenv for {{{ ARG_NAME_VALUE }}}" />
           {{%- endif %}}
           </criteria>
         </criteria>
         {{%- endif %}}
 
-        {{%- if check_boot_loader_entries %}}
-        {{# CRITERION: RHEL 9+ / Fedora / OL9 boot loader entries
-             Platforms: RHEL 9+, Fedora, OL9 (check_boot_loader_entries)
-             Checks: EACH /boot/loader/entries/*.conf (omit rescue) has {{{ ARG_NAME_VALUE }}}
-                     directly on the options line. No $kernelopts indirection on these platforms. #}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
+        {{%- if uses_boot_loader_entries and not uses_kernelopts %}}
+        {{# RHEL 9+ / Fedora / OL9 boot loader entries
+             Each `/boot/loader/entries/*.conf` (omit rescue) must have {{{ ARG_NAME_VALUE }}} directly
+             on the `options` line. No `$kernelopts` indirection on these platforms. #}}
+        <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries"
                    comment="Check each /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}}" />
         {{%- endif %}}
 
-        {{%- if check_grub_cfg %}}
-        {{# CRITERIA: OL7 / Ubuntu grub.cfg
-             Platforms: OL7, Ubuntu (check_grub_cfg)
-             BIOS: {grub2_boot_path}/grub.cfg          (e.g. /boot/grub2/grub.cfg)
-             UEFI: {grub2_uefi_boot_path}/grub.cfg      (e.g. /boot/efi/EFI/redhat/grub.cfg)
-             UEFI criterion only emitted when has_separate_bios_and_uefi is true. #}}
+        {{%- if uses_grub_cfg %}}
+        {{# OL7 / Ubuntu `{grub2_boot_path}/grub.cfg` (`uses_grub_cfg`)
+             BIOS: `{grub2_boot_path}/grub.cfg`          (e.g. `/boot/grub2/grub.cfg`)
+             UEFI: `{grub2_uefi_boot_path}/grub.cfg`  (e.g. `/boot/efi/EFI/redhat/grub.cfg`)
+             UEFI criterion only emitted when `has_separate_bios_and_uefi` is true. #}}
         <criteria operator="OR">
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grub_cfg"
+          <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_in_grub_cfg"
                       comment="Check {{{ grub2_boot_path }}}/grub.cfg for {{{ ARG_NAME_VALUE }}}" />
           {{%- if has_separate_bios_and_uefi %}}
-          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_in_grub_cfg_uefi"
+          <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_in_grub_cfg_uefi"
                       comment="Check {{{ grub2_uefi_boot_path }}}/grub.cfg for {{{ ARG_NAME_VALUE }}}" />
           {{%- endif %}}
         </criteria>
         {{%- endif %}}
 
-      {{% if check_etc_default_grub %}}
-        {{# CRITERIA: /etc/default/grub persistent configuration
-             Platforms: all (check_etc_default_grub = true)
-             Passes if GRUB_CMDLINE_LINUX has {{{ ARG_NAME_VALUE }}} (applies to all entries),
-             OR GRUB_CMDLINE_LINUX_DEFAULT has it + GRUB_DISABLE_RECOVERY=true.
-             _DEFAULT only covers non-recovery boots, so disabling recovery ensures coverage. #}}
+        {{# `/etc/default/grub` persistent configuration (all products)
+             `GRUB_CMDLINE_LINUX` in `/etc/default/grub` has {{{ ARG_NAME_VALUE }}} (applies to all boot entries),
+             OR `GRUB_CMDLINE_LINUX_DEFAULT` in `/etc/default/grub` has it + `GRUB_DISABLE_RECOVERY=true`.
+             `GRUB_CMDLINE_LINUX_DEFAULT` only covers non-recovery boots, so disabling recovery ensures coverage. #}}
         <criteria operator="OR">
 
-          {{# CRITERIA: GRUB_CMDLINE_LINUX (applies to all entries)
-               Checks /etc/default/grub, plus grub.d drop-ins on Ubuntu. #}}
+          {{# `GRUB_CMDLINE_LINUX` (applies to all boot entries).
+               Checks `/etc/default/grub`, plus `/etc/default/grub.d/*.cfg` drop-ins on Ubuntu. #}}
           <criteria operator="OR">
-            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux"
+            <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_grub_cmdline_linux"
                        comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub for {{{ ARG_NAME_VALUE }}}" />
-          {{% if check_etc_default_grub_d %}}
-            <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d"
+          {{% if uses_etc_default_grub_d %}}
+            <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_grub_cmdline_linux_from_grub_d"
                        comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}" />
           {{% endif %}}
           </criteria>
 
-          {{# CRITERIA: GRUB_CMDLINE_LINUX_DEFAULT + GRUB_DISABLE_RECOVERY=true
-               _DEFAULT only applies to non-recovery entries, so recovery must be disabled
-               to ensure the arg is on ALL boot entries. Checks /etc/default/grub,
-               plus grub.d drop-ins on Ubuntu. #}}
+          {{# `GRUB_CMDLINE_LINUX_DEFAULT` + `GRUB_DISABLE_RECOVERY=true` in `/etc/default/grub`
+
+               `GRUB_CMDLINE_LINUX_DEFAULT` only applies to non-recovery boot entries, so if this variable is used,
+               rescue boot entries have to be disabled with GRUB_DISABLE_RECOVERY=true in `/etc/default/grub`,
+               to ensure the argument ARG_NAME_UNDERSCORED is set for ALL boot entries. 
+               Also checks `/etc/default/grub.d/*.cfg` drop-ins for Ubuntu. #}}
           <criteria operator="AND">
             <criteria operator="OR">
-              <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default"
+              <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_grub_cmdline_linux_default"
                          comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub for {{{ ARG_NAME_VALUE }}}" />
-            {{% if check_etc_default_grub_d %}}
-              <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d"
+            {{% if uses_etc_default_grub_d %}}
+              <criterion test_ref="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_grub_cmdline_linux_default_from_grub_d"
                          comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}" />
             {{% endif %}}
             </criteria>
@@ -298,366 +431,287 @@
                                comment="Verify GRUB_DISABLE_RECOVERY=true in /etc/default/grub" />
           </criteria>
         </criteria>
-      {{% endif %}}
 
       </criteria>
 
     </criteria>
   </definition>
 
-
-
-
-{{# TESTS #}}
-{{% if check_boot_loader_entries_or_grubenv %}}
-  {{# Check that EACH /boot/loader/entries/*.conf (omit rescue) has {{{ ARG_NAME_VALUE }}}
-       on the options line OR references $kernelopts (grub env variable).
-       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
-       Extracts the full "options" line as subexpression.
-       state_operator="OR" because entries may have args on options line or via $kernelopts. #}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf"
-  comment="Check each /boot/loader/entries/*.conf for {{{ ARG_NAME_VALUE }}} on options line or $kernelopts reference"
-  state_operator="OR" check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" />
-  </ind:textfilecontent54_test>
-
-  {{# Collect the "options" line from each /boot/loader/entries/*.conf.
-       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
-       Each .conf file produces one collected item. Rescue entries (*rescue.conf) excluded.
-       Shared by two tests: the arg-or-$kernelopts check and the $kernelopts-presence check. #}}
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf" version="1"
-  comment="Collect options line from each /boot/loader/entries/*.conf (exclude rescue)">
-    <ind:path>/boot/loader/entries/</ind:path>
-    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    {{# regex: ^options (.*)$  -- captures the full space-separated arg list after "options " #}}
-    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    <filter action="exclude">state_grub2_{{{ _RULE_ID }}}_is_rescue_entry</filter>
-  </ind:textfilecontent54_object>
-
-  {{# Exclude filter: matches filenames ending in "rescue.conf".
-       Used by boot entry objects to skip rescue entries -- we only care about normal entries. #}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ _RULE_ID }}}_is_rescue_entry" version="1"
-  comment="Match rescue entry filenames for exclusion">
-    {{# regex: .*rescue\.conf$  -- matches rescue entry filenames to exclude them #}}
-    <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
-  </ind:textfilecontent54_state>
-
-  {{# Check if at least one /boot/loader/entries/*.conf references $kernelopts.
-       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
-       Uses the same object as above. Used negated in criteria: if NO entry has $kernelopts,
-       all args are on the options line and the grubenv check is skipped. #}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_kernelopts_in_any_boot_loader_entry"
-  comment="Check if any /boot/loader/entries/*.conf references $kernelopts"
-  check="all" check_existence="at_least_one_exists" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_options_from_boot_loader_entries_conf" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" />
-  </ind:textfilecontent54_test>
-{{% endif %}}
-
-{{%- if check_etc_default_grub %}}
-  {{# Check GRUB_CMDLINE_LINUX in /etc/default/grub for {{{ ARG_NAME_VALUE }}}.
-       Platforms: all (check_etc_default_grub = true)
-       GRUB_CMDLINE_LINUX is passed to ALL boot entries by grub2-mkconfig. #}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux"
-  comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub for {{{ ARG_NAME_VALUE }}}"
-  check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-  </ind:textfilecontent54_test>
-
-  {{# Collect GRUB_CMDLINE_LINUX="..." from /etc/default/grub.
-       Platforms: all (check_etc_default_grub = true)
-       Extracts everything between the double quotes as subexpression. #}}
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux" version="1"
-  comment="Collect GRUB_CMDLINE_LINUX value from /etc/default/grub">
-    <ind:filepath>/etc/default/grub</ind:filepath>
-    {{# regex: ^\s*GRUB_CMDLINE_LINUX="(.*)"$  -- captures everything between the quotes #}}
-    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+{{# Collect a grub shell variable (GRUB_CMDLINE_LINUX or GRUB_CMDLINE_LINUX_DEFAULT)
+     from /etc/default/grub or /etc/default/grub.d/*.cfg drop-ins, and check for {{{ ARG_NAME }}}.
+     When has_value: extracts just the value via capture group.
+     When not has_value (nousb): checks the arg name is present (existence only, no state). #}}
+{{%- macro etc_default_grub_object_and_test(grub_var, from_grub_d=false, check="all") %}}
+  {{%- set name = "grub2_" ~ ARG_NAME_UNDERSCORED ~ "_" ~ grub_var|lower ~ ("_from_grub_d" if from_grub_d else "") -%}}
+  {{%- set source_file = "/etc/default/grub.d/*.cfg" if from_grub_d else "/etc/default/grub" -%}}
+  <ind:textfilecontent54_object id="obj_{{{ name }}}" version="1"
+  comment="Collect {{{ ARG_NAME }}} from {{{ grub_var }}} in {{{ source_file }}}">
+    {{%- if from_grub_d %}}
+    {{# operation must be pattern match -- the filepath below is a regex;
+         without it OVAL defaults to equals and looks for a file literally named [^/]+\.cfg. #}}
+    <ind:filepath operation="pattern match">/etc/default/grub.d/[^/]+\.cfg</ind:filepath>
+    {{%- else %}}
+    <ind:filepath>{{{ source_file }}}</ind:filepath>
+    {{%- endif %}}
+    {{%- if has_value %}}
+    <ind:pattern operation="pattern match">^\s*{{{ grub_var }}}="(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}=([^\s"]+)</ind:pattern>
+    {{%- else %}}
+    <ind:pattern operation="pattern match">^\s*{{{ grub_var }}}="(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}(?:\s.*)?"$</ind:pattern>
+    {{%- endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{# Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub for {{{ ARG_NAME_VALUE }}}.
-       Platforms: all (check_etc_default_grub = true)
-       _DEFAULT only applies to non-recovery entries, so criteria requires
-       GRUB_DISABLE_RECOVERY=true alongside this test. #}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default"
-  comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub for {{{ ARG_NAME_VALUE }}}"
-  check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+  <ind:textfilecontent54_test id="test_{{{ name }}}"
+  comment="Check {{{ grub_var }}} in {{{ source_file }}} for {{{ ARG_NAME_VALUE }}}"
+  check="{{{ check }}}" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_{{{ name }}}" />
+    {{%- if has_value %}}
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" />
+    {{%- endif %}}
   </ind:textfilecontent54_test>
+{{%- endmacro %}}
 
-  {{# Collect GRUB_CMDLINE_LINUX_DEFAULT="..." from /etc/default/grub.
-       Platforms: all (check_etc_default_grub = true)
-       Extracts everything between the double quotes as subexpression.
-       Only passed to non-recovery boot entries by grub2-mkconfig. #}}
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default" version="1"
-  comment="Collect GRUB_CMDLINE_LINUX_DEFAULT value from /etc/default/grub">
-    <ind:filepath>/etc/default/grub</ind:filepath>
-    {{# regex: ^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$  -- captures everything between the quotes #}}
-    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+{{# Check grubenv for {{{ ARG_NAME_VALUE }}} in the kernelopts= line.
+     Platforms: RHEL 8, OL8 (uses_kernelopts).
+     When has_value: extracts just the value.
+     When not has_value: checks arg name is present (existence only). #}}
+{{%- macro test_and_object_for_grubenv(variant="") %}}
+  {{%- set path = (grub2_uefi_boot_path if variant == "uefi" else grub2_boot_path) ~ "/grubenv" -%}}
+  {{%- set name = "grub2_" ~ ARG_NAME_UNDERSCORED ~ "_in_grubenv" ~ ("_uefi" if variant == "uefi" else "") -%}}
+  <ind:textfilecontent54_object id="obj_{{{ name }}}" version="1"
+  comment="Collect {{{ ARG_NAME }}} from {{{ path }}}">
+    <ind:filepath>{{{ path }}}</ind:filepath>
+    {{%- if has_value %}}
+    <ind:pattern operation="pattern match">^kernelopts=(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}=(\S+)</ind:pattern>
+    {{%- else %}}
+    <ind:pattern operation="pattern match">^kernelopts=(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}(?:\s|$)</ind:pattern>
+    {{%- endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
-{{%- if check_etc_default_grub_d %}}
-    {{# Check GRUB_CMDLINE_LINUX in /etc/default/grub.d/*.cfg drop-ins for {{{ ARG_NAME_VALUE }}}.
-         Platforms: Ubuntu (check_etc_default_grub_d)
-         Same as the /etc/default/grub check but from drop-in config files.
-         Passes if at least one drop-in has it (check="at least one"). #}}
-    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d"
-    comment="Check GRUB_CMDLINE_LINUX in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}"
-    check="at least one" check_existence="all_exist" version="1">
-      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d" />
-      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-    </ind:textfilecontent54_test>
-
-    {{# Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.d/*.cfg drop-ins for {{{ ARG_NAME_VALUE }}}.
-         Platforms: Ubuntu (check_etc_default_grub_d)
-         Same as the /etc/default/grub check but from drop-in config files.
-         Requires GRUB_DISABLE_RECOVERY=true (same as the non-drop-in variant). #}}
-    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d"
-    comment="Check GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub.d/*.cfg for {{{ ARG_NAME_VALUE }}}"
-    check="all" check_existence="all_exist" version="1">
-      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d" />
-      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-    </ind:textfilecontent54_test>
-
-    {{# Collect GRUB_CMDLINE_LINUX="..." from /etc/default/grub.d/*.cfg drop-in files.
-         Platforms: Ubuntu (check_etc_default_grub_d)
-         Same regex as the /etc/default/grub object, but iterates over all .cfg drop-ins. #}}
-    <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_from_grub_d" version="1"
-    comment="Collect GRUB_CMDLINE_LINUX value from /etc/default/grub.d/*.cfg">
-      {{# regex: /etc/default/grub.d/[^/]+\.cfg  -- match .cfg drop-in files (Ubuntu) #}}
-      <ind:filepath operation="pattern match">/etc/default/grub.d/[^/]+\.cfg</ind:filepath>
-      {{# regex: same as /etc/default/grub -- captures everything between the quotes #}}
-      <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
-      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    </ind:textfilecontent54_object>
-
-    {{# Collect GRUB_CMDLINE_LINUX_DEFAULT="..." from /etc/default/grub.d/*.cfg drop-in files.
-         Platforms: Ubuntu (check_etc_default_grub_d)
-         Same regex as the /etc/default/grub object, but iterates over all .cfg drop-ins.
-         Only applies to non-recovery entries (same as GRUB_CMDLINE_LINUX_DEFAULT). #}}
-    <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_grub_cmdline_linux_default_from_grub_d" version="1"
-    comment="Collect GRUB_CMDLINE_LINUX_DEFAULT value from /etc/default/grub.d/*.cfg">
-      <ind:filepath>/etc/default/grub.d/*.cfg</ind:filepath>
-      {{# regex: same as /etc/default/grub -- captures everything between the quotes #}}
-      <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
-      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    </ind:textfilecontent54_object>
-{{%- endif %}}
-
-{{%- if check_boot_loader_entries_or_grubenv %}}
-  {{# Check grubenv for {{{ ARG_NAME_VALUE }}} in the kernelopts= line.
-       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
-       BIOS: {grub2_boot_path}/grubenv          (e.g. /boot/grub2/grubenv)
-       UEFI: {grub2_uefi_boot_path}/grubenv      (e.g. /boot/efi/EFI/redhat/grubenv)
-       UEFI variant only emitted when has_separate_bios_and_uefi is true.
-       Used when boot loader entries reference $kernelopts instead of listing args on options line. #}}
-  {{%- macro test_and_object_for_grubenv(variant="") %}}
-    {{%- set path = (grub2_uefi_boot_path if variant == "uefi" else grub2_boot_path) ~ "/grubenv" -%}}
-    {{%- set name = "grub2_" ~ SANITIZED_ARG_NAME ~ "_in_grubenv" ~ ("_uefi" if variant == "uefi" else "") -%}}
   <ind:textfilecontent54_test id="test_{{{ name }}}"
   comment="Check {{{ path }}} for {{{ ARG_NAME_VALUE }}}"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="obj_{{{ name }}}" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+    {{%- if has_value %}}
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" />
+    {{%- endif %}}
   </ind:textfilecontent54_test>
+{{%- endmacro %}}
 
-  {{# Collect kernelopts=... from grubenv (everything after "kernelopts=").
-       This is the grub environment variable that boot entries expand via $kernelopts. #}}
+{{# Check grub.cfg vmlinuz lines for {{{ ARG_NAME_VALUE }}} in the kernel command line.
+     Platforms: OL7, Ubuntu (uses_grub_cfg).
+     When has_value: extracts just the value.
+     When not has_value: checks arg name is present (existence only). #}}
+{{%- macro test_and_object_for_grub_cfg(variant, path) %}}
+  {{% set name = "grub2_" ~ ARG_NAME_UNDERSCORED ~ "_in_grub_cfg" ~ ("_uefi" if variant == "uefi" else "") -%}}
   <ind:textfilecontent54_object id="obj_{{{ name }}}" version="1"
-  comment="Collect kernelopts value from {{{ path }}}">
+  comment="Collect {{{ ARG_NAME }}} value from {{{ path }}}">
     <ind:filepath>{{{ path }}}</ind:filepath>
-    {{# regex: ^kernelopts=(.*)$  -- captures the full space-separated arg list from kernelopts #}}
-    <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
+    {{%- if has_value %}}
+    <ind:pattern operation="pattern match">^.*/vmlinuz.*\s{{{ ARG_NAME_ESCAPED_DOTS }}}=(\S+)</ind:pattern>
+    {{%- else %}}
+    <ind:pattern operation="pattern match">^.*/vmlinuz.*\s{{{ ARG_NAME_ESCAPED_DOTS }}}(?:\s|$)</ind:pattern>
+    {{%- endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  {{%- endmacro %}}
+
+  <ind:textfilecontent54_test id="test_{{{ name }}}"
+  comment="Check {{{ path }}} for {{{ ARG_NAME_VALUE }}}"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_{{{ name }}}" />
+    {{%- if has_value %}}
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" />
+    {{%- endif %}}
+  </ind:textfilecontent54_test>
+{{%- endmacro %}}
+
+{{# Shared state for value comparison.
+     Uses OVAL-native operation + datatype instead of regex.
+     Skipped entirely for args without a value (e.g. nousb). #}}
+
+{{% if ARG_VARIABLE %}}
+  <external_variable comment="Expected {{{ ARG_NAME }}} value from XCCDF variable {{{ ARG_VARIABLE }}}" datatype="{{{ DATATYPE }}}" id="{{{ ARG_VARIABLE }}}" version="1" />
+
+  <ind:textfilecontent54_state id="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" version="1">
+    <ind:subexpression datatype="{{{ DATATYPE }}}" operation="{{{ OPERATION }}}" var_ref="{{{ ARG_VARIABLE }}}" />
+  </ind:textfilecontent54_state>
+{{% elif ARG_VALUE %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" version="1">
+    <ind:subexpression datatype="{{{ DATATYPE }}}" operation="{{{ OPERATION }}}">{{{ ARG_VALUE }}}</ind:subexpression>
+  </ind:textfilecontent54_state>
+{{% endif %}}
+
+{{# --- /etc/default/grub (all products) --- #}}
+
+{{{ etc_default_grub_object_and_test("GRUB_CMDLINE_LINUX") }}}
+{{{ etc_default_grub_object_and_test("GRUB_CMDLINE_LINUX_DEFAULT") }}}
+
+
+{{# RHEL 8/9/10, Fedora, OL8/9 — uses_boot_loader_entries
+     ID uses _RULE_ID (not ARG_NAME_UNDERSCORED) to guarantee uniqueness across rules. #}}
+{{% if uses_boot_loader_entries %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ _RULE_ID }}}_is_rescue_entry" version="1"
+  comment="Match /boot/loader/entries/*rescue.conf filenames for exclusion">
+    <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
+  </ind:textfilecontent54_state>
+{{% endif %}}
+
+{{# RHEL 8, OL8 — uses_kernelopts #}}
+{{% if uses_kernelopts %}}
+  {{# Full-line capture from `/boot/loader/entries/*.conf` for the RHEL 8 coverage test.
+       Each entry produces one item with the full `options` line as subexpression.
+       Used to check that every entry has {{{ ARG_NAME }}} OR `$kernelopts`. #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries" version="1"
+  comment="Collect options line from each /boot/loader/entries/*.conf (exclude rescue)">
+    <ind:path>/boot/loader/entries/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_grub2_{{{ _RULE_ID }}}_is_rescue_entry</filter>
+  </ind:textfilecontent54_object>
+{{% endif %}}
+
+{{# RHEL 9+/Fedora/OL9 (uses_boot_loader_entries, not uses_kernelopts)
+     OR RHEL 8/OL8 (uses_kernelopts, has_value only) #}}
+{{%- if (uses_boot_loader_entries and not uses_kernelopts) or (uses_kernelopts and has_value) %}}
+  {{# Extract the {{{ ARG_NAME }}} from each `/boot/loader/entries/*.conf`.
+       On RHEL 9+, this is the only BLS object — every entry must have the correct value.
+
+       On RHEL 8, entries may use `$kernelopts` instead of listing args directly. Entries
+       that DO have the arg directly are checked here (`check_existence=any_exist` means
+       zero matches is OK — all entries delegated to `$kernelopts`).
+
+       Edge case: if an entry has both `$kernelopts` and a direct arg override
+       (e.g. `options $kernelopts audit_backlog_limit=4096`), this captures the direct
+       value. The kernel uses the last occurrence, so the direct value wins. 
+  #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_value" version="1"
+  comment="Extract {{{ ARG_NAME }}} value from /boot/loader/entries/*.conf (exclude rescue)">
+    <ind:path>/boot/loader/entries/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{# (?:.*\s)? skips any preceding args on the options line so the arg is matched
+         regardless of position (first, middle, or last). 
+         The group is optional because the {{{ ARG_NAME }}} may be the first thing after `options`. #}}
+    {{%- if has_value %}}
+    <ind:pattern operation="pattern match">^options\s+(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}=(\S+)</ind:pattern>
+    {{%- else %}}
+    <ind:pattern operation="pattern match">^options\s+(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}(?:\s|$)</ind:pattern>
+    {{%- endif %}}
+    {{# Collect at least one match from each `/boot/loader/entries/*.conf`. #}}
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    {{# Exclude rescue entries. #}}
+    <filter action="exclude">state_grub2_{{{ _RULE_ID }}}_is_rescue_entry</filter>
+  </ind:textfilecontent54_object>
+{{%- endif %}}
+
+{{# RHEL 8, OL8 — uses_kernelopts — coverage + value tests + $kernelopts gate #}}
+{{% if uses_kernelopts %}}
+  {{# RHEL 8 coverage state: arg name present (with or without =value) in the full `options` line.
+       Used by the coverage test to ensure every entry accounts for {{{ ARG_NAME }}}. #}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_name_present" version="1">
+    {{# Match the {{{ ARG_NAME }}} name (with optional value) in the full options line. #}}
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ARG_NAME_ESCAPED_DOTS }}}(?:=\S+)?(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument_is_kernelopts" version="1">
+    {{# Match the `$kernelopts` keyword in the full options line. #}}
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?\$kernelopts(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  {{# RHEL 8 coverage test: every `/boot/loader/entries/*.conf` has {{{ ARG_NAME }}} OR `$kernelopts`.
+       `state_operator` = `OR`: entry passes if it matches either state.
+       `check` = `all`: every entry must pass. #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_coverage"
+  comment="Check each /boot/loader/entries/*.conf has {{{ ARG_NAME }}} or $kernelopts"
+  state_operator="OR" check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries" />
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_name_present" />
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument_is_kernelopts" />
+  </ind:textfilecontent54_test>
+
+  {{%- if has_value %}}
+  {{# RHEL 8 value test: entries that list {{{ ARG_NAME }}} directly have the correct value.
+       `check_existence` = `any_exist`: if all entries use `$kernelopts` and none have
+       the arg directly, zero items are collected and the test passes (grubenv handles it). #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_value"
+  comment="Check /boot/loader/entries/*.conf value of {{{ ARG_NAME }}}"
+  check="all" check_existence="any_exist" version="1">
+    <ind:object object_ref="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_value" />
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" />
+  </ind:textfilecontent54_test>
+  {{%- endif %}}
+
+  {{# $kernelopts presence test: at least one /boot/loader/entries/*.conf references $kernelopts.
+       Used negated in criteria: if no entry has $kernelopts, grubenv check is skipped. #}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_kernelopts_in_any_boot_loader_entry"
+  comment="Check if any /boot/loader/entries/*.conf references $kernelopts"
+  check="at least one" check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries" />
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument_is_kernelopts" />
+  </ind:textfilecontent54_test>
 
   {{{- test_and_object_for_grubenv() }}}
   {{%- if has_separate_bios_and_uefi -%}}
     {{{- test_and_object_for_grubenv(variant="uefi") }}}
   {{%- endif %}}
+{{% endif %}}
+
+{{# Ubuntu, only — uses_etc_default_grub_d #}}
+{{%- if uses_etc_default_grub_d %}}
+  {{# `/etc/default/grub.d/*.cfg` drop-in files.
+       `GRUB_CMDLINE_LINUX` and `GRUB_CMDLINE_LINUX_DEFAULT` from `/etc/default/grub.d/*.cfg` drop-in config files.
+       `GRUB_CMDLINE_LINUX` uses `check` = `at least one` -- passes if any `/etc/default/grub.d/*.cfg` has the arg. #}}
+  {{{ etc_default_grub_object_and_test("GRUB_CMDLINE_LINUX", from_grub_d=true, check="at least one") }}}
+  {{{ etc_default_grub_object_and_test("GRUB_CMDLINE_LINUX_DEFAULT", from_grub_d=true) }}}
 {{%- endif %}}
 
-{{%- if check_boot_loader_entries %}}
-    {{# Check EACH /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}} on options line.
-         Platforms: RHEL 9+, Fedora, OL9 (check_boot_loader_entries)
-         No $kernelopts indirection -- RHEL 9+ has all kernel args on the options line. #}}
-    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
-                                comment="Check each /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}}"
-                                check="all" check_existence="all_exist" version="1">
-      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" />
-      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
-    </ind:textfilecontent54_test>
-
-  {{# Collect the "options" line from each /boot/loader/entries/*.conf.
-       Platforms: RHEL 9+, Fedora, OL9 (check_boot_loader_entries)
-       Each .conf file produces one collected item. Rescue entries (*rescue.conf) excluded.
-       Unlike the RHEL 8 variant, no $kernelopts indirection -- args are always on the options line. #}}
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" version="1"
-  comment="Collect options line from each /boot/loader/entries/*.conf (exclude rescue)">
-    <ind:path>/boot/loader/entries/</ind:path>
-    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    {{# regex: ^options (.*)$  -- captures the full space-separated arg list after "options " #}}
-    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    <filter action="exclude">state_grub2_{{{ _RULE_ID }}}_is_rescue_entry</filter>
-  </ind:textfilecontent54_object>
-
-  {{# Exclude filter: matches filenames ending in "rescue.conf" (same as above). #}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ _RULE_ID }}}_is_rescue_entry" version="1"
-  comment="Match rescue entry filenames for exclusion">
-    {{# regex: .*rescue\.conf$  -- matches rescue entry filenames to exclude them #}}
-    <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
-  </ind:textfilecontent54_state>
-{{%- endif %}}
-
-{{%- if check_grub_cfg %}}
-  {{# Check grub.cfg vmlinuz lines for {{{ ARG_NAME_VALUE }}} in the kernel command line.
-       Platforms: OL7, Ubuntu (check_grub_cfg)
-       BIOS: {grub2_boot_path}/grub.cfg          (e.g. /boot/grub2/grub.cfg)
-       UEFI: {grub2_uefi_boot_path}/grub.cfg      (e.g. /boot/efi/EFI/redhat/grub.cfg)
-       UEFI variant only emitted when has_separate_bios_and_uefi is true. #}}
-  {{%- macro test_and_object_for_grub_cfg(variant, path) %}}
-    {{% set name = "grub2_" ~ SANITIZED_ARG_NAME ~ "_in_grub_cfg" ~ ("_uefi" if variant == "uefi" else "") -%}}
-  <ind:textfilecontent54_test id="test_{{{ name }}}"
-  comment="Check {{{ path }}} for {{{ ARG_NAME_VALUE }}}"
-  check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="obj_{{{ name }}}" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+{{# RHEL 9+, Fedora, OL9 — uses_boot_loader_entries, not uses_kernelopts #}}
+{{%- if uses_boot_loader_entries and not uses_kernelopts %}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries"
+                              comment="Check each /boot/loader/entries/*.conf (omit rescue) for {{{ ARG_NAME_VALUE }}}"
+                              check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_bls_entries_value" />
+    {{%- if has_value %}}
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" />
+    {{%- endif %}}
   </ind:textfilecontent54_test>
+{{%- endif %}}
 
-  {{# Collect kernel command line from vmlinuz lines in grub.cfg.
-       Captures from "root=" onwards, which includes all kernel args.
-       Each vmlinuz line corresponds to one boot entry. #}}
-  <ind:textfilecontent54_object id="obj_{{{ name }}}" version="1"
-  comment="Collect kernel command line from {{{ path }}}">
-    <ind:filepath>{{{ path }}}</ind:filepath>
-    {{# regex: ^.*/vmlinuz.*(root=.*)$  -- captures from "root=" onwards on vmlinuz lines (OL7, Ubuntu) #}}
-    <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-  {{%- endmacro %}}
-
+{{# OL7, Ubuntu — uses_grub_cfg #}}
+{{%- if uses_grub_cfg %}}
+  {{# Emit BIOS variant (`{grub2_boot_path}/grub.cfg`) unconditionally;
+       emit UEFI variant (`{grub2_uefi_boot_path}/grub.cfg`) only when the platform has separate BIOS and UEFI paths. #}}
   {{{ test_and_object_for_grub_cfg("bios", grub2_boot_path ~ "/grub.cfg") }}}
   {{%- if has_separate_bios_and_uefi -%}}
     {{{- test_and_object_for_grub_cfg("uefi", grub2_uefi_boot_path ~ "/grub.cfg") }}}
   {{%- endif %}}
 {{%- endif %}}
 
-{{% if check_boot_loader_entries_or_grubenv %}}
-  {{# Match "$kernelopts" as a whole word in the captured "options" line.
-       Platforms: RHEL 8, OL8 (check_boot_loader_entries_or_grubenv)
-       $kernelopts is a grub env variable expanded at boot time from grubenv. #}}
-  {{# regex: ^(?:.*\s)?\$kernelopts(?:\s.*)?$  -- checks if $kernelopts appears as a word in the options line (RHEL 8 indirection) #}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_is_kernelopts" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?\$kernelopts(?:\s.*)?$</ind:subexpression>
-  </ind:textfilecontent54_state>
-{{% endif %}}
-
-{{# Match {{{ ARG_NAME_VALUE }}} as a whole word in the captured options/kernelopts/cmdline line.
-     Shared by ALL grub-location tests (except bootc kargs.d which has its own state).
-     If ARG_VARIABLE is set, the regex is built at scan time from an XCCDF variable.
-     Otherwise, the expected value is hardcoded into the regex at build time.
-     NOTE: in the rewrite, this entire state + local_variable goes away --
-           objects will extract just the value, and the state will use operation+datatype natively. #}}
-{{% if ARG_VARIABLE %}}
-  {{# Value comes from XCCDF variable {{{ ARG_VARIABLE }}} -- regex built at scan time. #}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
-    {{# regex built at scan time via local_variable concat -- checks "arg=<XCCDF_VALUE>" as a word in the line #}}
-    <ind:subexpression datatype="string" operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}" />
-  </ind:textfilecontent54_state>
-
-  {{# Build regex: ^(?:.*\s)?{ARG_NAME}=<XCCDF_VALUE>(?:\s.*)?$
-       Matches arg=value as a whole word. IS_SUBSTRING wraps value with \S* (partial match). #}}
-  <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}"
-  comment="Build regex to match {{{ ARG_NAME }}}={{{ ARG_VARIABLE }}} as a whole word"
-  datatype="string" version="1">
-    <concat>
-      <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
-      {{% if IS_SUBSTRING == "true" %}}
-      <literal_component>\S*</literal_component>
-      {{% endif %}}
-      <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
-      {{% if IS_SUBSTRING == "true" %}}
-      <literal_component>\S*</literal_component>
-      {{% endif %}}
-      <literal_component>(?:\s.*)?$</literal_component>
-    </concat>
-  </local_variable>
-
-  {{# Expected value of {{{ ARG_NAME }}}, provided by XCCDF benchmark at scan time. #}}
-  <external_variable comment="Expect {{{ ARG_NAME }}} value from XCCDF variable {{{ ARG_VARIABLE }}}" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
-{{% else %}}
-  {{# Expected value hardcoded at build time: {{{ ESCAPED_ARG_NAME_VALUE }}} #}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
-    {{# regex: ^(?:.*\s)?{ARG_NAME_VALUE}(?:\s.*)?$  -- checks "arg=value" appears as a whole word in the full options line #}}
-    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
-  </ind:textfilecontent54_state>
-{{% endif %}}
-
-{{# Bootc / RHEL Image Mode: kernel args live in /usr/lib/bootc/kargs.d/*.toml instead of grub. #}}
+{{# RHEL 9+, RHEL 10 — bootable_containers_supported #}}
 {{%- if bootable_containers_supported == "true" %}}
-  {{# Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}} in the kargs array.
-       Platforms: RHEL 9+, RHEL 10 with bootc support (bootable_containers_supported)
-       Passes if at least one .toml file has it (check="at least one").
-       Has its own state (not shared) because TOML wraps values in quotes. #}}
-  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
-                              comment="Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}}"
-                              check="at least one" check_existence="at_least_one_exists" version="1">
-    <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
-    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
-  </ind:textfilecontent54_test>
-  {{# Collect kargs array from /usr/lib/bootc/kargs.d/*.toml.
-       Captures everything between the square brackets: kargs = ["arg=val", "arg2=val2"] #}}
-  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1"
-  comment="Collect kargs array from /usr/lib/bootc/kargs.d/*.toml">
+  {{# bootc object extracts the value from within the TOML quotes, so the shared state works directly. #}}
+  <ind:textfilecontent54_object id="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_usr_lib_bootc_kargs_d" version="1"
+  comment="Collect {{{ ARG_NAME }}} from /usr/lib/bootc/kargs.d/*.toml">
     <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
     <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
-    {{# regex: ^kargs = \[([^\]]+)\]$  -- captures contents of the TOML kargs array, e.g. "arg=val", "arg2=val2" #}}
-    <ind:pattern operation="pattern match">^kargs = \[([^\]]+)\]$</ind:pattern>
+    {{%- if has_value %}}
+    <ind:pattern operation="pattern match">^kargs\s*=\s*\[.*"{{{ ARG_NAME_ESCAPED_DOTS }}}=([^"]+)".*\]$</ind:pattern>
+    {{%- else %}}
+    <ind:pattern operation="pattern match">^kargs\s*=\s*\[.*"{{{ ARG_NAME_ESCAPED_DOTS }}}".*\]$</ind:pattern>
+    {{%- endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  {{# Match {{{ ARG_NAME_VALUE }}} as a quoted string in the TOML kargs array (e.g. "arg=val").
-       Separate from state_argument because TOML wraps values in double quotes.
-       Same ARG_VARIABLE / hardcoded split as state_argument. #}}
-  {{%- if ARG_VARIABLE %}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
-    <ind:subexpression operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs" />
-  </ind:textfilecontent54_state>
 
-  {{# Build regex: ^.*"{ARG_NAME}=<XCCDF_VALUE>".*$
-       Matches "arg=value" as a quoted string in TOML. IS_SUBSTRING wraps value with \S*. #}}
-  <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs"
-  comment="Regex that matches {{{ ARG_NAME }}} with value {{{ ARG_VARIABLE }}}"
-  datatype="string" version="1">
-    <concat>
-      <literal_component>^.*"{{{ ARG_NAME }}}=</literal_component>
-      {{% if IS_SUBSTRING == "true" %}}
-      <literal_component>\S*</literal_component>
-      {{% endif %}}
-      <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
-      {{% if IS_SUBSTRING == "true" %}}
-      <literal_component>\S*</literal_component>
-      {{% endif %}}
-      <literal_component>".*$</literal_component>
-    </concat>
-  </local_variable>
-
-  {{# Expected value of {{{ ARG_NAME }}}, same XCCDF variable as above. #}}
-  <external_variable comment="Expect {{{ ARG_NAME }}} value from XCCDF variable {{{ ARG_VARIABLE }}}" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
-  {{%- else %}}
-  {{# Expected value hardcoded at build time, with surrounding quotes for TOML format. #}}
-  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
-    <ind:subexpression operation="pattern match">^.*"{{{ ESCAPED_ARG_NAME_VALUE }}}".*$</ind:subexpression>
-  </ind:textfilecontent54_state>
-  {{%- endif %}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ ARG_NAME_UNDERSCORED }}}_usr_lib_bootc_kargs_d"
+                              comment="Check /usr/lib/bootc/kargs.d/*.toml for {{{ ARG_NAME_VALUE }}}"
+                              check="at least one" check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="obj_grub2_{{{ ARG_NAME_UNDERSCORED }}}_usr_lib_bootc_kargs_d" />
+    {{%- if has_value %}}
+    <ind:state state_ref="state_grub2_{{{ ARG_NAME_UNDERSCORED }}}_argument" />
+    {{%- endif %}}
+  </ind:textfilecontent54_test>
 {{% endif %}}
+
 
 </def-group>

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -1,29 +1,56 @@
 import ssg.utils
 
+VALID_OPERATIONS = {
+    "pattern match",
+    "greater than or equal",
+}
+
 
 def preprocess(data, lang):
+    # arg_value and arg_variable are mutually exclusive
     if 'arg_value' in data and 'arg_variable' in data:
         raise RuntimeError(
                 "ERROR: The template should not set both 'arg_value' and 'arg_variable'.\n"
                 "arg_name: {0}\n"
                 "arg_variable: {1}".format(data['arg_value'], data['arg_variable']))
 
-    if 'arg_variable' in data:
+    # Fallback to pattern match operation if not set
+    if "operation" not in data:
+        data["operation"] = "pattern match"
+
+    # Placeholder values substituted into tests/*.sh scenarios via
+    # TEST_CORRECT_VALUE / TEST_WRONG_VALUE (e.g. grub2_bootloader_argument_remediation calls)  
+    match data["operation"]:
+        case "pattern match":
+            data["test_correct_value"] = "correct_value"
+            data["test_wrong_value"] = "wrong_value"
+        case "greater than or equal":
+            data["test_correct_value"] = "200"
+            data["test_wrong_value"] = "199"
+        case _:
+            raise RuntimeError(
+                f"ERROR: Invalid operation '{data['operation']}' for rule "
+                f"'{data['_rule_id']}'. "
+                f"Must be one of: {sorted(VALID_OPERATIONS)}"
+            )
+
+    # Build ARG_NAME_VALUE ("name=value") used in oval.template comments/metadata,
+    # bash.template remediation, and ansible.template remediation.
+    # When arg_variable is set the value comes from an XCCDF variable at eval time.
+    
+    if 'arg_variable' in data or "arg_value" not in data:
         data["arg_name_value"] = data["arg_name"]
     else:
-        if "arg_value" in data:
             data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
-        else:
-            data["arg_name_value"] = data["arg_name"]
 
     if 'is_substring' not in data:
         data["is_substring"] = "false"
 
-    if lang == "oval":
-        # escape dot, this is used in oval regex
-        data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")
-        data["escaped_arg_name"] = data["arg_name"].replace(".", "\\.")
-        # replace . with _, this is used in test / object / state ids
-
+    # OVAL-specific: escape dots for regex patterns in oval.template
+    # (ESCAPED_ARG_NAME_VALUE in state subexpressions, ESCAPED_ARG_NAME in object patterns)
+    data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")
+    data["escaped_arg_name"] = data["arg_name"].replace(".", "\\.")
+    # SANITIZED_ARG_NAME: used as component of OVAL IDs (test_grub2_<name>_*,
+    # obj_grub2_<name>_*, state_grub2_<name>_*) and bash bootc .toml filenames
     data["sanitized_arg_name"] = ssg.utils.escape_id(data["arg_name"])
     return data

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -1,29 +1,211 @@
 import ssg.utils
 
 
-def preprocess(data, lang):
-    if 'arg_value' in data and 'arg_variable' in data:
+# Valid (datatype, operation) combinations for the OVAL ``<ind:subexpression>``
+# element.  Ordering operations on strings would do lexicographic comparison,
+# which is never what we want for kernel boot arguments.  Pattern match on int
+# is equally nonsensical.
+VALID_OPERATIONS_BY_DATATYPE = {
+    "string": [
+        "equals",
+        "not equal",
+        "pattern match",
+    ],
+    "int": [
+        "equals",
+        "not equal",
+        "greater than",
+        "less than",
+        "greater than or equal",
+        "less than or equal",
+    ],
+}
+
+VALID_DATATYPES = list(VALID_OPERATIONS_BY_DATATYPE.keys())
+
+
+def validate_rule_template_arguments(data, rule_id):
+    """Validate and set defaults for rule.yml template arguments.
+
+    Sets operation/datatype defaults for non-variable rules, requires
+    explicit values for arg_variable rules, then validates all combinations.
+    """
+    arg_value    = data.get("arg_value")
+    arg_variable = data.get("arg_variable")
+
+    # arg_value and arg_variable are mutually exclusive
+    if arg_value is not None and arg_variable is not None:
         raise RuntimeError(
-                "ERROR: The template should not set both 'arg_value' and 'arg_variable'.\n"
-                "arg_name: {0}\n"
-                "arg_variable: {1}".format(data['arg_value'], data['arg_variable']))
+            f"The template must not set both 'arg_value' and 'arg_variable'.\n"
+            f"arg_name: {arg_value}\n"
+            f"arg_variable: {arg_variable}"
+        )
 
-    if 'arg_variable' in data:
-        data["arg_name_value"] = data["arg_name"]
+    # arg_value must be quoted in rule.yml.  YAML auto-parses unquoted
+    # scalars: 8192 becomes int, on/off become bool True/False.  The
+    # template needs a string to build regexes and config file content —
+    # a silent int or bool would produce wrong patterns downstream.
+    if arg_value is not None and type(arg_value) is not str:
+        raise TypeError(
+            f"arg_value must be a quoted string in rule.yml, got "
+            f"{type(arg_value).__name__}: {arg_value!r} "
+            f"for rule '{rule_id}'"
+        )
+
+    # arg_variable rules must set operation and datatype explicitly.
+    # The .var file defines the XCCDF variable type (string/number) and
+    # operator (equals/greater than or equal/...).  The OVAL state must
+    # use matching datatype and operation, but template.py cannot read
+    # .var files — so we force the rule author to declare both in
+    # rule.yml and keep them in sync with the .var file manually.
+    # Non-variable rules get safe defaults (equals/string).
+    if arg_variable is not None:
+        if "operation" not in data:
+            raise ValueError(
+                f"Missing 'operation' in rule '{rule_id}'. "
+                f"Required because arg_variable '{arg_variable}' is used — "
+                f"set it to match the 'operator' field in "
+                f"'{arg_variable}.var'."
+            )
+        if "datatype" not in data:
+            raise ValueError(
+                f"Missing 'datatype' in rule '{rule_id}'. "
+                f"Required because arg_variable '{arg_variable}' is used — "
+                f"set it to match the 'type' field in "
+                f"'{arg_variable}.var'."
+            )
     else:
-        if "arg_value" in data:
-            data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
-        else:
-            data["arg_name_value"] = data["arg_name"]
+        if "operation" not in data:
+            data["operation"] = "equals"
+        if "datatype" not in data:
+            data["datatype"] = "string"
 
-    if 'is_substring' not in data:
-        data["is_substring"] = "false"
+    # From here on, operation and datatype are always present
+    operation = data["operation"]
+    datatype  = data["datatype"]
+
+    # Validate datatype/operation combination
+    if datatype not in VALID_DATATYPES:
+        raise ValueError(
+            f"Unsupported datatype '{datatype}' for rule '{rule_id}'. "
+            f"Must be one of: {VALID_DATATYPES}"
+        )
+
+    valid_ops = VALID_OPERATIONS_BY_DATATYPE[datatype]
+    if operation not in valid_ops:
+        raise ValueError(
+            f"Operation '{operation}' is not valid with "
+            f"datatype '{datatype}' for rule '{rule_id}'. "
+            f"Valid operations for '{datatype}': {valid_ops}"
+        )
+
+    # Any arg_value is a valid string, but int needs a parseable number
+    if datatype == "int" and arg_value is not None:
+        try:
+            int(arg_value)
+        except ValueError as err:
+            raise ValueError(
+                f"datatype is 'int' but arg_value '{arg_value}' "
+                f"is not a valid integer for rule '{rule_id}'."
+            ) from err
+
+
+def preprocess(data, lang):
+    """Preprocess template variables before rendering.
+
+    Validates, sets defaults, escapes names for OVAL regex, and computes
+    test scenario values.
+    """
+    rule_id = data.get("_rule_id", "unknown_rule_id") # default set to trace errors easier
+
+    validate_rule_template_arguments(data, rule_id)
+
+    arg_name     = data["arg_name"]
+    arg_value    = data.get("arg_value")
+    arg_variable = data.get("arg_variable")
+    operation    = data["operation"]
+    datatype     = data["datatype"]
+
+    # --- Build derived variables ---
+
+    # ARG_NAME_VALUE:
+    #   arg_name and arg_value          -> "arg_name=arg_value"
+    #   arg_variable or just arg_name   -> "arg_name" (arg_variable is injected in OVAL)
+    data["arg_name_value"] = (
+        f"{arg_name}={arg_value}" if arg_value is not None
+        else arg_name
+    )
 
     if lang == "oval":
-        # escape dot, this is used in oval regex
-        data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")
-        data["escaped_arg_name"] = data["arg_name"].replace(".", "\\.")
-        # replace . with _, this is used in test / object / state ids
+        # Dots in arg names must be escaped in OVAL regex patterns
+        # (e.g. ipv6.disable -> ipv6\.disable)
+        data["arg_name_escaped_dots"] = arg_name.replace(".", "\\.")
 
-    data["sanitized_arg_name"] = ssg.utils.escape_id(data["arg_name"])
+    # Dots replaced by underscores
+    # (e.g. ipv6.disable -> ipv6_disable)
+    data["arg_name_underscored"] = ssg.utils.escape_id(arg_name)
+
+    # --- Test scenario values ---
+    #
+    # Automatus test scripts write values into GRUB config files, then oscap
+    # scans and the result is compared to the filename (.pass.sh / .fail.sh).
+    # Works because OVAL checks file contents directly — no service reload.
+    #
+    # arg_value rules:    value known at build time, compute real pass/fail.
+    # arg_variable rules: value is an XCCDF variable resolved at scan time.
+    #   template.py has no access to .var files, so we use
+    #   arbitrary dummies (99999 for int).  Test scripts emit a directive
+    #   (# variables = var_name=value) that makes Automatus XSLT-patch the
+    #   datastream so oscap resolves the variable to the dummy.
+    #   Same approach as sysctl/template.py.
+    # flag-only GRUB argument (nousb): no value, skip.
+    #
+    if arg_variable is not None:
+        if datatype == "int":
+            data["test_value_pass"]    = "99999"
+            data["test_value_fail"]    = "99998"
+            data["value_below"]        = "99998"
+            data["value_at_threshold"] = "99999"
+            data["value_above"]        = "100000"
+        else:
+            # string variable — arbitrary placeholders
+            data["test_value_pass"] = "correct_value"
+            data["test_value_fail"] = "wrong_value"
+
+    elif arg_value is not None:
+        # arg_value rules: value is known at build time, compute real test values
+        if datatype == "int":
+            threshold          = int(arg_value)
+            value_below        = threshold - 1
+            value_at_threshold = threshold
+            value_above        = threshold + 1
+
+            data["value_below"]        = value_below
+            data["value_at_threshold"] = value_at_threshold
+            data["value_above"]        = value_above
+
+            if operation == "equals":
+                correct, wrong = value_at_threshold, value_above
+            elif operation == "greater than or equal":
+                correct, wrong = value_at_threshold, value_below
+            else:
+                raise ValueError(
+                    f"No test values defined for int operation "
+                    f"'{operation}' in rule '{rule_id}'"
+                )
+        else:
+            # string with known value
+            if operation in ("equals", "pattern match"):
+                correct, wrong = arg_value, "wrong_value"
+            else:
+                raise ValueError(
+                    f"No test values defined for string operation "
+                    f"'{operation}' in rule '{rule_id}'"
+                )
+
+        data["test_value_pass"] = correct
+        data["test_value_fail"] = wrong
+
+    # else: flag-only argument (e.g. nousb) — no value, no test values needed
+
     return data

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -24,41 +24,43 @@ VALID_OPERATIONS_BY_DATATYPE = {
 VALID_DATATYPES = list(VALID_OPERATIONS_BY_DATATYPE.keys())
 
 
-def validate_rule_template_arguments(data, rule_id):
-    """Validate and set defaults for rule.yml template arguments.
+def set_default_operation_and_datatype(data):
+    if "operation" not in data:
+        data["operation"] = "equals"
+    if "datatype" not in data:
+        data["datatype"] = "string"
 
-    Sets operation/datatype defaults for non-variable rules, requires
-    explicit values for arg_variable rules, then validates all combinations.
-    """
+
+def validate_rule_template_arguments(data, rule_id):
+    """Validate variables used in the rule.yml and set required defaults if missing."""
     arg_value    = data.get("arg_value")
     arg_variable = data.get("arg_variable")
 
-    # arg_value and arg_variable are mutually exclusive
-    if arg_value is not None and arg_variable is not None:
-        raise RuntimeError(
-            f"The template must not set both 'arg_value' and 'arg_variable'.\n"
-            f"arg_name: {arg_value}\n"
-            f"arg_variable: {arg_variable}"
-        )
+    if arg_value is not None:
+        # arg_value and arg_variable are mutually exclusive
+        if arg_variable is not None:
+            raise RuntimeError(
+                f"The template must not set both 'arg_value' and 'arg_variable'.\n"
+                f"arg_value: {arg_value}\n"
+                f"arg_variable: {arg_variable}"
+            )
 
-    # arg_value must be quoted in rule.yml.  YAML auto-parses unquoted
-    # scalars: 8192 becomes int, on/off become bool True/False.  The
-    # template needs a string to build regexes and config file content —
-    # a silent int or bool would produce wrong patterns downstream.
-    if arg_value is not None and type(arg_value) is not str:
-        raise TypeError(
-            f"arg_value must be a quoted string in rule.yml, got "
-            f"{type(arg_value).__name__}: {arg_value!r} "
-            f"for rule '{rule_id}'"
-        )
+        # Require `arg_value` to be written as a quoted string in `rule.yml`.
+        # - arg_name_value and the templates expect it to be a string.
+        # - This check mainly catches unquoted numbers, as `ssg/yaml.py` keeps
+        #   words such as `true` and `on` as strings, not booleans.
+        if type(arg_value) is not str:
+            raise TypeError(
+                f"arg_value must be written as a quoted string in rule.yml. "
+                f"Got {type(arg_value).__name__}: {arg_value!r} "
+                f"for rule '{rule_id}'"
+            )
 
-    # arg_variable rules must set operation and datatype explicitly.
-    # The .var file defines the XCCDF variable type (string/number) and
-    # operator (equals/greater than or equal/...).  The OVAL state must
-    # use matching datatype and operation, but template.py cannot read
-    # .var files — so we force the rule author to declare both in
-    # rule.yml and keep them in sync with the .var file manually.
-    # Non-variable rules get safe defaults (equals/string).
+    # If arg_variable is set:
+    #   - operation must be explicit
+    #   - datatype must be explicit
+    #   - both must match the values in the `.var` file. `template.py` cannot read
+    #     `.var` files, so the rule author must keep `rule.yml` in sync manually.
     if arg_variable is not None:
         if "operation" not in data:
             raise ValueError(
@@ -74,13 +76,11 @@ def validate_rule_template_arguments(data, rule_id):
                 f"set it to match the 'type' field in "
                 f"'{arg_variable}.var'."
             )
-    else:
-        if "operation" not in data:
-            data["operation"] = "equals"
-        if "datatype" not in data:
-            data["datatype"] = "string"
 
-    # From here on, operation and datatype are always present
+    # If rule.yml does not set operation or datatype, use the defaults.
+    if "operation" not in data or "datatype" not in data:
+        set_default_operation_and_datatype(data)
+
     operation = data["operation"]
     datatype  = data["datatype"]
 
@@ -99,7 +99,7 @@ def validate_rule_template_arguments(data, rule_id):
             f"Valid operations for '{datatype}': {valid_ops}"
         )
 
-    # Any arg_value is a valid string, but int needs a parseable number
+    # If datatype is `int`, `arg_value` must be an integer.
     if datatype == "int" and arg_value is not None:
         try:
             int(arg_value)
@@ -145,21 +145,11 @@ def preprocess(data, lang):
     # (e.g. ipv6.disable -> ipv6_disable)
     data["arg_name_underscored"] = ssg.utils.escape_id(arg_name)
 
-    # --- Test scenario values ---
-    #
-    # Automatus test scripts write values into GRUB config files, then oscap
-    # scans and the result is compared to the filename (.pass.sh / .fail.sh).
-    # Works because OVAL checks file contents directly — no service reload.
-    #
-    # arg_value rules:    value known at build time, compute real pass/fail.
-    # arg_variable rules: value is an XCCDF variable resolved at scan time.
-    #   template.py has no access to .var files, so we use
-    #   arbitrary dummies (99999 for int).  Test scripts emit a directive
-    #   (# variables = var_name=value) that makes Automatus XSLT-patch the
-    #   datastream so oscap resolves the variable to the dummy.
-    #   Same approach as sysctl/template.py.
-    # flag-only GRUB argument (nousb): no value, skip.
-    #
+    # --- Test values for template tests ---
+
+    # If `arg_value` is set, it can be used to compute real test values.
+    # If `arg_variable` is set, its value cannot be resolved from the XCCDF var.
+    #   Therefore, we need to use dummy values for the test scenarios.
     if arg_variable is not None:
         if datatype == "int":
             data["test_value_pass"]    = "99999"
@@ -206,6 +196,6 @@ def preprocess(data, lang):
         data["test_value_pass"] = correct
         data["test_value_fail"] = wrong
 
-    # else: flag-only argument (e.g. nousb) — no value, no test values needed
+    # else: only arg_name is set (e.g. nousb), no test values needed
 
     return data

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
@@ -4,8 +4,8 @@
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
@@ -4,16 +4,17 @@
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
-# Removes argument from kernel command line in /boot/loader/entries/*.conf
-
+# --- Make oscap fail: remove arg from BLS entries ---
 for file in /boot/loader/entries/*.conf ; do
   if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*' "$file" ; then
 	    sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 \2/' "$file"

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
@@ -3,8 +3,8 @@
 # platform = multi_platform_all
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
@@ -3,15 +3,17 @@
 # platform = multi_platform_all
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
-# Removes argument from kernel command line in /etc/default/grub
+# --- Make oscap fail: remove arg from /etc/default/grub ---
 if grep -q '^GRUB_CMDLINE_LINUX=.*\<{{{ ARG_NAME }}}\>=\?.*"'  '/etc/default/grub' ; then
 	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
 fi

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
@@ -2,8 +2,8 @@
 
 # platform = multi_platform_all
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
 # platform = multi_platform_all
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value (recovery disabled) ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
-# Removes the argument from kernel command line in /etc/default/grub
+# --- Make oscap fail: remove arg from /etc/default/grub ---
 if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*\<{{{ ARG_NAME }}}\>=\?.*"' '/etc/default/grub' ; then
 	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/' '/etc/default/grub'
 fi

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_and_not_referenced.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_and_not_referenced.pass.sh
@@ -4,8 +4,8 @@
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_and_not_referenced.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_and_not_referenced.pass.sh
@@ -4,12 +4,14 @@
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 # ensure that the grubenv entry is not referenced
 # also in RHEL 8, after performing previous steps, the only option is $kernelopts

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_but_referenced.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_but_referenced.fail.sh
@@ -3,8 +3,8 @@
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_but_referenced.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_but_referenced.fail.sh
@@ -2,13 +2,16 @@
 
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Make oscap fail: entries reference $kernelopts but arg missing from grubenv ---
 for entry in /boot/loader/entries/*.conf; do
   if ! grep -q '\$kernelopts' "$entry"; then
     sed -i 's/^\(options.*\)$/\1 \$kernelopts/' "$entry"

--- a/shared/templates/grub2_bootloader_argument/tests/arg_value_below_minimal.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_value_below_minimal.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-{{% if IS_SUBSTRING != "true" %}}
+
+{{% if OPERATION == "pattern match" %}}
 # platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all
@@ -9,14 +10,10 @@
 {{%- else %}}
 # packages = grub2,grubby
 {{%- endif %}}
-
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
-{{%- endif %}}
-
-{{%- set ARG_NAME_VALUE= ARG_NAME_VALUE ~ "A" %}}
+{{% endif %}}
 
 source common.sh
 
-{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME ~ "=" ~ TEST_WRONG_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/arg_value_meets_minimal.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_value_meets_minimal.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-{{% if IS_SUBSTRING != "true" %}}
+
+{{% if OPERATION == "pattern match" %}}
 # platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all
@@ -9,14 +10,10 @@
 {{%- else %}}
 # packages = grub2,grubby
 {{%- endif %}}
-
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
-{{%- endif %}}
-
-{{%- set ARG_NAME_VALUE= ARG_NAME_VALUE ~ "A" %}}
+{{% endif %}}
 
 source common.sh
 
-{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
@@ -7,8 +7,8 @@
 # packages = grub2,grubby
 {{%- endif %}}
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
@@ -7,12 +7,14 @@
 # packages = grub2,grubby
 {{%- endif %}}
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value (recovery disabled) ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir.pass.sh
@@ -3,7 +3,7 @@
 # platform = multi_platform_ubuntu
 # packages = grub2
 
-# Clean up
+# --- Setup: populate grub.d with correct value and update grub ---
 rm -f /etc/default/grub.d/*
 echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
 

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir.pass.sh
@@ -3,6 +3,12 @@
 # platform = multi_platform_ubuntu
 # packages = grub2
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
+{{%- endif %}}
+
 # --- Setup: populate grub.d with correct value and update grub ---
 rm -f /etc/default/grub.d/*
 echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir_noupdate.fail.sh
@@ -4,8 +4,8 @@
 # packages = grub2
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 # Clean up

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir_noupdate.fail.sh
@@ -4,15 +4,16 @@
 # packages = grub2
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
-# Clean up
+# --- Setup: clear grub.d and update grub.cfg to empty state ---
 rm -f /etc/default/grub.d/*
 echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
 {{{ grub_command("update") }}}
 
-# Set the correct argument without updating the grub.cfg
+# --- Make oscap fail: set correct value in grub.d without updating grub.cfg ---
 echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
 

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_exceeds_minimum.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_exceeds_minimum.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+{{% if OPERATION == "greater than or equal" %}}
+# platform = multi_platform_all
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
+# packages = grub2,grubby
+{{%- endif %}}
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ VALUE_AT_THRESHOLD }}}
+{{%- endif %}}
+
+source common.sh
+
+# --- Setup: populate all GRUB configs with value above GTE threshold ---
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME ~ "=" ~ VALUE_ABOVE) }}}
+{{% else %}}
+# platform = Not Applicable
+source common.sh
+{{% endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
@@ -3,8 +3,8 @@
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
@@ -2,13 +2,16 @@
 
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: correct value in grubenv with BLS entries referencing $kernelopts ---
 # adds argument from kernel command line into /etc/default/grub
 file="/etc/default/grub"
 if grep -q '^GRUB_CMDLINE_LINUX=.*\<{{{ ARG_NAME }}}\>=\?.*"'  "$file"; then

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_meets_minimum.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_meets_minimum.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+{{% if OPERATION == "greater than or equal" %}}
+# platform = multi_platform_all
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
+# packages = grub2,grubby
+{{%- endif %}}
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ VALUE_AT_THRESHOLD }}}
+{{%- endif %}}
+
+source common.sh
+
+# --- Setup: populate all GRUB configs with value at GTE threshold ---
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME ~ "=" ~ VALUE_AT_THRESHOLD) }}}
+{{% else %}}
+# platform = Not Applicable
+source common.sh
+{{% endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
@@ -3,8 +3,8 @@
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
@@ -2,13 +2,16 @@
 
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: correct value in both BLS entries and grubenv ---
 # adds argument from kernel command line into /etc/default/grub
 file="/etc/default/grub"
 if grep -q '^GRUB_CMDLINE_LINUX=.*\<{{{ ARG_NAME }}}\>=\?.*"'  "$file"; then

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
@@ -3,8 +3,8 @@
 # platform = multi_platform_all
 # packages = grub2
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
@@ -2,18 +2,20 @@
 
 # platform = multi_platform_all
 # packages = grub2
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
-# Clean up
+# --- Setup: clear configs and update grub.cfg to empty state ---
 rm -f /etc/default/grub.d/*
 echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
 {{{ grub_command("update") }}}
 
-# Set the correct argument without updating the grub.cfg
+# --- Make oscap fail: set correct value in /etc/default/grub without updating grub.cfg ---
 echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub
 

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_remediated.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_remediated.pass.sh
@@ -7,8 +7,8 @@
 # packages = grub2,grubby
 {{%- endif %}}
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_remediated.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_remediated.pass.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
 # platform = multi_platform_all
+
 {{%- if 'ubuntu' in product %}}
 # packages = grub2
 {{%- else %}}
 # packages = grub2,grubby
 {{%- endif %}}
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_left.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_left.pass.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-{{% if IS_SUBSTRING != "true" %}}
-# platform = Not Applicable
-{{% else %}}
+# Test: expected value appears inside a longer actual value (appended flags).
+# Example: slub_debug on OL8 — profile expects "P", system has "PA" (P + extra flag).
+# operation: pattern match finds "P" inside "PA" -> PASS.
+#
+# Only applicable when the rule uses operation: pattern match.
+
+{{% if OPERATION == "pattern match" %}}
 # platform = multi_platform_all
+{{% else %}}
+# platform = Not Applicable
 {{% endif %}}
 {{%- if 'ubuntu' in product %}}
 # packages = grub2
@@ -12,11 +18,14 @@
 
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
 {{%- endif %}}
 
+# Append "A" to the value: e.g. slub_debug=PA instead of slub_debug=P
 {{%- set ARG_NAME_VALUE= ARG_NAME_VALUE ~ "A" %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with value containing extra leading chars ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_right.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_right.pass.sh
@@ -11,8 +11,8 @@
 {{%- endif %}}
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 {{%- set ARG_NAME_VALUE = (ARG_NAME_VALUE | replace("=","=A")) %}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_right.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_right.pass.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-{{% if IS_SUBSTRING != "true" %}}
-# platform = Not Applicable
-{{% else %}}
+# Test: expected value appears inside a longer actual value (prepended flags).
+# Example: slub_debug on OL8 — profile expects "P", system has "FP" (extra flag + P).
+# operation: pattern match finds "P" inside "FP" -> PASS.
+#
+# Only applicable when the rule uses operation: pattern match.
+
+{{% if OPERATION == "pattern match" %}}
 # platform = multi_platform_all
+{{% else %}}
+# platform = Not Applicable
 {{% endif %}}
 {{%- if 'ubuntu' in product %}}
 # packages = grub2
@@ -12,11 +18,14 @@
 
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
 {{%- endif %}}
 
+# Prepend "A" to the value: e.g. slub_debug=AP instead of slub_debug=P
 {{%- set ARG_NAME_VALUE = (ARG_NAME_VALUE | replace("=","=A")) %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with value containing extra trailing chars ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
@@ -3,8 +3,8 @@
 # platform = Red Hat Enterprise Linux 9,Red Hat Enterprise Linux 10,multi_platform_fedora
 # packages = grub2,grubby
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
@@ -2,13 +2,16 @@
 
 # platform = Red Hat Enterprise Linux 9,Red Hat Enterprise Linux 10,multi_platform_fedora
 # packages = grub2,grubby
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Rule should find this file and notice it is not right

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_below_minimum.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_below_minimum.fail.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+{{% if OPERATION == "greater than or equal" %}}
+# platform = multi_platform_all
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
+# packages = grub2,grubby
+{{%- endif %}}
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ VALUE_AT_THRESHOLD }}}
+{{%- endif %}}
+
+source common.sh
+
+# --- Make oscap fail: set value below GTE threshold in all configs ---
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME ~ "=" ~ VALUE_BELOW) }}}
+{{% else %}}
+# platform = Not Applicable
+source common.sh
+{{% endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -3,9 +3,9 @@
 # platform = multi_platform_fedora,multi_platform_rhel
 # packages = grub2,grubby
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_WRONG_VALUE %}}
 {{%- else %}}
 {{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
 {{%- endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -2,19 +2,21 @@
 
 # platform = multi_platform_fedora,multi_platform_rhel
 # packages = grub2,grubby
+
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
-{{%- else %}}
-{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
+{{#- Wrong value: right argument name, wrong value (e.g. audit_backlog_limit=8191) #}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_VALUE_FAIL %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
-# Breaks argument from kernel command line in /boot/loader/entries/*.conf
+# --- Make oscap fail: set wrong value in BLS entries ---
 for file in /boot/loader/entries/*.conf ; do
   if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*'  "$file" ; then
       # modify the GRUB command-line if an ={{{ARG_NAME}}} arg already exists

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
@@ -9,9 +9,9 @@
 {{%- endif %}}
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_WRONG_VALUE %}}
 {{%- else %}}
 {{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
 {{%- endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
@@ -9,19 +9,19 @@
 {{%- endif %}}
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
-{{%- else %}}
-{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
+{{#- Wrong value: right argument name, wrong value (e.g. audit_backlog_limit=8191) #}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_VALUE_FAIL %}}
 
 source common.sh
 
-# Clean up and make sure we are at a passing state
+# --- Setup: populate /etc/default/grub with correct value and update grub.cfg ---
 rm -f /etc/default/grub.d/*
 echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub
 {{{ grub_command("update") }}}
 
-# Set to wrong var/value
-echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE_WRONG }}}=\"" > /etc/default/grub
+# --- Make oscap fail: set wrong value in /etc/default/grub ---
+echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE_WRONG }}}\"" > /etc/default/grub

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
@@ -4,8 +4,8 @@
 # packages = grub2
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
 {{%- endif %}}
 
 # Clean up and make sure we are at a passing state
@@ -15,5 +15,5 @@ echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custo
 {{{ grub_command("update") }}}
 
 # Set to wrong var/value
-echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME }}}=wrong_value\"" > /etc/default/grub.d/custom.cfg
+echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME }}}={{{ TEST_WRONG_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
 

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
@@ -4,16 +4,19 @@
 # packages = grub2
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
+{{#- Wrong value: right argument name, wrong value (e.g. audit_backlog_limit=8191) #}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_VALUE_FAIL %}}
 
-# Clean up and make sure we are at a passing state
+# --- Setup: populate grub.d with correct value and update grub.cfg ---
 rm -f /etc/default/grub.d/*
 echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
 echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
 {{{ grub_command("update") }}}
 
-# Set to wrong var/value
-echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME }}}=wrong_value\"" > /etc/default/grub.d/custom.cfg
+# --- Make oscap fail: set wrong value in /etc/default/grub.d/ ---
+echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME_VALUE_WRONG }}}\"" > /etc/default/grub.d/custom.cfg
 

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
@@ -2,9 +2,9 @@
 # platform = multi_platform_all
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_WRONG_VALUE %}}
 {{%- else %}}
 {{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
 {{%- endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
@@ -2,16 +2,16 @@
 # platform = multi_platform_all
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
-{{%- else %}}
-{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
+{{#- Wrong value: right argument name, wrong value (e.g. audit_backlog_limit=8191) #}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_VALUE_FAIL %}}
 
 source common.sh
 
-# Clean up and make sure we are at a passing state
+# --- Make oscap fail: set wrong value in /etc/default/grub (recovery disabled) ---
 rm -f /etc/default/grub.d/*
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
@@ -4,9 +4,9 @@
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_CORRECT_VALUE %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_WRONG_VALUE %}}
 {{%- else %}}
 {{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
 {{%- endif %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
@@ -4,25 +4,26 @@
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
-{{%- else %}}
-{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+# variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}
+{{#- Rules that use arg_variable have no =value in ARG_NAME_VALUE, override with dummy #}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=" ~ TEST_VALUE_PASS %}}
 {{%- endif %}}
+{{#- Wrong value: right argument name, wrong value (e.g. audit_backlog_limit=8191) #}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=" ~ TEST_VALUE_FAIL %}}
 
 source common.sh
 
+# --- Setup: populate all GRUB configs with correct value ---
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
-# Break the argument in kernel command line in /boot/grub2/grubenv
+# --- Make oscap fail: set wrong value in grubenv ---
 file="/boot/grub2/grubenv"
 if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*' "$file" ; then
 	# modify the GRUB command-line if the arg already exists
-	sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong \2/' "$file"
+	sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}} \2/' "$file"
 else
 	# no arg is present, append it
-	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong/' "$file"
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}/' "$file"
 fi
 
 # Ensure that grubenv is referenced through $kernelopts

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -60,7 +60,8 @@ def _unicode_constructor(self, node):
     return str(string_like)
 
 
-# Don't follow python bool case
+# keep YAML booleans as Python strings (on/off/yes/no/true/false,...)
+# instead of converting them to Python bools
 yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:bool', _bool_constructor)
 # Python2-relevant - become able to resolve "unicode strings"
 yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:python/unicode', _unicode_constructor)


### PR DESCRIPTION
#### Description:
- Add `operation` and `datatype` parameters to the
  `grub2_bootloader_argument` template so rules can use numeric
  comparisons (e.g. `"greater than or equal"`) and typed matching
  instead of exact string regex.
- Objects now extract only the argument value via capturing groups.
  States compare using OVAL-native `operation` and `datatype`.
- `template.py` validates operation/datatype combinations at build
  time, requires quoted `arg_value`, requires explicit params for
  `arg_variable` rules. Follows the `sysctl` template pattern.
- Update `grub2_audit_backlog_limit_argument` to use
  `"greater than or equal"` + `int`.
- Update `grub2_slub_debug_argument@ol8` to use `"pattern match"`
  (replaces deprecated `is_substring`).
- All other 17 rules set to `"equals"` + `"string"` (explicit).
- Update test scenarios to be more modular — pass custom testing
  values via `template.py` instead of hardcoding in the scripts.
- 3 new tests for >= (value at threshold, above, below).
- Fix existing template automatus test scripts: use the actual 
  argument name with a wrong value instead of replacing the
  entire argument with garbage.
- Document new parameters in `template_reference.md`.
#### Rationale:
- A system with `audit_backlog_limit=16384` would FAIL the check even
  though 16384 exceeds the required threshold of 8192 — the old
  template used exact string matching for all comparisons.
- Implements the `operation` + `datatype` approach suggested in the
  original PR review (orthogonal to `arg_value`/`arg_variable`).
- Fixes #13923
#### Review Hints:
- Review commits in order: `template.py` first (preprocessing), then
  `oval.template` (the OVAL plumbing), then rule YAMLs, tests, docs.
- Build and inspect representative OVALs:
```
$ ./build_product --datastream-only
```

- `rhel9 / grub2_audit_backlog_limit_argument` — variable + int + >= + bootc
- `rhel9 / grub2_audit_argument` — literal + int + equals + bootc
- `rhel9 / grub2_nousb_argument` — no value, existence-only (no state)
- `rhel8 / grub2_audit_backlog_limit_argument` — variable + int + >= + $kernelopts
- `ol8 / grub2_slub_debug_argument` — variable + string + pattern match
- `ubuntu2404 / grub2_pti_argument` — literal + string + equals + grub.d
- `rhel9 / grub2_ipv6_disable_argument` — literal + int + equals + dot in name
- State must have correct `operation`/`datatype`, no `<local_variable>`
or `<concat>`.
- Test with `automatus.py` — needs a VM, not a container. Using multiple
parallel VMs is recommended (`--slice` argument):
```
$ ./tests/automatus.py template
--libvirt qemu:///session
--datastream ./build/ssg-rhel9-ds.xml
grub2_bootloader_argument
```

- The `oval.template` has extensive inline comments — the header
documentation is a good starting point.
- The RHEL 8 presence+value split is the trickiest part — it exists
because the wide-capture object must stay for `$kernelopts` detection.
- Local VM testing: RHEL 9 202/202, RHEL 8 239/240 (one pre-existing
`grub2_ipv6_disable_argument` failure).
- CI failures are all pre-existing — see comment below.