### PR TITLE
Make sure the sequoia package is installed across CIS profiles

### DIFF
--- a/products/rhel10/controls/cis_rhel10.yml
+++ b/products/rhel10/controls/cis_rhel10.yml
@@ -369,6 +369,7 @@ controls:
       status: partial
       rules:
           - ensure_redhat_gpgkey_installed
+          - package_sequoia-sq_installed
       notes: >
         In CIS Benchmark, the requirement is manual, because of GPG keys for 3rd party repositories.
         But, add the rule ensure_redhat_gpgkey_installed to the profile because the requirement 1.2.1.2

--- a/tests/data/profile_stability/rhel10/cis.profile
+++ b/tests/data/profile_stability/rhel10/cis.profile
@@ -338,6 +338,7 @@ package_openldap-clients_removed
 package_pam_pwquality_installed
 package_rsync_removed
 package_samba_removed
+package_sequoia-sq_installed
 package_setroubleshoot_removed
 package_squid_removed
 package_sudo_installed

--- a/tests/data/profile_stability/rhel10/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_server_l1.profile
@@ -240,6 +240,7 @@ package_nginx_removed
 package_pam_pwquality_installed
 package_rsync_removed
 package_samba_removed
+package_sequoia-sq_installed
 package_setroubleshoot_removed
 package_squid_removed
 package_sudo_installed

--- a/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
@@ -236,6 +236,7 @@ package_nginx_removed
 package_pam_pwquality_installed
 package_rsync_removed
 package_samba_removed
+package_sequoia-sq_installed
 package_squid_removed
 package_sudo_installed
 package_systemd-journal-remote_installed

--- a/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
@@ -337,6 +337,7 @@ package_openldap-clients_removed
 package_pam_pwquality_installed
 package_rsync_removed
 package_samba_removed
+package_sequoia-sq_installed
 package_squid_removed
 package_sudo_installed
 package_systemd-journal-remote_installed


### PR DESCRIPTION


#### Description:

- The package might not be always installed by default and the fingerprint of PQC keys does not work properly.

#### Rationale:

- Should fix the gpg import tasks where the sequoia package is not installed by default.
- Related to: #14193