### PR TITLE
Add rule accounts_umask_etc_bashrc and accounts_umask_etc_profile to Hummingbird

### DIFF
--- a/components/tcsh.yml
+++ b/components/tcsh.yml
@@ -1,5 +1,5 @@
 name: tcsh
 packages:
-- tcsh
+  - tcsh
 rules:
-- accounts_umask_etc_csh_cshrc
+  - accounts_umask_etc_csh_cshrc

--- a/components/tcsh.yml
+++ b/components/tcsh.yml
@@ -1,0 +1,5 @@
+name: tcsh
+packages:
+- tcsh
+rules:
+- accounts_umask_etc_csh_cshrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/hummingbird/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/hummingbird/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+
+{{{ bash_instantiate_variables("var_accounts_user_umask") }}}
+
+if grep -q "^[^#]*\bumask" "$NEWROOT/etc/bashrc" ; then
+    sed -i -E -e "s/^([^#]*\bumask)[[:space:]]+[[:digit:]]+/\1 $var_accounts_user_umask/g" "$NEWROOT/etc/bashrc"
+else
+    echo "umask $var_accounts_user_umask" >> "$NEWROOT/etc/bashrc"
+fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/rule.yml
@@ -62,3 +62,5 @@ fixtext: |-
     umask {{{ xccdf_value("var_accounts_user_umask") }}}
 
 srg_requirement: '{{{ full_name }}} must define default permissions for the c shell.'
+
+platform: package[tcsh]

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/rule.yml
@@ -50,7 +50,7 @@ ocil: |-
 
     UMASK {{{ xccdf_value("var_accounts_user_umask") }}}</pre>
 
-platform: package[shadow-utils]
+platform: package[shadow-utils] and system_with_kernel
 
 checktext: |-
     Verify {{{ full_name }}} defines default permissions for all authenticated users in such a way that the user can only read and modify their own files with the following command:

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/hummingbird/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/hummingbird/shared.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+{{{ bash_instantiate_variables("var_accounts_user_umask") }}}
+
+readarray -t profile_files < <(find $NEWROOT/etc/profile.d/ -type f -name '*.sh' -or -name 'sh.local')
+
+for file in "${profile_files[@]}" $NEWROOT/etc/profile; do
+  grep -qE '^[^#]*umask' "$file" && sed -i -E "s/^(\s*umask\s*)[0-7]+/\1$var_accounts_user_umask/g" "$file"
+done
+
+if ! grep -qrE '^[^#]*umask' $NEWROOT/etc/profile*; then
+  echo "umask $var_accounts_user_umask" >> $NEWROOT/etc/profile
+fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/rule.yml
@@ -47,3 +47,5 @@ fixtext: |-
     If the account is for an application, the requirement for a umask less restrictive than "077" can be documented with the Information System Security Officer, but the user agreement for access to the account must specify that the local interactive user must log on to their account first and then switch the user to the application account with the correct option to gain the account's environment variables.
 
 srg_requirement: '{{{ full_name }}} must set the umask value to 077 for all local interactive user accounts.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/group.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/group.yml
@@ -18,4 +18,3 @@ description: |-
     easy to intentionally share files with groups of which the user is
     a member.
     <br /><br />
-

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/group.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/group.yml
@@ -19,4 +19,3 @@ description: |-
     a member.
     <br /><br />
 
-platform: system_with_kernel

--- a/products/hummingbird/controls/cis_hummingbird.yml
+++ b/products/hummingbird/controls/cis_hummingbird.yml
@@ -1682,7 +1682,10 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: not applicable
+      status: automated
+      rules:
+          - accounts_umask_etc_bashrc
+          - var_accounts_user_umask=027
 
     - id: 6.1.1
       title: Ensure AIDE is installed (Automated)

--- a/products/hummingbird/controls/cis_hummingbird.yml
+++ b/products/hummingbird/controls/cis_hummingbird.yml
@@ -1685,6 +1685,7 @@ controls:
       status: automated
       rules:
           - accounts_umask_etc_bashrc
+          - accounts_umask_etc_profile
           - var_accounts_user_umask=027
 
     - id: 6.1.1

--- a/products/hummingbird/controls/stig_hummingbird.yml
+++ b/products/hummingbird/controls/stig_hummingbird.yml
@@ -1212,6 +1212,7 @@ controls:
       status: automated
       rules:
           - accounts_umask_etc_bashrc
+          - accounts_umask_etc_profile
           - var_accounts_user_umask=027
 
     - id: SRG-OS-000590-GPOS-00110

--- a/products/hummingbird/controls/stig_hummingbird.yml
+++ b/products/hummingbird/controls/stig_hummingbird.yml
@@ -1209,7 +1209,10 @@ controls:
       levels:
           - medium
       title: 'Red Hat Hummingbird must limit the ability of non-privileged users to grant other users direct access to the contents of their home directories/folders.'
-      status: does not meet
+      status: automated
+      rules:
+          - accounts_umask_etc_bashrc
+          - var_accounts_user_umask=027
 
     - id: SRG-OS-000590-GPOS-00110
       levels:

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -172,3 +172,5 @@ args:
     pkgname: rsyslog
   rootfiles:
     pkgname: rootfiles
+  tcsh:
+    pkgname: tcsh


### PR DESCRIPTION
#### Description:
Add rules accounts_umask_etc_bashrc and accounts_umask_etc_profile to Hummingbird to STIG and CIS profiles. Add a special remediation for hummingbird for these rules.

#### Rationale:

The rules `accounts_umask_etc_bashrc` and `accounts_umask_etc_profile` evaluate as FAIL by default on most hummingbird images. Having these rules with a remediation in the content will allow us to demonstrate and test how the remediation will work during the container image build time.

#### Review Hints:

