### PR TITLE
yamllint: prevent the script from being killed before we get output

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -44,9 +44,11 @@ jobs:
             if grep -qP '\{\{[%{#]' "$file"; then
               # File contains Jinja2 constructs — strip them before linting.
               # yamllint -s exits: 0 = clean, 1 = errors, 2 = warnings only.
+              # Use "|| rc=$?" to prevent set -e from killing the script before
+              # we can capture the exit code and print the diagnostic output.
+              rc=0
               output=$(python3 utils/strip_jinja_for_yamllint.py "$file" \
-                       | yamllint -s -c .yamllint - 2>&1)
-              rc=$?
+                       | yamllint -s -c .yamllint - 2>&1) || rc=$?
               # Show all output (warnings and errors), replacing "stdin"
               # with the actual filename since yamllint reads from a pipe.
               if [ -n "$output" ]; then
@@ -57,8 +59,8 @@ jobs:
                 exit_code=1
               fi
             else
-              yamllint -s -c .yamllint "$file"
-              rc=$?
+              rc=0
+              yamllint -s -c .yamllint "$file" || rc=$?
               if [ "$rc" -eq 1 ]; then
                 exit_code=1
               fi


### PR DESCRIPTION
#### Description:

- Fix the CI yamllint linting workflow (`.github/workflows/ci_lint.yml`) to prevent `set -e` from killing the script before the yamllint exit code and diagnostic output can be captured. The fix uses `|| rc=$?` to capture the return code inline instead of relying on a separate `$?` assignment after the command, which `set -e` would never reach on non-zero exit.

#### Rationale:

- The `set -e` at the beginning of the script causes it to abort immediately when yamllint returns a non-zero exit code (e.g., for warnings or errors). This prevents the script from printing the yamllint output, making it impossible to see what the linting issues actually are. The fix applies to both the Jinja2-stripping path and the direct yamllint path.

#### Review Hints:

- This is a small, self-contained CI infrastructure fix — only `.github/workflows/ci_lint.yml` is changed.
- The change applies the same `|| rc=$?` pattern to both branches of the `if` (Jinja2 files and plain YAML files).
- To verify correctness, check that `rc` is initialized to `0` before each command and that `|| rc=$?` correctly captures non-zero exits without triggering `set -e`.
- No product builds or Automatus tests are needed — this only affects CI linting.
