### PR TITLE
Add variable for pacakge_chrony_installed

### DIFF
--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -116,6 +116,7 @@ controls:
       levels:
           - low
       rules:
+          - var_timesync_service=chronyd
           - package_chrony_installed
       status: automated
 


### PR DESCRIPTION
#### Description:

- Add variable for package_chrony_installed

#### Rationale:

- It's missing