### PR TITLE
DISA STIG: Update RHEL8 V2R6 → V2R7

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/policy/stig/shared.yml
@@ -7,9 +7,7 @@ vuldiscussion: |-
 
 
 checktext: |-
-    Note: For systems that use BIOS, this requirement is Not Applicable.
-
-    Note: If the /boot/efi partition is mounted with a vfat filesystem, this requirement is Not Applicable.
+    Note: For systems that use BIOS, this requirement is not applicable.
 
     Verify the /boot/efi directory is mounted with the "nosuid" option with the following command:
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -33,7 +33,6 @@ template:
     vars:
         mountpoint: /boot/efi
         mountoption: nosuid
-        exclude_filesystem_type: vfat
     backends:
         anaconda: "off"
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_with_nosuid.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_with_nosuid.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # This test verifies that the rule passes when /boot/efi is mounted with vfat filesystem
-# Even with nosuid set, vfat is excluded from the requirement (nosuid has no effect on vfat)
 
 # packages = dosfstools
 
@@ -14,7 +13,7 @@ VFAT_PARTITION="/root/vfat_partition"
 dd if=/dev/zero of=$VFAT_PARTITION bs=1M count=50
 mkfs.vfat $VFAT_PARTITION
 
-# Add to fstab with nosuid option (should still pass because vfat is excluded)
+# Add to fstab with nosuid option
 mkdir -p /boot/efi
 echo "$VFAT_PARTITION /boot/efi vfat rw,nosuid,relatime,loop 0 0" >> /etc/fstab
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_without_nosuid.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_without_nosuid.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# This test verifies that the rule passes when /boot/efi is mounted with vfat filesystem
-# The nosuid requirement is not applicable to vfat filesystems
+# This test verifies that the rule fails when /boot/efi
+# is mounted with vfat without the nosuid option
 
 # packages = dosfstools
 
@@ -14,7 +14,7 @@ VFAT_PARTITION="/root/vfat_partition"
 dd if=/dev/zero of=$VFAT_PARTITION bs=1M count=50
 mkfs.vfat $VFAT_PARTITION
 
-# Add to fstab without nosuid option (should pass because vfat is excluded)
+# Add to fstab without the nosuid option
 mkdir -p /boot/efi
 echo "$VFAT_PARTITION /boot/efi vfat rw,relatime,loop 0 0" >> /etc/fstab
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -39,10 +39,12 @@ ocil: |-
     The runtime status of the <code>kernel.kptr_restrict</code> kernel parameter can be queried
     by running the following command:
     <pre>$ sysctl kernel.kptr_restrict</pre>
-    The output of the command should indicate either:
+    The output of the command should indicate:
     <code>kernel.kptr_restrict = 1</code>
+    {{% if product != 'rhel8' %}}
     or:
     <code>kernel.kptr_restrict = 2</code>
+    {{% endif %}}
     The output of the command should not indicate:
     <code>kernel.kptr_restrict = 0</code>
 
@@ -55,12 +57,14 @@ ocil: |-
     <pre>$ grep -r '^\s*kernel.kptr_restrict\s*=' /etc/sysctl.conf /etc/sysctl.d</pre>
     The command should not find any assignments other than:
     kernel.kptr_restrict = 1
+    {{% if product != 'rhel8' %}}
     or:
     kernel.kptr_restrict = 2
+    {{% endif %}}
 
     Conflicting assignments are not allowed.
 
-ocil_clause: "the kernel.kptr_restrict is not set to 1 or 2 or is configured to be 0"
+ocil_clause: "the kernel.kptr_restrict is not set to 1{{% if product != 'rhel8' %}} or 2{{% endif %}} or is configured to be 0"
 
 srg_requirement: '{{{ full_name }}} must restrict exposed kernel pointer addresses access.'
 
@@ -70,7 +74,10 @@ template:
     name: sysctl
     vars:
         sysctlvar: kernel.kptr_restrict
-        {{% if 'ol' in families or 'rhel' in product %}}
+        {{% if product == 'rhel8' %}}
+        sysctlval: '1'
+        wrong_sysctlval_for_testing: "0"
+        {{% elif 'ol' in families or 'rhel' in product %}}
         sysctlval:
         - '1'
         - '2'

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_2_rhel8.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_2_rhel8.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if product == 'rhel8' %}}
-# platform = Not Applicable
-{{% else %}}
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
-{{% endif %}}
+# platform = Red Hat Enterprise Linux 8
 
 # Clean sysctl config directories
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
@@ -27,7 +27,7 @@ ocil_clause: 'the command does not return any output, or the line is commented o
 ocil: |-
     If the device or {{{ full_name }}} does not have a camera installed, this requirement is not applicable.
 
-    This requirement is not applicable to mobile devices (smartphones and tablets), where the use of the camera is a local AO decision.
+    This requirement is not applicable to mobile devices (smartphones and tablets), where the use of the camera is a local Authorizing Official (AO) decision.
 
     This requirement is not applicable to dedicated VTC suites located in approved VTC locations that are centrally managed.
 
@@ -35,20 +35,21 @@ ocil: |-
 
     For a built-in camera, the camera must be protected by a camera cover (e.g., laptop camera cover slide) when not in use. If the built-in camera is not protected with a camera cover, or is not physically disabled, this is a finding.
 
-    If the camera is not disconnected, covered, or physically disabled, determine if it is being disabled via software with the following commands:
+    If the camera is not disconnected, covered, or physically disabled, determine if it is being disabled via software.
 
-    Verify the operating system disables the ability to load the uvcvideo kernel module.
+    Verify the operating system disables the ability to load the uvcvideo kernel module and ensure that the uvcvideo protocol module is disabled with the following command:
 
