### PR TITLE
Customize and limit Renovate service to tekton pipelines and RPM lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "ok-to-test"
+  ],
+  "enabledManagers": [
+      "tekton",
+      "rpm-lockfile"
+  ]
+}


### PR DESCRIPTION


#### Description:

- Override enabled managers to only `tekton` pipelines and `rpm-lockfile` refreshes.
- Automatically add `ok-to-test` label on PRs opened by the bot.

#### Rationale:

- By adding a `renovate.json` to the default branch we can configure and customize Renovate's functionality.

- Restricts Renovate from bumping python and GitHub Actions dependencies.

#### Review Hints:

- Unfortunately there is no good way to test this, besides merging and seeing how Renovate acts.
- Docs: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#configuration