### PR TITLE
Fix chronyd_or_ntpd_set_maxpoll bash remediation when /etc/chrony.d is missing

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -48,25 +48,31 @@
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
   when: chrony_conf_exist_result.stat.exists
 
+- name: "{{{ rule_title }}} - Check That {{{ chrony_d_path }}} Exist"
+  ansible.builtin.stat:
+    path: "{{{ chrony_d_path }}}"
+  register: chrony_d_path_exists
+
 - name: "{{{ rule_title }}} - Get Conf Files from {{{ chrony_d_path }}}"
   ansible.builtin.find:
     path: "{{{ chrony_d_path }}}"
     patterns: '*.conf'
     file_type: file
   register: chrony_d_conf_files
+  when: chrony_d_path_exists.stat.exists and chrony_d_path_exists.stat.isdir
 
 - name: "{{{ rule_title }}} - Update the maxpoll Values in {{{ chrony_d_path }}}"
   ansible.builtin.replace:
     path: "{{ item.path }}"
     regexp: '^((?:server|pool|peer).*maxpoll)[ ]+[0-9,-]+(.*)$'
     replace: '\1 {{ var_time_service_set_maxpoll }}\2'
-  loop: '{{ chrony_d_conf_files.files }}'
-  when: chrony_d_conf_files.matched
+  loop: '{{ chrony_d_conf_files.files | default([]) }}'
+  when: chrony_d_conf_files is defined and chrony_d_conf_files.matched
 
 - name: "{{{ rule_title }}} - Set the maxpoll Values in {{{ chrony_d_path }}}"
   ansible.builtin.replace:
     path: "{{ item.path }}"
     regexp: '(^(?:server|pool|peer)\s+((?!maxpoll).)*)$'
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
-  loop: '{{ chrony_d_conf_files.files }}'
-  when: chrony_d_conf_files.matched
+  loop: '{{ chrony_d_conf_files.files | default([]) }}'
+  when: chrony_d_conf_files is defined and chrony_d_conf_files.matched

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -12,11 +12,11 @@ pof="/usr/sbin/pidof"
 CONFIG_FILES="/etc/ntp.conf"
 $pof ntpd || {
     CHRONY_D_PATH={{{ chrony_d_path }}}
-    {{% if 'slmicro' in product %}}
-    mapfile -t CONFIG_FILES < <(find ${CHRONY_D_PATH} -type f -name '*.conf')
-    {{% else %}}
-    mapfile -t CONFIG_FILES < <(find ${CHRONY_D_PATH}.* -type f -name '*.conf')
-    {{% endif %}}
+    if [ -d "${CHRONY_D_PATH}" ]; then
+        mapfile -t CONFIG_FILES < <(find ${CHRONY_D_PATH} -type f -name '*.conf')
+    else
+        CONFIG_FILES=()
+    fi
     CONFIG_FILES+=({{{ chrony_conf_path }}})
 }
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_d_missing_main_conf_configured.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_d_missing_main_conf_configured.pass.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# packages = chrony
+# variables = var_time_service_set_maxpoll=16
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+
+{{{ bash_package_remove("ntp") }}}
+
+# Remove the /etc/chrony.d directory to simulate systems where it doesn't exist
+# (e.g., ppc64le systems with chrony-dhcp in Testing Farm)
+rm -rf {{{ chrony_d_path }}}
+
+# Configure maxpoll correctly in the main chrony.conf file
+sed -i "/^\(server\|pool\).*/d" {{{ chrony_conf_path }}}
+echo "pool pool.ntp.org iburst maxpoll 16" >> {{{ chrony_conf_path }}}
+echo "server time.nist.gov maxpoll 16" >> {{{ chrony_conf_path }}}
+
+systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_d_missing_main_conf_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_d_missing_main_conf_misconfigured.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = chrony
+# variables = var_time_service_set_maxpoll=16
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# remediation = bash,ansible
+
+{{{ bash_package_remove("ntp") }}}
+
+# Remove the /etc/chrony.d directory to simulate systems where it doesn't exist
+# (e.g., ppc64le systems with chrony-dhcp in Testing Farm)
+rm -rf {{{ chrony_d_path }}}
+
+# Configure maxpoll incorrectly in the main chrony.conf file
+sed -i "/^\(server\|pool\).*/d" {{{ chrony_conf_path }}}
+echo "pool pool.ntp.org iburst maxpoll 18" >> {{{ chrony_conf_path }}}
+echo "server time.nist.gov maxpoll 20" >> {{{ chrony_conf_path }}}
+
+systemctl enable chronyd.service


### PR DESCRIPTION
#### Description:

Both bash and Ansible remediation scripts failed when /etc/chrony.d directory
doesn't exist, which happens on systems using chrony-dhcp (e.g., ppc64le
systems in Testing Farm).

Bash remediation:
- Add directory existence check before running find
- Remove product-specific branching and unify code path
- Initialize empty array if directory is missing

Ansible remediation:
- Add stat task to check directory existence before find
- Only run find when directory exists and is a directory
- Use 'default([])' for safe variable handling
- Check variable is defined before accessing .matched


#### Rationale:

- Fixes #14541 