-    $ sudo grep -r uvcvideo /etc/modprobe.d/* | grep "/bin/true"
+    $ sudo grep -r uvcvideo /etc/modprobe.d/
 
-    install uvcvideo /bin/true
+    /etc/modprobe.d/uvcvideo-blacklist.conf:install uvcvideo /bin/false
+    /etc/modprobe.d/uvcvideo-blacklist.conf:blacklist uvcvideo
 
 fixtext: |-
     Configure {{{ full_name }}} to disable the built-in or attached camera when not in use.
 
-    Build or modify the "/etc/modprobe.d/blacklist.conf" file by using the following example:
+    Add or update the following lines in the "/etc/modprobe.d/uvcvideo-blacklist.conf" file:
 
-    install uvcvideo /bin/true
+    install uvcvideo /bin/false
     blacklist uvcvideo
 
     Reboot the system for the settings to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/policy/stig/shared.yml
@@ -7,7 +7,7 @@ vuldiscussion: |-
 checktext: |-
     Verify that the IPsec service uses the system crypto policy with the following command:
 
-    Note: If the ipsec service is not installed, this requirement is Not Applicable.
+    Note: If the IPsec service is not installed, this requirement is not applicable.
 
     $ sudo grep include /etc/ipsec.conf /etc/ipsec.d/*.conf
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: |-
     the "IPsec" service is active and the ipsec configuration file does not contain does not contain <tt>include /etc/crypto-policies/back-ends/libreswan.config</tt>
 
 ocil: |-
-    Verify that the IPSec service uses the system crypto policy.
+    Verify that the IPsec service uses the system crypto policy.
 
-    If the ipsec service is not installed is not applicable.
+    If the IPsec service is not installed, this requirement is not applicable.
 
     Check to see if the "IPsec" service is active with the following command:
 

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/policy/stig/shared.yml
@@ -12,6 +12,8 @@ vuldiscussion: |-
     Installing software updates is a fundamental mitigation against the exploitation of publicly known vulnerabilities. If the most recent security patches and updates are not installed, unauthorized users may take advantage of weaknesses in the unpatched software. The lack of prompt attention to patching could result in a system compromise.
 
 checktext: |-
+    Note: If the system is not connected to the internet, this requirement is not applicable.
+
     Verify {{{ full_name }}} security patches and updates are installed and up to date. Updates are required to be applied with a frequency determined by organizational policy.
 
     Obtain the list of available package security updates from Red Hat. The URL for updates is https://access.redhat.com/errata-search/. It is important to note that updates provided by Red Hat may not be present on the system if the underlying packages are not installed.

--- a/products/rhel8/controls/stig_rhel8.yml
+++ b/products/rhel8/controls/stig_rhel8.yml
@@ -2,7 +2,7 @@
 policy: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
 title: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
 id: stig_rhel8
-version: V2R6
+version: V2R7
 source: https://www.cyber.mil/stigs/downloads
 reference_type: stigid
 product: rhel8

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -2,7 +2,7 @@
 documentation_complete: true
 
 metadata:
-    version: V2R6
+    version: V2R7
     SMEs:
         - mab879
         - ggbecker
@@ -13,7 +13,7 @@ title: 'DISA STIG for Red Hat Enterprise Linux 8'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for Red Hat Enterprise Linux 8 V2R6.
+    DISA STIG for Red Hat Enterprise Linux 8 V2R7.
 
     In addition to being applicable to Red Hat Enterprise Linux 8, this
     configuration baseline is applicable to the operating system tier of

--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -2,7 +2,7 @@
 documentation_complete: true
 
 metadata:
-    version: V2R6
+    version: V2R7
     SMEs:
         - mab879
         - ggbecker
@@ -13,7 +13,7 @@ title: 'DISA STIG with GUI for Red Hat Enterprise Linux 8'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG with GUI for Red Hat Enterprise Linux 8 V2R6.
+    DISA STIG with GUI for Red Hat Enterprise Linux 8 V2R7.
 
     In addition to being applicable to Red Hat Enterprise Linux 8, this
     configuration baseline is applicable to the operating system tier of


### PR DESCRIPTION
#### Description:

- Update RHEL 8 DISA STIG profiles and control file from V2R6 to V2R7
- Rule changes across STIG IDs:
  - RHEL-08-010010 (`security_patches_up_to_date`): update policy checktext
    for systems not connected to the internet
  - RHEL-08-010572 (`mount_option_boot_efi_nosuid`): drop the vfat exclusion
    from the mount_option template — the rule now checks nosuid regardless of
    filesystem type; fix and rename test scenarios
  - RHEL-08-040020 (`kernel_module_uvcvideo_disabled`): switch to blacklist
    approach and use `/bin/false` instead of `/bin/true`
  - RHEL-08-040060 (`configure_libreswan_crypto_policy`): grammar and policy
    text fix
  - RHEL-08-040283 (`sysctl_kernel_kptr_restrict`): enforce
    `kernel.kptr_restrict=1` only (drop acceptance of value 2); add tests

#### Rationale:

- DISA released STIG V2R7 for RHEL 8; the profiles and rules need to track it

#### Review Hints:

- `mount_option_boot_efi_nosuid`: the vfat exclusion was wrong — `/boot/efi`
  is always vfat, so the check never applied; removing `exclude_filesystem_type`
  makes the rule actually evaluate
- `sysctl_kernel_kptr_restrict`: `value_2_rhel8.fail.sh` is a product-specific
  test that only applies to RHEL 8 STIG; value 2 remains valid for other
  products
- To test locally: `./build_product rhel8 --datastream-only` then run automatus
  against the changed rules on a RHEL 8 VM


> [!WARNING]
> These changes also include fs/kernel rules so it cannot be tested in a container - some of the tests WILL fail because of this