### PR TITLE
Add NIST 800-53 Rev 5 control framework with OSCAL metadata and CIS mappings (Split per product)

### DIFF
--- a/products/rhel10/controls/nist_800_53/ac.yml
+++ b/products/rhel10/controls/nist_800_53/ac.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 AC Family: Access Control
 controls:
     - id: ac-1
       title: Policy and Procedures
@@ -10,40 +9,81 @@ controls:
       title: Account Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - service_auditd_enabled
+      status: automated
     - id: ac-2.1
       title: Automated System Account Management
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_password_pam_enforce_local
+          - accounts_passwords_pam_faillock_enforce_local
+      status: automated
     - id: ac-2.2
       title: Automated Temporary and Emergency Account Management
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - account_emergency_expire_date
+          - account_temp_expire_date
+      status: automated
     - id: ac-2.3
       title: Disable Accounts
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - account_disable_post_pw_expiration
+          - account_emergency_expire_date
+          - account_temp_expire_date
+          - accounts_set_post_pw_existing
+      status: automated
     - id: ac-2.4
       title: Automated Audit Actions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_etc_group_open
+          - audit_rules_etc_group_open_by_handle_at
+          - audit_rules_etc_group_openat
+          - audit_rules_etc_gshadow_open
+          - audit_rules_etc_gshadow_open_by_handle_at
+          - audit_rules_etc_gshadow_openat
+          - audit_rules_etc_passwd_open
+          - audit_rules_etc_passwd_open_by_handle_at
+          - audit_rules_etc_passwd_openat
+          - audit_rules_etc_shadow_open
+          - audit_rules_etc_shadow_open_by_handle_at
+          - audit_rules_etc_shadow_openat
+          - audit_rules_execution_semanage
+          - audit_rules_privileged_commands
+          - audit_rules_privileged_commands_chage
+          - audit_rules_privileged_commands_chsh
+          - audit_rules_privileged_commands_gpasswd
+          - audit_rules_privileged_commands_newgidmap
+          - audit_rules_privileged_commands_newgrp
+          - audit_rules_privileged_commands_newuidmap
+          - audit_rules_privileged_commands_passwd
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+          - audit_rules_privileged_commands_usernetctl
+          - audit_rules_usergroup_modification
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+      status: automated
     - id: ac-2.5
       title: Inactivity Logout
       levels:
           - moderate
       rules:
-          - no_invalid_shell_accounts_unlocked
-          - no_password_auth_for_systemaccounts
-          - no_shelllogin_for_systemaccounts
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
       status: automated
     - id: ac-2.6
       title: Dynamic Privilege Management
@@ -51,8 +91,9 @@ controls:
       status: pending
     - id: ac-2.7
       title: Privileged User Accounts
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_sysadmin_actions
+      status: automated
     - id: ac-2.8
       title: Dynamic Account Management
       rules: []
@@ -88,151 +129,44 @@ controls:
       levels:
           - low
       rules:
-          - accounts_umask_etc_bashrc
-          - accounts_umask_etc_login_defs
-          - accounts_umask_etc_profile
-          - accounts_umask_root
-          - audit_rules_immutable
-          - dir_perms_world_writable_sticky_bits
-          - directory_groupowner_sshd_config_d
-          - directory_owner_sshd_config_d
-          - directory_permissions_sshd_config_d
-          - ensure_pam_wheel_group_empty
-          - file_at_allow_exists
-          - file_at_deny_not_exist
-          - file_cron_allow_exists
-          - file_cron_deny_not_exist
-          - file_groupowner_at_allow
-          - file_groupowner_backup_etc_group
-          - file_groupowner_backup_etc_gshadow
-          - file_groupowner_backup_etc_passwd
-          - file_groupowner_backup_etc_shadow
-          - file_groupowner_cron_allow
-          - file_groupowner_cron_d
-          - file_groupowner_cron_daily
-          - file_groupowner_cron_hourly
-          - file_groupowner_cron_monthly
-          - file_groupowner_cron_weekly
-          - file_groupowner_cron_yearly
-          - file_groupowner_crontab
-          - file_groupowner_etc_group
-          - file_groupowner_etc_gshadow
-          - file_groupowner_etc_issue
-          - file_groupowner_etc_issue_net
-          - file_groupowner_etc_motd
-          - file_groupowner_etc_passwd
-          - file_groupowner_etc_security_opasswd
-          - file_groupowner_etc_security_opasswd_old
-          - file_groupowner_etc_shadow
+          - disable_host_auth
+          - enable_authselect
           - file_groupowner_etc_shells
-          - file_groupowner_sshd_config
-          - file_groupowner_sshd_drop_in_config
-          - file_groupownership_sshd_private_key
-          - file_groupownership_sshd_pub_key
-          - file_owner_at_allow
-          - file_owner_backup_etc_group
-          - file_owner_backup_etc_gshadow
-          - file_owner_backup_etc_passwd
-          - file_owner_backup_etc_shadow
-          - file_owner_cron_allow
-          - file_owner_cron_d
-          - file_owner_cron_daily
-          - file_owner_cron_hourly
-          - file_owner_cron_monthly
-          - file_owner_cron_weekly
-          - file_owner_cron_yearly
-          - file_owner_crontab
-          - file_owner_etc_group
-          - file_owner_etc_gshadow
-          - file_owner_etc_issue
-          - file_owner_etc_issue_net
-          - file_owner_etc_motd
-          - file_owner_etc_passwd
-          - file_owner_etc_security_opasswd
-          - file_owner_etc_security_opasswd_old
-          - file_owner_etc_shadow
           - file_owner_etc_shells
-          - file_owner_sshd_config
-          - file_owner_sshd_drop_in_config
-          - file_ownership_sshd_private_key
-          - file_ownership_sshd_pub_key
-          - file_permissions_at_allow
-          - file_permissions_backup_etc_group
-          - file_permissions_backup_etc_gshadow
-          - file_permissions_backup_etc_passwd
-          - file_permissions_backup_etc_shadow
-          - file_permissions_cron_allow
-          - file_permissions_cron_d
-          - file_permissions_cron_daily
-          - file_permissions_cron_hourly
-          - file_permissions_cron_monthly
-          - file_permissions_cron_weekly
-          - file_permissions_cron_yearly
-          - file_permissions_crontab
-          - file_permissions_etc_group
-          - file_permissions_etc_gshadow
-          - file_permissions_etc_issue
-          - file_permissions_etc_issue_net
-          - file_permissions_etc_motd
-          - file_permissions_etc_passwd
-          - file_permissions_etc_security_opasswd
-          - file_permissions_etc_security_opasswd_old
-          - file_permissions_etc_shadow
           - file_permissions_etc_shells
-          - file_permissions_sshd_config
-          - file_permissions_sshd_drop_in_config
-          - file_permissions_sshd_private_key
-          - file_permissions_sshd_pub_key
-          - file_permissions_unauthorized_world_writable
-          - grub2_enable_selinux
-          - grub2_password
-          - mount_option_dev_shm_nodev
-          - mount_option_dev_shm_noexec
-          - mount_option_dev_shm_nosuid
-          - mount_option_home_nodev
-          - mount_option_home_nosuid
-          - mount_option_tmp_noexec
-          - mount_option_tmp_nosuid
-          - mount_option_var_log_audit_nodev
-          - mount_option_var_log_audit_noexec
-          - mount_option_var_log_audit_nosuid
-          - mount_option_var_log_nodev
-          - mount_option_var_log_noexec
-          - mount_option_var_log_nosuid
-          - mount_option_var_nodev
-          - mount_option_var_nosuid
-          - mount_option_var_tmp_nodev
-          - mount_option_var_tmp_noexec
-          - mount_option_var_tmp_nosuid
-          - package_libselinux_installed
-          - package_mcstrans_removed
-          - package_setroubleshoot_removed
-          - rsyslog_files_groupownership
-          - rsyslog_files_ownership
-          - rsyslog_files_permissions
-          - selinux_not_disabled
-          - selinux_policytype
+          - ftp_restrict_to_anon
+          - require_emergency_target_auth
+          - require_singleuser_auth
           - sshd_limit_user_access
-          - sysctl_fs_protected_hardlinks
-          - sysctl_fs_protected_symlinks
-          - use_pam_wheel_group_for_su
       status: automated
     - id: ac-3.1
       title: Restricted Access to Privileged Functions
-      rules: []
-      status: pending
+      rules:
+          - grub2_password_legacy
+          - grub2_uefi_password_legacy
+      status: automated
     - id: ac-3.2
       title: Dual Authorization
       rules: []
       status: pending
     - id: ac-3.3
       title: Mandatory Access Control
-      rules: []
-      status: pending
+      rules:
+          - coreos_enable_selinux_kernel_argument
+          - grub2_enable_selinux
+          - selinux_all_devicefiles_labeled
+          - selinux_confinement_of_daemons
+          - selinux_policytype
+          - selinux_state
+      status: automated
     - id: ac-3.4
       title: Discretionary Access Control
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - package_pam_apparmor_installed
+          - selinux_confine_to_least_privilege
+          - selinux_context_elevation_for_sudo
+      status: automated
     - id: ac-3.5
       title: Security-relevant Information
       rules: []
@@ -281,8 +215,15 @@ controls:
       title: Information Flow Enforcement
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_ports
+          - libreswan_approved_tunnels
+          - service_firewalld_enabled
+          - service_ip6tables_enabled
+          - service_iptables_enabled
+          - service_rdisc_disabled
+          - set_ip6tables_default_rule
+      status: automated
     - id: ac-4.1
       title: Object Security and Privacy Attributes
       rules: []
@@ -424,23 +365,152 @@ controls:
       levels:
           - moderate
       rules:
-          - sshd_disable_root_login
-          - sudo_add_use_pty
-          - sudo_remove_no_authenticate
-          - sudo_remove_nopasswd
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
+          - restrict_serial_port_logins
+          - securetty_root_login_console_only
+          - selinux_all_devicefiles_labeled
+          - selinux_confinement_of_daemons
+          - sshd_enable_strictmodes
+          - sshd_use_priv_separation
+          - sysctl_kernel_perf_event_paranoid
+          - sysctl_kernel_unprivileged_bpf_disabled
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - tftpd_uses_secure_mode
       status: automated
     - id: ac-6.1
       title: Authorize Access to Security Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_csh_cshrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - dconf_gnome_disable_ctrlaltdel_reboot
+          - dconf_gnome_disable_restart_shutdown
+          - dir_perms_var_log_httpd
+          - dir_perms_world_writable_sticky_bits
+          - dir_perms_world_writable_system_owned
+          - dir_perms_world_writable_system_owned_group
+          - directory_group_ownership_var_log_audit
+          - directory_groupowner_sshd_config_d
+          - directory_owner_sshd_config_d
+          - directory_ownership_var_log_audit
+          - directory_permissions_sshd_config_d
+          - directory_permissions_var_log_audit
+          - disable_ctrlaltdel_burstaction
+          - disable_ctrlaltdel_reboot
+          - file_group_ownership_var_log_audit
+          - file_groupowner_cron_allow
+          - file_groupowner_cron_d
+          - file_groupowner_cron_daily
+          - file_groupowner_cron_hourly
+          - file_groupowner_cron_monthly
+          - file_groupowner_cron_weekly
+          - file_groupowner_cron_yearly
+          - file_groupowner_crontab
+          - file_groupowner_efi_grub2_cfg
+          - file_groupowner_efi_user_cfg
+          - file_groupowner_etc_group
+          - file_groupowner_etc_gshadow
+          - file_groupowner_etc_passwd
+          - file_groupowner_etc_shadow
+          - file_groupowner_grub2_cfg
+          - file_groupowner_sshd_config
+          - file_groupowner_sshd_drop_in_config
+          - file_groupowner_user_cfg
+          - file_owner_cron_allow
+          - file_owner_cron_d
+          - file_owner_cron_daily
+          - file_owner_cron_hourly
+          - file_owner_cron_monthly
+          - file_owner_cron_weekly
+          - file_owner_cron_yearly
+          - file_owner_crontab
+          - file_owner_efi_grub2_cfg
+          - file_owner_efi_user_cfg
+          - file_owner_etc_group
+          - file_owner_etc_gshadow
+          - file_owner_etc_passwd
+          - file_owner_etc_shadow
+          - file_owner_grub2_cfg
+          - file_owner_sshd_config
+          - file_owner_sshd_drop_in_config
+          - file_owner_user_cfg
+          - file_ownership_binary_dirs
+          - file_ownership_library_dirs
+          - file_ownership_var_log_audit
+          - file_ownership_var_log_audit_stig
+          - file_permissions_binary_dirs
+          - file_permissions_cron_d
+          - file_permissions_cron_daily
+          - file_permissions_cron_hourly
+          - file_permissions_cron_monthly
+          - file_permissions_cron_weekly
+          - file_permissions_cron_yearly
+          - file_permissions_crontab
+          - file_permissions_efi_grub2_cfg
+          - file_permissions_efi_user_cfg
+          - file_permissions_etc_group
+          - file_permissions_etc_gshadow
+          - file_permissions_etc_passwd
+          - file_permissions_etc_shadow
+          - file_permissions_grub2_cfg
+          - file_permissions_home_dirs
+          - file_permissions_httpd_server_conf_d_files
+          - file_permissions_httpd_server_conf_files
+          - file_permissions_httpd_server_modules_files
+          - file_permissions_library_dirs
+          - file_permissions_sshd_config
+          - file_permissions_sshd_drop_in_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - file_permissions_unauthorized_sgid
+          - file_permissions_unauthorized_suid
+          - file_permissions_unauthorized_world_writable
+          - file_permissions_ungroupowned
+          - file_permissions_user_cfg
+          - file_permissions_var_log_audit
+          - gnome_gdm_disable_automatic_login
+          - mount_option_boot_nodev
+          - mount_option_boot_nosuid
+          - mount_option_dev_shm_nodev
+          - mount_option_dev_shm_noexec
+          - mount_option_dev_shm_nosuid
+          - mount_option_home_nosuid
+          - mount_option_nodev_nonroot_local_partitions
+          - mount_option_nodev_removable_partitions
+          - mount_option_noexec_removable_partitions
+          - mount_option_nosuid_remote_filesystems
+          - mount_option_nosuid_removable_partitions
+          - mount_option_tmp_nodev
+          - mount_option_tmp_noexec
+          - mount_option_tmp_nosuid
+          - mount_option_var_log_audit_nodev
+          - mount_option_var_log_audit_noexec
+          - mount_option_var_log_audit_nosuid
+          - mount_option_var_log_nodev
+          - mount_option_var_log_noexec
+          - mount_option_var_log_nosuid
+          - mount_option_var_nodev
+          - mount_option_var_tmp_bind
+          - no_files_unowned_by_user
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+          - sysctl_fs_protected_fifos
+          - sysctl_fs_protected_hardlinks
+          - sysctl_fs_protected_regular
+          - sysctl_fs_protected_symlinks
+          - umask_for_daemons
+      status: automated
     - id: ac-6.2
       title: Non-privileged Access for Nonsecurity Functions
       levels:
           - moderate
       rules:
-          - package_sudo_installed
+          - sshd_disable_root_login
       status: automated
     - id: ac-6.3
       title: Network Access to Privileged Commands
@@ -456,8 +526,9 @@ controls:
       title: Privileged Accounts
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_no_uid_except_zero
+      status: automated
     - id: ac-6.6
       title: Privileged Access by Non-organizational Users
       rules: []
@@ -470,27 +541,112 @@ controls:
       status: pending
     - id: ac-6.8
       title: Privilege Levels for Code Execution
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - mount_option_noexec_remote_filesystems
+          - package_pam_apparmor_installed
+      status: automated
     - id: ac-6.9
       title: Log Use of Privileged Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_etc_group_open
+          - audit_rules_etc_group_open_by_handle_at
+          - audit_rules_etc_group_openat
+          - audit_rules_etc_gshadow_open
+          - audit_rules_etc_gshadow_open_by_handle_at
+          - audit_rules_etc_gshadow_openat
+          - audit_rules_etc_passwd_open
+          - audit_rules_etc_passwd_open_by_handle_at
+          - audit_rules_etc_passwd_openat
+          - audit_rules_etc_shadow_open
+          - audit_rules_etc_shadow_open_by_handle_at
+          - audit_rules_etc_shadow_openat
+          - audit_rules_execution_chcon
+          - audit_rules_execution_restorecon
+          - audit_rules_execution_semanage
+          - audit_rules_execution_setfiles
+          - audit_rules_execution_setsebool
+          - audit_rules_execution_seunshare
+          - audit_rules_immutable
+          - audit_rules_kernel_module_loading
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_login_events
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - audit_rules_login_events_tallylog
+          - audit_rules_media_export
+          - audit_rules_networkconfig_modification
+          - audit_rules_privileged_commands
+          - audit_rules_privileged_commands_at
+          - audit_rules_privileged_commands_chage
+          - audit_rules_privileged_commands_chsh
+          - audit_rules_privileged_commands_crontab
+          - audit_rules_privileged_commands_gpasswd
+          - audit_rules_privileged_commands_mount
+          - audit_rules_privileged_commands_newgidmap
+          - audit_rules_privileged_commands_newgrp
+          - audit_rules_privileged_commands_newuidmap
+          - audit_rules_privileged_commands_pam_timestamp_check
+          - audit_rules_privileged_commands_passwd
+          - audit_rules_privileged_commands_postdrop
+          - audit_rules_privileged_commands_postqueue
+          - audit_rules_privileged_commands_pt_chown
+          - audit_rules_privileged_commands_ssh_keysign
+          - audit_rules_privileged_commands_su
+          - audit_rules_privileged_commands_sudo
+          - audit_rules_privileged_commands_sudoedit
+          - audit_rules_privileged_commands_umount
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+          - audit_rules_privileged_commands_userhelper
+          - audit_rules_privileged_commands_usernetctl
+          - audit_rules_suid_privilege_function
+          - audit_rules_sysadmin_actions
+          - audit_rules_time_adjtimex
+          - audit_rules_time_clock_settime
+          - audit_rules_time_settimeofday
+          - audit_rules_time_stime
+          - audit_rules_time_watch_localtime
+          - audit_rules_usergroup_modification
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+          - directory_access_var_log_audit
+          - service_auditd_enabled
+      status: automated
     - id: ac-6.10
       title: Prohibit Non-privileged Users from Executing Privileged Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - mount_option_noexec_remote_filesystems
+          - package_pam_apparmor_installed
+          - selinux_confine_to_least_privilege
+          - selinux_context_elevation_for_sudo
+      status: automated
     - id: ac-7
       title: Unsuccessful Logon Attempts
       levels:
           - low
       rules:
-          - account_password_pam_faillock_password_auth
-          - account_password_pam_faillock_system_auth
+          - accounts_logon_fail_delay
+          - accounts_password_pam_retry
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_dir
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - package_audit-libs_installed
+          - package_audit_installed
       status: automated
     - id: ac-7.1
       title: Automatic Account Lock
@@ -513,8 +669,13 @@ controls:
       levels:
           - low
       rules:
+          - banner_etc_gdm_banner
+          - banner_etc_issue
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
+          - postfix_server_banner
+          - sshd_enable_warning_banner
+          - sshd_enable_warning_banner_net
       status: automated
     - id: ac-9
       title: Previous Logon Notification
@@ -522,8 +683,10 @@ controls:
       status: pending
     - id: ac-9.1
       title: Unsuccessful Logons
-      rules: []
-      status: pending
+      rules:
+          - display_login_attempts
+          - sshd_print_last_log
+      status: automated
     - id: ac-9.2
       title: Successful and Unsuccessful Logons
       rules: []
@@ -540,30 +703,37 @@ controls:
       title: Concurrent Session Control
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - accounts_max_concurrent_login_sessions
+      status: automated
     - id: ac-11
       title: Device Lock
       levels:
           - moderate
       rules:
+          - configure_tmux_lock_command
+          - dconf_gnome_screensaver_idle_activation_enabled
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
-          - dconf_gnome_screensaver_user_locks
-          - dconf_gnome_session_idle_user_locks
       status: automated
     - id: ac-11.1
       title: Pattern-hiding Displays
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_screensaver_mode_blank
+      status: automated
     - id: ac-12
       title: Session Termination
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+      status: automated
     - id: ac-12.1
       title: User-initiated Logouts
       rules: []
@@ -643,20 +813,77 @@ controls:
       levels:
           - low
       rules:
-          - configure_custom_crypto_policy_cis
+          - directory_groupowner_sshd_config_d
+          - directory_owner_sshd_config_d
+          - directory_permissions_sshd_config_d
+          - disable_host_auth
+          - enable_ldap_client
+          - file_groupowner_sshd_config
+          - file_groupowner_sshd_drop_in_config
+          - file_owner_sshd_config
+          - file_owner_sshd_drop_in_config
+          - file_permissions_sshd_config
+          - file_permissions_sshd_drop_in_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - firewalld_sshd_port_enabled
+          - ftp_restrict_to_anon
+          - libreswan_approved_tunnels
+          - logind_session_timeout
+          - mount_option_krb_sec_remote_filesystems
+          - sshd_disable_compression
+          - sshd_disable_empty_passwords
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+          - sshd_disable_rhosts
+          - sshd_disable_rhosts_rsa
+          - sshd_disable_root_login
+          - sshd_disable_user_known_hosts
+          - sshd_do_not_permit_user_env
+          - sshd_enable_strictmodes
+          - sshd_enable_warning_banner
+          - sshd_enable_warning_banner_net
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+          - sshd_set_loglevel_info
+          - sshd_use_priv_separation
+          - use_kerberos_security_all_exports
       status: automated
     - id: ac-17.1
       title: Monitoring and Control
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - rsyslog_remote_access_monitoring
+          - sshd_set_loglevel_verbose
+      status: automated
     - id: ac-17.2
       title: Protection of Confidentiality and Integrity Using Encryption
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_crypto_policy
+          - configure_gnutls_tls_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_openssl_tls_crypto_policy
+          - configure_ssh_crypto_policy
+          - dconf_gnome_remote_access_encryption
+          - harden_ssh_client_crypto_policy
+          - harden_sshd_ciphers_openssh_conf_crypto_policy
+          - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+          - harden_sshd_crypto_policy
+          - harden_sshd_macs_openssh_conf_crypto_policy
+          - harden_sshd_macs_opensshserver_conf_crypto_policy
+          - ldap_client_start_tls
+          - sshd_allow_only_protocol2
+          - sshd_enable_x11_forwarding
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_kex_ordered_stig
+          - sshd_use_approved_macs
+      status: automated
     - id: ac-17.3
       title: Managed Access Control Points
       levels:
@@ -698,7 +925,9 @@ controls:
       levels:
           - low
       rules:
-          - wireless_disable_interfaces
+          - kernel_module_atm_disabled
+          - kernel_module_can_disabled
+          - kernel_module_firewire-core_disabled
       status: automated
     - id: ac-18.1
       title: Authentication and Encryption
@@ -714,14 +943,27 @@ controls:
       title: Disable Wireless Networking
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_bluetooth_disabled
+          - kernel_module_cfg80211_disabled
+          - kernel_module_iwlmvm_disabled
+          - kernel_module_iwlwifi_disabled
+          - kernel_module_mac80211_disabled
+          - service_bluetooth_disabled
+          - wireless_disable_in_bios
+          - wireless_disable_interfaces
+      status: automated
     - id: ac-18.4
       title: Restrict Configurations by Users
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_cfg80211_disabled
+          - kernel_module_iwlmvm_disabled
+          - kernel_module_iwlwifi_disabled
+          - kernel_module_mac80211_disabled
+          - network_nmcli_permissions
+      status: automated
     - id: ac-18.5
       title: Antennas and Transmission Power Levels
       levels:
@@ -808,8 +1050,9 @@ controls:
       status: pending
     - id: ac-23
       title: Data Mining Protection
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_disable_user_list
+      status: automated
     - id: ac-24
       title: Access Control Decisions
       rules: []

--- a/products/rhel10/controls/nist_800_53/au.yml
+++ b/products/rhel10/controls/nist_800_53/au.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 AU Family: Audit and Accountability
 controls:
     - id: au-1
       title: Policy and Procedures
@@ -83,6 +84,7 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_login_events_faillog
           - audit_rules_privileged_commands_chfn
           - auditd_log_format
           - auditd_name_format
@@ -93,6 +95,11 @@ controls:
       levels:
           - moderate
       rules:
+          - audit_rules_etc_cron_d
+          - audit_rules_networkconfig_modification_etc_hosts
+          - audit_rules_networkconfig_modification_etc_issue
+          - audit_rules_networkconfig_modification_etc_issue_net
+          - audit_rules_networkconfig_modification_etc_networkmanager_system_connections
           - audit_rules_privileged_commands_insmod
           - audit_rules_privileged_commands_kmod
           - audit_rules_privileged_commands_modprobe
@@ -132,6 +139,8 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_continue_loading
+          - audit_rules_enable_syscall_auditing
           - audit_rules_system_shutdown
           - postfix_client_configure_mail_alias_postmaster
       status: automated
@@ -313,6 +322,9 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_immutable_login_uids
+          - audit_rules_mac_modification_etc_apparmor
+          - audit_rules_mac_modification_etc_apparmor_d
           - directory_permissions_var_log_audit
           - file_audit_tools_group_ownership
           - file_audit_tools_ownership
@@ -430,12 +442,19 @@ controls:
           - audit_rules_dac_modification_lsetxattr
           - audit_rules_dac_modification_removexattr
           - audit_rules_dac_modification_setxattr
+          - audit_rules_dac_modification_umount
+          - audit_rules_dac_modification_umount2
+          - audit_rules_execution_chacl
           - audit_rules_execution_chcon
+          - audit_rules_execution_chmod
+          - audit_rules_execution_rm
+          - audit_rules_execution_setfacl
           - audit_rules_file_deletion_events_rename
           - audit_rules_file_deletion_events_renameat
           - audit_rules_file_deletion_events_renameat2
           - audit_rules_file_deletion_events_unlink
           - audit_rules_file_deletion_events_unlinkat
+          - audit_rules_kernel_module_loading_create
           - audit_rules_kernel_module_loading_delete
           - audit_rules_kernel_module_loading_finit
           - audit_rules_kernel_module_loading_init

--- a/products/rhel10/controls/nist_800_53/au.yml
+++ b/products/rhel10/controls/nist_800_53/au.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 AU Family: Audit and Accountability
 controls:
     - id: au-1
       title: Policy and Procedures
@@ -13,6 +12,36 @@ controls:
       rules:
           - aide_build_database
           - aide_periodic_cron_checking
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success_aarch64
+          - audit_access_success_ppc64le
+          - audit_basic_configuration
+          - audit_create_failed
+          - audit_create_failed_aarch64
+          - audit_create_failed_ppc64le
+          - audit_create_success
+          - audit_create_success_aarch64
+          - audit_create_success_ppc64le
+          - audit_delete_failed
+          - audit_delete_failed_aarch64
+          - audit_delete_failed_ppc64le
+          - audit_delete_success
+          - audit_delete_success_aarch64
+          - audit_delete_success_ppc64le
+          - audit_immutable_login_uids
+          - audit_modify_failed
+          - audit_modify_failed_aarch64
+          - audit_modify_failed_ppc64le
+          - audit_modify_success
+          - audit_modify_success_aarch64
+          - audit_modify_success_ppc64le
+          - audit_module_load
+          - audit_module_load_ppc64le
+          - audit_ospp_general
+          - audit_ospp_general_aarch64
           - audit_rules_execution_chacl
           - audit_rules_execution_chcon
           - audit_rules_execution_setfacl
@@ -54,78 +83,22 @@ controls:
       levels:
           - low
       rules:
-          - audit_rules_dac_modification_chmod
-          - audit_rules_dac_modification_chown
-          - audit_rules_dac_modification_fchmod
-          - audit_rules_dac_modification_fchmodat
-          - audit_rules_dac_modification_fchown
-          - audit_rules_dac_modification_fchownat
-          - audit_rules_dac_modification_fremovexattr
-          - audit_rules_dac_modification_fsetxattr
-          - audit_rules_dac_modification_lchown
-          - audit_rules_dac_modification_lremovexattr
-          - audit_rules_dac_modification_lsetxattr
-          - audit_rules_dac_modification_removexattr
-          - audit_rules_dac_modification_setxattr
-          - audit_rules_kernel_module_loading_delete
-          - audit_rules_kernel_module_loading_finit
-          - audit_rules_kernel_module_loading_init
-          - audit_rules_kernel_module_loading_query
-          - audit_rules_login_events_faillock
-          - audit_rules_login_events_lastlog
-          - audit_rules_mac_modification_etc_selinux
-          - audit_rules_mac_modification_usr_share
-          - audit_rules_networkconfig_modification_etc_hosts
-          - audit_rules_networkconfig_modification_etc_issue
-          - audit_rules_networkconfig_modification_etc_issue_net
-          - audit_rules_networkconfig_modification_etc_networkmanager_system_connections
-          - audit_rules_networkconfig_modification_etc_sysconfig_network
-          - audit_rules_networkconfig_modification_hostname_file
-          - audit_rules_networkconfig_modification_networkmanager
-          - audit_rules_networkconfig_modification_setdomainname
-          - audit_rules_networkconfig_modification_sethostname
-          - audit_rules_privileged_commands
-          - audit_rules_privileged_commands_kmod
-          - audit_rules_session_events_btmp
-          - audit_rules_session_events_utmp
-          - audit_rules_session_events_wtmp
-          - audit_rules_suid_auid_privilege_function
-          - audit_rules_sysadmin_actions
-          - audit_rules_time_adjtimex
-          - audit_rules_time_clock_settime
-          - audit_rules_time_settimeofday
-          - audit_rules_time_watch_localtime
-          - audit_rules_unsuccessful_file_modification_creat
-          - audit_rules_unsuccessful_file_modification_ftruncate
-          - audit_rules_unsuccessful_file_modification_open
-          - audit_rules_unsuccessful_file_modification_openat
-          - audit_rules_unsuccessful_file_modification_truncate
-          - audit_rules_usergroup_modification_group
-          - audit_rules_usergroup_modification_gshadow
-          - audit_rules_usergroup_modification_nsswitch_conf
-          - audit_rules_usergroup_modification_opasswd
-          - audit_rules_usergroup_modification_pam_conf
-          - audit_rules_usergroup_modification_pamd
-          - audit_rules_usergroup_modification_passwd
-          - audit_rules_usergroup_modification_shadow
-          - chronyd_specify_remote_server
-          - directory_permissions_var_log_audit
-          - file_groupownership_audit_binaries
-          - file_ownership_var_log_audit_stig
-          - file_permissions_audit_binaries
-          - journald_storage
-          - sshd_set_loglevel_verbose
-          - sshd_set_max_auth_tries
-          - sudo_custom_logfile
-          - sysctl_net_ipv4_conf_all_log_martians
-          - sysctl_net_ipv4_conf_default_log_martians
+          - audit_rules_privileged_commands_chfn
+          - auditd_log_format
+          - auditd_name_format
+          - service_auditd_enabled
       status: automated
     - id: au-3.1
       title: Additional Audit Information
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_privileged_commands_insmod
+          - audit_rules_privileged_commands_kmod
+          - audit_rules_privileged_commands_modprobe
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+      status: automated
     - id: au-3.2
       title: Centralized Management of Planned Audit Record Content
       rules: []
@@ -139,40 +112,89 @@ controls:
       levels:
           - low
       rules:
-          - journald_compress
+          - partition_for_var_log
+          - partition_for_var_log_audit
       status: automated
     - id: au-4.1
       title: Transfer to Alternate Storage
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_syslog_plugin_activated
+          - auditd_overflow_action
+          - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
+          - rsyslog_encrypt_offload_actionsendstreamdrivermode
+          - rsyslog_encrypt_offload_defaultnetstreamdriver
+          - rsyslog_remote_loghost
+          - service_rsyslog_enabled
+          - service_syslogng_enabled
+      status: automated
     - id: au-5
       title: Response to Audit Logging Process Failures
       levels:
           - low
       rules:
-          - auditd_data_disk_error_action
-          - auditd_data_disk_full_action
+          - audit_rules_system_shutdown
+          - postfix_client_configure_mail_alias_postmaster
       status: automated
     - id: au-5.1
       title: Storage Capacity Warning
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.2
       title: Real-time Alerts
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_action_mail_acct
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.3
       title: Configurable Traffic Volume Thresholds
       rules: []
       status: pending
     - id: au-5.4
       title: Shutdown on Failure
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.5
       title: Alternate Audit Logging Capability
       rules: []
@@ -197,12 +219,16 @@ controls:
       title: Correlate Audit Record Repositories
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_accept_remote_messages_tcp
+          - rsyslog_accept_remote_messages_udp
+      status: automated
     - id: au-6.4
       title: Central Review and Analysis
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_accept_remote_messages_tcp
+          - rsyslog_accept_remote_messages_udp
+      status: automated
     - id: au-6.5
       title: Integrated Analysis of Audit Records
       levels:
@@ -235,40 +261,65 @@ controls:
       title: Audit Record Reduction and Report Generation
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: au-7.1
       title: Automatic Processing
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-7.2
       title: Automatic Sort and Search
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-8
       title: Time Stamps
       levels:
           - low
       rules:
-          - auditd_data_retention_max_log_file
-          - auditd_data_retention_max_log_file_action
+          - audit_rules_suid_privilege_function
       status: automated
     - id: au-8.1
       title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
+      rules:
+          - chronyd_client_only
+          - chronyd_configure_pool_and_server
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - chronyd_specify_remote_server
+          - ntpd_specify_multiple_servers
+          - ntpd_specify_remote_server
+          - service_chronyd_or_ntpd_enabled
+          - service_ntp_enabled
+          - service_ntpd_enabled
+          - service_timesyncd_enabled
+      status: automated
     - id: au-8.2
       title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      rules:
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - ntpd_specify_multiple_servers
+      status: automated
     - id: au-9
       title: Protection of Audit Information
       levels:
           - low
       rules:
-          - audit_rules_immutable
+          - directory_permissions_var_log_audit
+          - file_audit_tools_group_ownership
+          - file_audit_tools_ownership
+          - file_audit_tools_permissions
+          - permissions_local_var_log_audit
+          - selinux_policytype
+          - selinux_state
       status: automated
     - id: au-9.1
       title: Hardware Write-once Media
@@ -278,20 +329,34 @@ controls:
       title: Store on Separate Physical Systems or Components
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_remote_loghost
+      status: automated
     - id: au-9.3
       title: Cryptographic Protection
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - aide_check_audit_tools
+          - auditd_audispd_encrypt_sent_records
+          - encrypt_partitions
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+          - rsyslog_remote_tls
+      status: automated
     - id: au-9.4
       title: Access by Subset of Privileged Users
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - directory_group_ownership_var_log_audit
+          - directory_ownership_var_log_audit
+          - file_group_ownership_var_log_audit
+          - file_ownership_var_log_audit
+          - file_ownership_var_log_audit_stig
+          - file_permissions_var_log_audit
+      status: automated
     - id: au-9.5
       title: Dual Authorization
       rules: []
@@ -308,8 +373,11 @@ controls:
       title: Non-repudiation
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - service_auditd_enabled
+      status: automated
     - id: au-10.1
       title: Association of Identities
       rules: []
@@ -334,8 +402,11 @@ controls:
       title: Audit Record Retention
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - auditd_data_retention_flush
+          - auditd_data_retention_max_log_file
+          - auditd_data_retention_num_logs
+      status: automated
     - id: au-11.1
       title: Long-term Retrieval Capability
       rules: []
@@ -396,18 +467,26 @@ controls:
       title: System-wide and Time-correlated Audit Trail
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - chronyd_client_only
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - service_chronyd_or_ntpd_enabled
+      status: automated
     - id: au-12.2
       title: Standardized Formats
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-12.3
       title: Changes by Authorized Individuals
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: au-12.4
       title: Query Parameter Audits of Personally Identifiable Information
       rules: []
@@ -430,12 +509,17 @@ controls:
       status: pending
     - id: au-14
       title: Session Audit
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-14.1
       title: System Start-up
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - service_auditd_enabled
+      status: automated
     - id: au-14.2
       title: Capture and Record Content
       rules: []

--- a/products/rhel10/controls/nist_800_53/cm.yml
+++ b/products/rhel10/controls/nist_800_53/cm.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 CM Family: Configuration Management
 controls:
     - id: cm-1
       title: Policy and Procedures
@@ -265,6 +266,11 @@ controls:
           - accounts_passwords_pam_faillock_interval
           - accounts_passwords_pam_faillock_unlock_time
           - accounts_passwords_pam_tally2_deny_root
+          - file_groupowner_boot_grub2
+          - file_owner_boot_grub2
+          - file_permissions_boot_grub2
+          - grub2_password
+          - grub2_uefi_password
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -323,9 +329,11 @@ controls:
           - package_kea_removed
           - package_net-snmp_removed
           - package_nginx_removed
+          - package_nis_removed
           - package_openldap-clients_removed
           - package_telnet-server_removed
           - package_telnet_removed
+          - package_telnetd_removed
           - package_tftp-server_removed
           - package_tftp_removed
           - package_vsftpd_removed
@@ -337,10 +345,14 @@ controls:
           - partition_for_var_log_audit
           - partition_for_var_tmp
           - postfix_network_listening_disabled
+          - service_apport_disabled
           - service_bluetooth_disabled
           - service_cockpit_disabled
           - service_cups_disabled
+          - service_dhcpd_disabled
           - service_dnsmasq_disabled
+          - service_oddjobd_disabled
+          - service_quota_nld_disabled
           - sshd_disable_forwarding
           - wireless_disable_interfaces
       status: automated

--- a/products/rhel10/controls/nist_800_53/cm.yml
+++ b/products/rhel10/controls/nist_800_53/cm.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 CM Family: Configuration Management
 controls:
     - id: cm-1
       title: Policy and Procedures
@@ -133,14 +132,19 @@ controls:
       status: pending
     - id: cm-3.5
       title: Automated Security Response
-      rules: []
-      status: pending
+      rules:
+          - aide_scan_notification
+          - package_mailx_installed
+          - package_s-nail_installed
+      status: automated
     - id: cm-3.6
       title: Cryptography Management
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - enable_fips_mode
+          - service_sshd_disabled
+      status: automated
     - id: cm-3.7
       title: Review System Changes
       rules: []
@@ -177,16 +181,27 @@ controls:
       title: Automated Access Enforcement and Audit Records
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: cm-5.2
       title: Review System Changes
       rules: []
       status: pending
     - id: cm-5.3
       title: Signed Components
-      rules: []
-      status: pending
+      rules:
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+      status: automated
     - id: cm-5.4
       title: Dual Authorization
       rules: []
@@ -197,8 +212,20 @@ controls:
       status: pending
     - id: cm-5.6
       title: Limit Library Privileges
-      rules: []
-      status: pending
+      rules:
+          - dir_group_ownership_library_dirs
+          - dir_ownership_library_dirs
+          - dir_permissions_library_dirs
+          - dir_system_commands_group_root_owned
+          - dir_system_commands_root_owned
+          - file_groupownership_system_commands_dirs
+          - file_ownership_binary_dirs
+          - file_ownership_library_dirs
+          - file_permissions_binary_dirs
+          - file_permissions_library_dirs
+          - file_permissions_system_commands_dirs
+          - root_permissions_syslibrary_files
+      status: automated
     - id: cm-5.7
       title: Automatic Implementation of Security Safeguards
       rules: []
@@ -208,74 +235,36 @@ controls:
       levels:
           - low
       rules:
-          - accounts_password_pam_pwquality_password_auth
-          - accounts_password_pam_pwquality_system_auth
-          - accounts_umask_etc_bashrc
-          - accounts_umask_etc_login_defs
-          - accounts_umask_etc_profile
-          - accounts_user_interactive_home_directory_exists
-          - audit_rules_media_export
-          - banner_etc_issue_cis
-          - banner_etc_issue_net_cis
-          - banner_etc_motd_cis
-          - coredump_disable_backtraces
-          - coredump_disable_storage
-          - dconf_gnome_disable_user_list
-          - disable_host_auth
-          - disable_users_coredumps
-          - file_groupowner_boot_grub2
-          - file_groupownership_sshd_private_key
-          - file_groupownership_sshd_pub_key
-          - file_owner_boot_grub2
-          - file_ownership_home_directories
-          - file_ownership_sshd_private_key
-          - file_ownership_sshd_pub_key
-          - file_permissions_boot_grub2
-          - file_permissions_home_directories
-          - file_permissions_sshd_private_key
-          - file_permissions_sshd_pub_key
-          - no_empty_passwords
-          - no_empty_passwords_etc_shadow
-          - no_files_or_dirs_ungroupowned
-          - no_files_or_dirs_unowned_by_user
-          - package_pam_pwquality_installed
-          - package_rsync_removed
-          - package_samba_removed
-          - package_squid_removed
-          - partition_for_tmp
-          - partition_for_var_log
-          - service_nfs_disabled
-          - service_rpcbind_disabled
-          - sshd_disable_gssapi_auth
-          - sshd_set_login_grace_time
-          - sysctl_kernel_kptr_restrict
-          - sysctl_kernel_randomize_va_space
-          - sysctl_kernel_yama_ptrace_scope
-          - sysctl_net_ipv4_conf_all_accept_redirects
-          - sysctl_net_ipv4_conf_all_accept_source_route
-          - sysctl_net_ipv4_conf_all_forwarding
-          - sysctl_net_ipv4_conf_all_log_martians
-          - sysctl_net_ipv4_conf_all_rp_filter
-          - sysctl_net_ipv4_conf_all_secure_redirects
-          - sysctl_net_ipv4_conf_all_send_redirects
-          - sysctl_net_ipv4_conf_default_accept_redirects
-          - sysctl_net_ipv4_conf_default_accept_source_route
-          - sysctl_net_ipv4_conf_default_forwarding
-          - sysctl_net_ipv4_conf_default_log_martians
-          - sysctl_net_ipv4_conf_default_rp_filter
-          - sysctl_net_ipv4_conf_default_secure_redirects
-          - sysctl_net_ipv4_conf_default_send_redirects
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-          - sysctl_net_ipv4_ip_forward
-          - sysctl_net_ipv6_conf_all_accept_ra
-          - sysctl_net_ipv6_conf_all_accept_redirects
-          - sysctl_net_ipv6_conf_all_accept_source_route
-          - sysctl_net_ipv6_conf_all_forwarding
-          - sysctl_net_ipv6_conf_default_accept_ra
-          - sysctl_net_ipv6_conf_default_accept_redirects
-          - sysctl_net_ipv6_conf_default_accept_source_route
-          - sysctl_net_ipv6_conf_default_forwarding
+          - account_disable_post_pw_expiration
+          - account_emergency_expire_date
+          - account_temp_expire_date
+          - accounts_logon_fail_delay
+          - accounts_max_concurrent_login_sessions
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_all_shadowed
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_retry
+          - accounts_password_pam_ucredit
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -359,14 +348,18 @@ controls:
       title: Periodic Review
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - chronyd_no_chronyc_network
+      status: automated
     - id: cm-7.2
       title: Prevent Program Execution
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - network_sniffer_disabled
+          - package_pam_apparmor_installed
+      status: automated
     - id: cm-7.3
       title: Registration Compliance
       rules: []
@@ -379,8 +372,10 @@ controls:
       title: Authorized Software — Allow-by-exception
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - package_pam_apparmor_installed
+      status: automated
     - id: cm-7.6
       title: Confined Environments with Limited Privileges
       rules: []
@@ -419,8 +414,13 @@ controls:
       title: Automated Unauthorized Component Detection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - usbguard_generate_policy
+      status: automated
     - id: cm-8.4
       title: Accountability Information
       levels:
@@ -472,7 +472,12 @@ controls:
       levels:
           - low
       rules:
-          - package_xorg-x11-server-Xwayland_removed
+          - clean_components_post_updating
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
       status: automated
     - id: cm-11.1
       title: Alerts for Unauthorized Installations

--- a/products/rhel10/controls/nist_800_53/cp.yml
+++ b/products/rhel10/controls/nist_800_53/cp.yml
@@ -204,8 +204,11 @@ controls:
       title: System Backup
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_user_data_backups
+          - file_groupowner_backup_etc_shadow
+          - httpd_remove_backups
+      status: automated
     - id: cp-9.1
       title: Testing for Reliability and Integrity
       levels:

--- a/products/rhel10/controls/nist_800_53/ia.yml
+++ b/products/rhel10/controls/nist_800_53/ia.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 IA Family: Identification and Authentication
 controls:
     - id: ia-1
       title: Policy and Procedures
@@ -11,60 +10,113 @@ controls:
       levels:
           - low
       rules:
-          - account_unique_id
+          - accounts_no_uid_except_zero
+          - gid_passwd_group_same
+          - gnome_gdm_disable_guest_login
+          - no_direct_root_logins
+          - require_emergency_target_auth
+          - require_singleuser_auth
       status: automated
     - id: ia-2.1
       title: Multi-factor Authentication to Privileged Accounts
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+          - sssd_enable_pam_services
+      status: automated
     - id: ia-2.2
       title: Multi-factor Authentication to Non-privileged Accounts
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.3
       title: Local Access to Privileged Accounts
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.4
       title: Local Access to Non-privileged Accounts
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - service_sshd_disabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.5
       title: Individual Authentication with Group Authentication
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - sshd_disable_root_login
+      status: automated
     - id: ia-2.6
       title: Access to Accounts —separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.7
       title: Network Access to Non-privileged Accounts — Separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.8
       title: Access to Accounts — Replay Resistant
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_enable_smartcard_auth
+          - mount_option_krb_sec_remote_filesystems
+          - use_kerberos_security_all_exports
+      status: automated
     - id: ia-2.9
       title: Network Access to Non-privileged Accounts — Replay Resistant
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_enable_smartcard_auth
+          - mount_option_krb_sec_remote_filesystems
+          - use_kerberos_security_all_exports
+      status: automated
     - id: ia-2.10
       title: Single Sign-on
       rules: []
       status: pending
     - id: ia-2.11
       title: Remote Access — Separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+          - sssd_certificate_verification
+      status: automated
     - id: ia-2.12
       title: Acceptance of PIV Credentials
       levels:
@@ -80,9 +132,11 @@ controls:
       levels:
           - moderate
       rules:
-          - dconf_gnome_disable_automount
-          - dconf_gnome_disable_automount_open
-          - kernel_module_usb-storage_disabled
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - usbguard_generate_policy
       status: automated
     - id: ia-3.1
       title: Cryptographic Bidirectional Authentication
@@ -104,8 +158,13 @@ controls:
       title: Identifier Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - account_disable_inactivity_password_auth
+          - account_disable_inactivity_system_auth
+          - account_disable_post_pw_expiration
+          - accounts_no_uid_except_zero
+          - accounts_set_post_pw_existing
+      status: automated
     - id: ia-4.1
       title: Prohibit Account Identifiers as Public Identifiers
       rules: []
@@ -149,47 +208,86 @@ controls:
       levels:
           - low
       rules:
-          - accounts_minimum_age_login_defs
           - accounts_password_all_shadowed
-          - accounts_password_pam_dictcheck
-          - accounts_password_pam_difok
-          - accounts_password_pam_enforce_root
-          - accounts_password_pam_maxrepeat
-          - accounts_password_pam_maxsequence
-          - accounts_password_pam_minclass
-          - accounts_password_pam_minlen
-          - accounts_password_pam_pwhistory_enforce_for_root
-          - accounts_password_pam_pwhistory_use_authtok
-          - accounts_password_pam_unix_authtok
-          - accounts_password_set_min_life_existing
-          - no_empty_passwords_etc_shadow
-          - set_password_hashing_algorithm_logindefs
-          - set_password_hashing_algorithm_passwordauth
-          - set_password_hashing_algorithm_systemauth
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - cracklib_accounts_password_pam_ocredit
+          - snmpd_not_default_password
       status: automated
     - id: ia-5.1
       title: Password-based Authentication
       levels:
           - low
       rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_all_shadowed_sha512
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
-          - accounts_password_pam_unix_enabled
+          - accounts_password_pam_ucredit
+          - accounts_password_pam_unix_remember
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - auditd_data_retention_action_mail_acct
+          - no_empty_passwords
+          - no_netrc_files
+          - package_rsh-server_removed
+          - package_vsftpd_removed
+          - package_ypserv_removed
+          - passwd_system-auth_substack
+          - service_rexec_disabled
+          - service_rlogin_disabled
+          - service_rsh_disabled
+          - service_telnet_disabled
+          - service_ypbind_disabled
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_yescrypt_cost_factor_logindefs
+          - sshd_allow_only_protocol2
+          - sshd_use_approved_ciphers
       status: automated
     - id: ia-5.2
       title: Public Key-based Authentication
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - ssh_private_keys_have_passcode
+      status: automated
     - id: ia-5.3
       title: In-person or Trusted External Party Registration
       rules: []
       status: pending
     - id: ia-5.4
       title: Automated Support for Password Strength Determination
-      rules: []
-      status: pending
+      rules:
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_retry
+          - accounts_password_pam_ucredit
+      status: automated
     - id: ia-5.5
       title: Change Authenticators Prior to Delivery
       rules: []
@@ -202,8 +300,9 @@ controls:
       status: pending
     - id: ia-5.7
       title: No Embedded Unencrypted Static Authenticators
-      rules: []
-      status: pending
+      rules:
+          - no_netrc_files
+      status: automated
     - id: ia-5.8
       title: Multiple System Accounts
       rules: []
@@ -214,8 +313,9 @@ controls:
       status: pending
     - id: ia-5.10
       title: Dynamic Credential Binding
-      rules: []
-      status: pending
+      rules:
+          - service_sssd_enabled
+      status: automated
     - id: ia-5.11
       title: Hardware Token-based Authentication
       rules: []
@@ -226,8 +326,11 @@ controls:
       status: pending
     - id: ia-5.13
       title: Expiration of Cached Authenticators
-      rules: []
-      status: pending
+      rules:
+          - sssd_memcache_timeout
+          - sssd_offline_cred_expiration
+          - sssd_ssh_known_hosts_timeout
+      status: automated
     - id: ia-5.14
       title: Managing Content of PKI Trust Stores
       rules: []
@@ -258,8 +361,17 @@ controls:
       title: Cryptographic Module Authentication
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - installed_OS_is_FIPS_certified
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sysctl_crypto_fips_enabled
+      status: automated
     - id: ia-8
       title: Identification and Authentication (Non-organizational Users)
       levels:
@@ -317,6 +429,10 @@ controls:
       levels:
           - low
       rules:
+          - disallow_bypass_password_sudo
+          - sudo_remove_no_authenticate
+          - sudo_remove_nopasswd
+          - sudo_require_authentication
           - sudo_require_reauthentication
       status: automated
     - id: ia-12

--- a/products/rhel10/controls/nist_800_53/ir.yml
+++ b/products/rhel10/controls/nist_800_53/ir.yml
@@ -52,8 +52,11 @@ controls:
       title: Incident Handling
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_configure_remote_server
+          - auditd_offload_logs
+          - service_postfix_enabled
+      status: automated
     - id: ir-4.1
       title: Automated Incident Handling Processes
       levels:
@@ -124,8 +127,14 @@ controls:
       title: Incident Monitoring
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_file_deletion_events
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_rmdir
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+      status: automated
     - id: ir-5.1
       title: Automated Tracking, Data Collection, and Analysis
       levels:

--- a/products/rhel10/controls/nist_800_53/ra.yml
+++ b/products/rhel10/controls/nist_800_53/ra.yml
@@ -48,8 +48,17 @@ controls:
       title: Vulnerability Monitoring and Scanning
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_cramfs_disabled
+          - kernel_module_dccp_disabled
+          - kernel_module_freevxfs_disabled
+          - kernel_module_hfs_disabled
+          - kernel_module_hfsplus_disabled
+          - kernel_module_jffs2_disabled
+          - kernel_module_rds_disabled
+          - kernel_module_sctp_disabled
+          - kernel_module_tipc_disabled
+      status: automated
     - id: ra-5.1
       title: Update Tool Capability
       rules: []

--- a/products/rhel10/controls/nist_800_53/sc.yml
+++ b/products/rhel10/controls/nist_800_53/sc.yml
@@ -71,7 +71,12 @@ controls:
       levels:
           - low
       rules:
+          - accounts_passwords_pam_faillock_root_unlock_time
           - firewalld-backend
+          - kernel_config_binfmt_misc
+          - kernel_config_modify_ldt_syscall
+          - sshd_set_max_sessions
+          - sshd_set_maxstartups
           - sysctl_net_ipv4_conf_all_accept_source_route
           - sysctl_net_ipv4_conf_all_send_redirects
           - sysctl_net_ipv4_conf_default_accept_source_route
@@ -307,6 +312,10 @@ controls:
       levels:
           - moderate
       rules:
+          - dovecot_configure_ssl_cert
+          - dovecot_configure_ssl_key
+          - dovecot_enable_ssl
+          - httpd_configure_tls
           - libreswan_approved_tunnels
       status: automated
     - id: sc-8.1
@@ -463,6 +472,8 @@ controls:
           - harden_openssl_crypto_policy
           - harden_ssh_client_crypto_policy
           - harden_sshd_crypto_policy
+          - httpd_digest_authentication
+          - httpd_require_client_certs
           - installed_OS_is_FIPS_certified
           - is_fips_mode_enabled
           - package_dracut-fips-aesni_installed
@@ -573,6 +584,9 @@ controls:
       levels:
           - low
       rules:
+          - avahi_check_ttl
+          - avahi_ip_only
+          - avahi_restrict_published_information
           - network_configure_name_resolution
       status: automated
     - id: sc-20.1

--- a/products/rhel10/controls/nist_800_53/sc.yml
+++ b/products/rhel10/controls/nist_800_53/sc.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 SC Family: System and Communications Protection
 controls:
     - id: sc-1
       title: Policy and Procedures
@@ -15,8 +14,10 @@ controls:
       status: automated
     - id: sc-2.1
       title: Interfaces for Non-privileged Users
-      rules: []
-      status: pending
+      rules:
+          - coreos_disable_interactive_boot
+          - grub2_disable_interactive_boot
+      status: automated
     - id: sc-2.2
       title: Disassociability
       rules: []
@@ -26,8 +27,7 @@ controls:
       levels:
           - high
       rules:
-          - selinux_not_disabled
-          - selinux_state
+          - grub2_init_on_free
       status: automated
     - id: sc-3.1
       title: Hardware Separation
@@ -70,20 +70,42 @@ controls:
       levels:
           - low
       rules:
-          - sysctl_net_ipv4_tcp_syncookies
+          - firewalld-backend
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv4_tcp_invalid_ratelimit
       status: automated
     - id: sc-5.1
       title: Restrict Ability to Attack Other Systems
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-5.2
       title: Capacity, Bandwidth, and Redundancy
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - partition_for_home
+          - partition_for_tmp
+          - partition_for_var
+          - partition_for_var_log
+          - partition_for_var_log_audit
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-5.3
       title: Detection and Monitoring
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-6
       title: Resource Availability
       rules: []
@@ -92,8 +114,19 @@ controls:
       title: Boundary Protection
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_ip_forward
+      status: automated
     - id: sc-7.1
       title: Physically Separated Subnetworks
       rules: []
@@ -142,8 +175,15 @@ controls:
       status: pending
     - id: sc-7.10
       title: Prevent Exfiltration
-      rules: []
-      status: pending
+      rules:
+          - disable_users_coredumps
+          - service_systemd-coredump_disabled
+          - sysctl_kernel_core_pattern
+          - sysctl_kernel_unprivileged_bpf_disabled
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - sysctl_kernel_yama_ptrace_scope
+          - sysctl_net_core_bpf_jit_harden
+      status: automated
     - id: sc-7.11
       title: Restrict Incoming Communications Traffic
       rules: []
@@ -190,16 +230,28 @@ controls:
       title: Isolation of System Components
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - configure_firewalld_ports
+          - package_pam_apparmor_installed
+          - selinux_policytype
+          - selinux_state
+          - service_firewalld_enabled
+          - service_ip6tables_enabled
+          - service_iptables_enabled
+          - set_ip6tables_default_rule
+      status: automated
     - id: sc-7.22
       title: Separate Subnets for Connecting to Different Security Domains
       rules: []
       status: pending
     - id: sc-7.23
       title: Disable Sender Feedback on Protocol Validation Failure
-      rules: []
-      status: pending
+      rules:
+          - set_firewalld_default_zone
+          - set_iptables_default_rule
+          - set_iptables_default_rule_forward
+      status: automated
     - id: sc-7.24
       title: Personally Identifiable Information
       rules: []
@@ -229,26 +281,31 @@ controls:
       levels:
           - moderate
       rules:
-          - configure_custom_crypto_policy_cis
+          - libreswan_approved_tunnels
       status: automated
     - id: sc-8.1
       title: Cryptographic Protection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - harden_openssl_crypto_policy
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.2
       title: Pre- and Post-transmission Handling
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.3
       title: Cryptographic Protection for Message Externals
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.4
       title: Conceal or Randomize Communications
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.5
       title: Protected Distribution System
       rules: []
@@ -261,8 +318,13 @@ controls:
       title: Network Disconnect
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+      status: automated
     - id: sc-11
       title: Trusted Path
       rules: []
@@ -275,8 +337,9 @@ controls:
       title: Cryptographic Key Establishment and Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - ldap_client_start_tls
+      status: automated
     - id: sc-12.1
       title: Availability
       levels:
@@ -285,12 +348,62 @@ controls:
       status: pending
     - id: sc-12.2
       title: Symmetric Keys
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-12.3
       title: Asymmetric Keys
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sssd_ldap_configure_tls_ca
+          - sssd_ldap_configure_tls_ca_dir
+          - sssd_ldap_configure_tls_reqcert
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-12.4
       title: PKI Certificates
       rules: []
@@ -307,8 +420,34 @@ controls:
       title: Cryptographic Protection
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_ssh_crypto_policy
+          - disable_prelink
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - encrypt_partitions
+          - etc_system_fips_exists
+          - fips_crypto_policy_symlinks
+          - grub2_enable_fips_mode
+          - harden_openssl_crypto_policy
+          - harden_ssh_client_crypto_policy
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_allow_only_protocol2
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-13.1
       title: FIPS-validated Cryptography
       rules: []
@@ -407,8 +546,9 @@ controls:
       title: Secure Name/Address Resolution Service (Authoritative Source)
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - network_configure_name_resolution
+      status: automated
     - id: sc-20.1
       title: Child Subspaces
       rules: []
@@ -464,6 +604,7 @@ controls:
       levels:
           - high
       rules:
+          - audit_rules_system_shutdown
           - service_systemd-journald_enabled
       status: automated
     - id: sc-25
@@ -486,14 +627,18 @@ controls:
       title: Protection of Information at Rest
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - install_mcafee_antivirus
+          - mcafee_antivirus_definitions_updated
+          - service_nails_enabled
+      status: automated
     - id: sc-28.1
       title: Cryptographic Protection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - encrypt_partitions
+      status: automated
     - id: sc-28.2
       title: Offline Storage
       rules: []
@@ -520,8 +665,10 @@ controls:
       status: pending
     - id: sc-30.2
       title: Randomness
-      rules: []
-      status: pending
+      rules:
+          - sysctl_kernel_kptr_restrict
+          - sysctl_kernel_randomize_va_space
+      status: automated
     - id: sc-30.3
       title: Change Processing and Storage Locations
       rules: []
@@ -532,8 +679,9 @@ controls:
       status: pending
     - id: sc-30.5
       title: Concealment of System Components
-      rules: []
-      status: pending
+      rules:
+          - sysctl_kernel_kptr_restrict
+      status: automated
     - id: sc-31
       title: Covert Channel Analysis
       rules: []
@@ -610,8 +758,11 @@ controls:
       title: Process Isolation
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - bios_enable_execution_restrictions
+          - sysctl_kernel_exec_shield
+          - sysctl_user_max_user_namespaces
+      status: automated
     - id: sc-39.1
       title: Hardware Separation
       rules: []

--- a/products/rhel10/controls/nist_800_53/sc.yml
+++ b/products/rhel10/controls/nist_800_53/sc.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 SC Family: System and Communications Protection
 controls:
     - id: sc-1
       title: Policy and Procedures
@@ -115,6 +116,28 @@ controls:
       levels:
           - low
       rules:
+          - ensure_firewall_rules_for_open_ports
+          - firewall_single_service_active
+          - firewalld_loopback_traffic_restricted
+          - firewalld_loopback_traffic_trusted
+          - firewalld_sshd_disabled
+          - ftp_configure_firewall
+          - httpd_configure_firewall
+          - ip6tables_rules_for_open_ports
+          - iptables_rules_for_open_ports
+          - iptables_sshd_disabled
+          - nftables_ensure_default_deny_policy
+          - package_SuSEfirewall2_installed
+          - package_firewalld_removed
+          - service_SuSEfirewall2_enabled
+          - service_firewalld_disabled
+          - set_firewalld_appropriate_zone
+          - set_iptables_outbound_n_established
+          - set_nftables_new_connections
+          - set_nftables_table
+          - set_ufw_default_rule
+          - susefirewall2_ddos_protection
+          - susefirewall2_only_required_services
           - sysctl_net_ipv4_conf_all_accept_redirects
           - sysctl_net_ipv4_conf_all_accept_source_route
           - sysctl_net_ipv4_conf_all_rp_filter
@@ -126,6 +149,9 @@ controls:
           - sysctl_net_ipv4_conf_default_secure_redirects
           - sysctl_net_ipv4_conf_default_send_redirects
           - sysctl_net_ipv4_ip_forward
+          - ufw_only_required_services
+          - ufw_rate_limit
+          - ufw_rules_for_open_ports
       status: automated
     - id: sc-7.1
       title: Physically Separated Subnetworks

--- a/products/rhel10/controls/nist_800_53/si.yml
+++ b/products/rhel10/controls/nist_800_53/si.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 SI Family: System and Information Integrity
 controls:
     - id: si-1
       title: Policy and Procedures
@@ -22,8 +21,10 @@ controls:
       title: Automated Flaw Remediation Status
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - agent_mfetpd_running
+          - package_mcafeetp_installed
+      status: automated
     - id: si-2.3
       title: Time to Remediate Flaws and Benchmarks for Corrective Actions
       rules: []
@@ -34,12 +35,17 @@ controls:
       status: pending
     - id: si-2.5
       title: Automatic Software and Firmware Updates
-      rules: []
-      status: pending
+      rules:
+          - dnf-automatic_apply_updates
+          - dnf-automatic_security_updates_only
+          - security_patches_up_to_date
+          - timer_dnf-automatic_enabled
+      status: automated
     - id: si-2.6
       title: Removal of Previous Versions of Software and Firmware
-      rules: []
-      status: pending
+      rules:
+          - clean_components_post_updating
+      status: automated
     - id: si-2.7
       title: Root Cause Analysis
       rules: []
@@ -49,8 +55,8 @@ controls:
       levels:
           - low
       rules:
-          - kernel_module_usb-storage_disabled
-          - service_autofs_disabled
+          - install_mcafee_antivirus
+          - service_nails_enabled
       status: automated
     - id: si-3.1
       title: Central Management
@@ -58,8 +64,9 @@ controls:
       status: pending
     - id: si-3.2
       title: Automatic Updates
-      rules: []
-      status: pending
+      rules:
+          - mcafee_antivirus_definitions_updated
+      status: automated
     - id: si-3.3
       title: Non-privileged Users
       rules: []
@@ -205,12 +212,15 @@ controls:
       title: Unauthorized Network Services
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - package_fapolicyd_installed
+          - service_fapolicyd_enabled
+      status: automated
     - id: si-4.23
       title: Host-based Devices
-      rules: []
-      status: pending
+      rules:
+          - service_auditd_enabled
+      status: automated
     - id: si-4.24
       title: Indicators of Compromise
       rules: []
@@ -253,14 +263,31 @@ controls:
       title: Software, Firmware, and Information Integrity
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+      status: automated
     - id: si-7.1
       title: Integrity Checks
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - aide_periodic_checking_systemd_timer
+          - aide_periodic_cron_checking
+          - aide_use_fips_hashes
+          - aide_verify_acls
+          - aide_verify_ext_attributes
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+      status: automated
     - id: si-7.2
       title: Automated Notifications of Integrity Violations
       levels:
@@ -283,8 +310,11 @@ controls:
       status: pending
     - id: si-7.6
       title: Cryptographic Protection
-      rules: []
-      status: pending
+      rules:
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+      status: automated
     - id: si-7.7
       title: Integration of Detection and Response
       levels:
@@ -391,8 +421,14 @@ controls:
       title: Error Handling
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - file_groupownership_lastlog
+          - file_ownership_lastlog
+          - file_permissions_lastlog
+          - permissions_local_var_log
+          - sysctl_fs_suid_dumpable
+          - sysctl_kernel_dmesg_restrict
+      status: automated
     - id: si-12
       title: Information Management and Retention
       levels:
@@ -460,7 +496,8 @@ controls:
       levels:
           - moderate
       rules:
-          - sysctl_kernel_randomize_va_space
+          - coreos_pti_kernel_argument
+          - grub2_pti_argument
       status: automated
     - id: si-17
       title: Fail-safe Procedures

--- a/products/rhel10/controls/nist_800_53/si.yml
+++ b/products/rhel10/controls/nist_800_53/si.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 SI Family: System and Information Integrity
 controls:
     - id: si-1
       title: Policy and Procedures
@@ -11,7 +12,10 @@ controls:
           - low
       rules:
           - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
           - ensure_redhat_gpgkey_installed
+          - package_abrt_removed
       status: automated
     - id: si-2.1
       title: Central Management
@@ -55,7 +59,13 @@ controls:
       levels:
           - low
       rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+          - dconf_gnome_disable_autorun
           - install_mcafee_antivirus
+          - sebool_antivirus_can_scan_system
+          - sebool_antivirus_use_jit
+          - secure_boot_enabled
           - service_nails_enabled
       status: automated
     - id: si-3.1
@@ -104,10 +114,16 @@ controls:
       levels:
           - low
       rules:
+          - journald_compress
+          - journald_forward_to_syslog
+          - journald_storage
           - kernel_module_dccp_disabled
           - kernel_module_rds_disabled
           - kernel_module_sctp_disabled
           - kernel_module_tipc_disabled
+          - package_systemd-journal-remote_installed
+          - rsyslog_cron_logging
+          - rsyslog_logging_configured
           - service_avahi-daemon_disabled
       status: automated
     - id: si-4.1
@@ -391,8 +407,13 @@ controls:
       title: Information Input Validation
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - kernel_config_fortify_source
+          - kernel_config_randomize_base
+          - kernel_config_stackprotector
+          - sebool_selinuxuser_execheap
+          - sebool_selinuxuser_execstack
+      status: automated
     - id: si-10.1
       title: Manual Override Capability
       rules: []

--- a/products/rhel10/profiles/cis_nist.profile
+++ b/products/rhel10/profiles/cis_nist.profile
@@ -1,0 +1,11 @@
+documentation_complete: true
+metadata:
+  version: 1.0.1
+  SMEs:
+    - nist_sync_automation
+reference: https://www.cisecurity.org/benchmark/red_hat_linux/
+title: CIS Red Hat Enterprise Linux 10 Benchmark for Level 2 - Server (NIST-based)
+description: "This profile defines a baseline that aligns to the \"Level 2 - Server\"\nconfiguration from the Center for Internet Security® Red Hat Enterprise\nLinux 10 Benchmark™, v1.0.1.\n\nThis profile is generated from the NIST 800-53 control file and uses\nthe unified NIST 800-53 controls that include CIS-derived rules and\nvariables from all RHEL versions.\n\nThis profile includes Center for Internet Security®\nRed Hat Enterprise Linux 10 CIS Benchmarks™ content."
+selections:
+  - nist_800_53:all
+  - var_authselect_profile=local

--- a/products/rhel8/controls/nist_800_53/ac.yml
+++ b/products/rhel8/controls/nist_800_53/ac.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 AC Family: Access Control
 controls:
     - id: ac-1
       title: Policy and Procedures
@@ -10,40 +9,81 @@ controls:
       title: Account Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - service_auditd_enabled
+      status: automated
     - id: ac-2.1
       title: Automated System Account Management
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_password_pam_enforce_local
+          - accounts_passwords_pam_faillock_enforce_local
+      status: automated
     - id: ac-2.2
       title: Automated Temporary and Emergency Account Management
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - account_emergency_expire_date
+          - account_temp_expire_date
+      status: automated
     - id: ac-2.3
       title: Disable Accounts
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - account_disable_post_pw_expiration
+          - account_emergency_expire_date
+          - account_temp_expire_date
+          - accounts_set_post_pw_existing
+      status: automated
     - id: ac-2.4
       title: Automated Audit Actions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_etc_group_open
+          - audit_rules_etc_group_open_by_handle_at
+          - audit_rules_etc_group_openat
+          - audit_rules_etc_gshadow_open
+          - audit_rules_etc_gshadow_open_by_handle_at
+          - audit_rules_etc_gshadow_openat
+          - audit_rules_etc_passwd_open
+          - audit_rules_etc_passwd_open_by_handle_at
+          - audit_rules_etc_passwd_openat
+          - audit_rules_etc_shadow_open
+          - audit_rules_etc_shadow_open_by_handle_at
+          - audit_rules_etc_shadow_openat
+          - audit_rules_execution_semanage
+          - audit_rules_privileged_commands
+          - audit_rules_privileged_commands_chage
+          - audit_rules_privileged_commands_chsh
+          - audit_rules_privileged_commands_gpasswd
+          - audit_rules_privileged_commands_newgidmap
+          - audit_rules_privileged_commands_newgrp
+          - audit_rules_privileged_commands_newuidmap
+          - audit_rules_privileged_commands_passwd
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+          - audit_rules_privileged_commands_usernetctl
+          - audit_rules_usergroup_modification
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+      status: automated
     - id: ac-2.5
       title: Inactivity Logout
       levels:
           - moderate
       rules:
-          - no_invalid_shell_accounts_unlocked
-          - no_password_auth_for_systemaccounts
-          - no_shelllogin_for_systemaccounts
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
       status: automated
     - id: ac-2.6
       title: Dynamic Privilege Management
@@ -51,8 +91,9 @@ controls:
       status: pending
     - id: ac-2.7
       title: Privileged User Accounts
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_sysadmin_actions
+      status: automated
     - id: ac-2.8
       title: Dynamic Account Management
       rules: []
@@ -88,156 +129,44 @@ controls:
       levels:
           - low
       rules:
-          - accounts_umask_etc_bashrc
-          - accounts_umask_etc_login_defs
-          - accounts_umask_etc_profile
-          - accounts_umask_root
-          - audit_rules_immutable
-          - dir_perms_world_writable_sticky_bits
-          - ensure_pam_wheel_group_empty
-          - file_at_allow_exists
-          - file_at_deny_not_exist
-          - file_cron_allow_exists
-          - file_cron_deny_not_exist
-          - file_groupowner_at_allow
-          - file_groupowner_backup_etc_group
-          - file_groupowner_backup_etc_gshadow
-          - file_groupowner_backup_etc_passwd
-          - file_groupowner_backup_etc_shadow
-          - file_groupowner_cron_allow
-          - file_groupowner_cron_d
-          - file_groupowner_cron_daily
-          - file_groupowner_cron_hourly
-          - file_groupowner_cron_monthly
-          - file_groupowner_cron_weekly
-          - file_groupowner_cron_yearly
-          - file_groupowner_crontab
-          - file_groupowner_etc_group
-          - file_groupowner_etc_gshadow
-          - file_groupowner_etc_issue
-          - file_groupowner_etc_issue_net
-          - file_groupowner_etc_motd
-          - file_groupowner_etc_passwd
-          - file_groupowner_etc_security_opasswd
-          - file_groupowner_etc_security_opasswd_old
-          - file_groupowner_etc_shadow
+          - disable_host_auth
+          - enable_authselect
           - file_groupowner_etc_shells
-          - file_groupowner_etc_sysconfig_sshd
-          - file_groupowner_grub2_cfg
-          - file_groupowner_sshd_config
-          - file_groupowner_user_cfg
-          - file_groupownership_sshd_private_key
-          - file_groupownership_sshd_pub_key
-          - file_owner_at_allow
-          - file_owner_backup_etc_group
-          - file_owner_backup_etc_gshadow
-          - file_owner_backup_etc_passwd
-          - file_owner_backup_etc_shadow
-          - file_owner_cron_allow
-          - file_owner_cron_d
-          - file_owner_cron_daily
-          - file_owner_cron_hourly
-          - file_owner_cron_monthly
-          - file_owner_cron_weekly
-          - file_owner_cron_yearly
-          - file_owner_crontab
-          - file_owner_etc_group
-          - file_owner_etc_gshadow
-          - file_owner_etc_issue
-          - file_owner_etc_issue_net
-          - file_owner_etc_motd
-          - file_owner_etc_passwd
-          - file_owner_etc_security_opasswd
-          - file_owner_etc_security_opasswd_old
-          - file_owner_etc_shadow
           - file_owner_etc_shells
-          - file_owner_etc_sysconfig_sshd
-          - file_owner_grub2_cfg
-          - file_owner_sshd_config
-          - file_owner_user_cfg
-          - file_ownership_sshd_private_key
-          - file_ownership_sshd_pub_key
-          - file_permissions_at_allow
-          - file_permissions_backup_etc_group
-          - file_permissions_backup_etc_gshadow
-          - file_permissions_backup_etc_passwd
-          - file_permissions_backup_etc_shadow
-          - file_permissions_cron_allow
-          - file_permissions_cron_d
-          - file_permissions_cron_daily
-          - file_permissions_cron_hourly
-          - file_permissions_cron_monthly
-          - file_permissions_cron_weekly
-          - file_permissions_cron_yearly
-          - file_permissions_crontab
-          - file_permissions_etc_group
-          - file_permissions_etc_gshadow
-          - file_permissions_etc_issue
-          - file_permissions_etc_issue_net
-          - file_permissions_etc_motd
-          - file_permissions_etc_passwd
-          - file_permissions_etc_security_opasswd
-          - file_permissions_etc_security_opasswd_old
-          - file_permissions_etc_shadow
           - file_permissions_etc_shells
-          - file_permissions_etc_sysconfig_sshd
-          - file_permissions_grub2_cfg
-          - file_permissions_sshd_config
-          - file_permissions_sshd_private_key
-          - file_permissions_sshd_pub_key
-          - file_permissions_unauthorized_world_writable
-          - file_permissions_user_cfg
-          - grub2_enable_selinux
-          - grub2_password
-          - grub2_uefi_password
-          - mount_option_dev_shm_nodev
-          - mount_option_dev_shm_noexec
-          - mount_option_dev_shm_nosuid
-          - mount_option_home_nodev
-          - mount_option_home_nosuid
-          - mount_option_tmp_noexec
-          - mount_option_tmp_nosuid
-          - mount_option_var_log_audit_nodev
-          - mount_option_var_log_audit_noexec
-          - mount_option_var_log_audit_nosuid
-          - mount_option_var_log_nodev
-          - mount_option_var_log_noexec
-          - mount_option_var_log_nosuid
-          - mount_option_var_nodev
-          - mount_option_var_nosuid
-          - mount_option_var_tmp_nodev
-          - mount_option_var_tmp_noexec
-          - mount_option_var_tmp_nosuid
-          - package_libselinux_installed
-          - package_mcstrans_removed
-          - package_setroubleshoot_removed
-          - rsyslog_filecreatemode
-          - rsyslog_files_groupownership
-          - rsyslog_files_ownership
-          - rsyslog_files_permissions
-          - selinux_not_disabled
-          - selinux_policytype
+          - ftp_restrict_to_anon
+          - require_emergency_target_auth
+          - require_singleuser_auth
           - sshd_limit_user_access
-          - sysctl_fs_protected_hardlinks
-          - sysctl_fs_protected_symlinks
-          - use_pam_wheel_group_for_su
       status: automated
     - id: ac-3.1
       title: Restricted Access to Privileged Functions
-      rules: []
-      status: pending
+      rules:
+          - grub2_password_legacy
+          - grub2_uefi_password_legacy
+      status: automated
     - id: ac-3.2
       title: Dual Authorization
       rules: []
       status: pending
     - id: ac-3.3
       title: Mandatory Access Control
-      rules: []
-      status: pending
+      rules:
+          - coreos_enable_selinux_kernel_argument
+          - grub2_enable_selinux
+          - selinux_all_devicefiles_labeled
+          - selinux_confinement_of_daemons
+          - selinux_policytype
+          - selinux_state
+      status: automated
     - id: ac-3.4
       title: Discretionary Access Control
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - package_pam_apparmor_installed
+          - selinux_confine_to_least_privilege
+          - selinux_context_elevation_for_sudo
+      status: automated
     - id: ac-3.5
       title: Security-relevant Information
       rules: []
@@ -286,8 +215,15 @@ controls:
       title: Information Flow Enforcement
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_ports
+          - libreswan_approved_tunnels
+          - service_firewalld_enabled
+          - service_ip6tables_enabled
+          - service_iptables_enabled
+          - service_rdisc_disabled
+          - set_ip6tables_default_rule
+      status: automated
     - id: ac-4.1
       title: Object Security and Privacy Attributes
       rules: []
@@ -429,23 +365,152 @@ controls:
       levels:
           - moderate
       rules:
-          - sshd_disable_root_login
-          - sudo_add_use_pty
-          - sudo_remove_no_authenticate
-          - sudo_remove_nopasswd
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
+          - restrict_serial_port_logins
+          - securetty_root_login_console_only
+          - selinux_all_devicefiles_labeled
+          - selinux_confinement_of_daemons
+          - sshd_enable_strictmodes
+          - sshd_use_priv_separation
+          - sysctl_kernel_perf_event_paranoid
+          - sysctl_kernel_unprivileged_bpf_disabled
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - tftpd_uses_secure_mode
       status: automated
     - id: ac-6.1
       title: Authorize Access to Security Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_csh_cshrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - dconf_gnome_disable_ctrlaltdel_reboot
+          - dconf_gnome_disable_restart_shutdown
+          - dir_perms_var_log_httpd
+          - dir_perms_world_writable_sticky_bits
+          - dir_perms_world_writable_system_owned
+          - dir_perms_world_writable_system_owned_group
+          - directory_group_ownership_var_log_audit
+          - directory_groupowner_sshd_config_d
+          - directory_owner_sshd_config_d
+          - directory_ownership_var_log_audit
+          - directory_permissions_sshd_config_d
+          - directory_permissions_var_log_audit
+          - disable_ctrlaltdel_burstaction
+          - disable_ctrlaltdel_reboot
+          - file_group_ownership_var_log_audit
+          - file_groupowner_cron_allow
+          - file_groupowner_cron_d
+          - file_groupowner_cron_daily
+          - file_groupowner_cron_hourly
+          - file_groupowner_cron_monthly
+          - file_groupowner_cron_weekly
+          - file_groupowner_cron_yearly
+          - file_groupowner_crontab
+          - file_groupowner_efi_grub2_cfg
+          - file_groupowner_efi_user_cfg
+          - file_groupowner_etc_group
+          - file_groupowner_etc_gshadow
+          - file_groupowner_etc_passwd
+          - file_groupowner_etc_shadow
+          - file_groupowner_grub2_cfg
+          - file_groupowner_sshd_config
+          - file_groupowner_sshd_drop_in_config
+          - file_groupowner_user_cfg
+          - file_owner_cron_allow
+          - file_owner_cron_d
+          - file_owner_cron_daily
+          - file_owner_cron_hourly
+          - file_owner_cron_monthly
+          - file_owner_cron_weekly
+          - file_owner_cron_yearly
+          - file_owner_crontab
+          - file_owner_efi_grub2_cfg
+          - file_owner_efi_user_cfg
+          - file_owner_etc_group
+          - file_owner_etc_gshadow
+          - file_owner_etc_passwd
+          - file_owner_etc_shadow
+          - file_owner_grub2_cfg
+          - file_owner_sshd_config
+          - file_owner_sshd_drop_in_config
+          - file_owner_user_cfg
+          - file_ownership_binary_dirs
+          - file_ownership_library_dirs
+          - file_ownership_var_log_audit
+          - file_ownership_var_log_audit_stig
+          - file_permissions_binary_dirs
+          - file_permissions_cron_d
+          - file_permissions_cron_daily
+          - file_permissions_cron_hourly
+          - file_permissions_cron_monthly
+          - file_permissions_cron_weekly
+          - file_permissions_cron_yearly
+          - file_permissions_crontab
+          - file_permissions_efi_grub2_cfg
+          - file_permissions_efi_user_cfg
+          - file_permissions_etc_group
+          - file_permissions_etc_gshadow
+          - file_permissions_etc_passwd
+          - file_permissions_etc_shadow
+          - file_permissions_grub2_cfg
+          - file_permissions_home_dirs
+          - file_permissions_httpd_server_conf_d_files
+          - file_permissions_httpd_server_conf_files
+          - file_permissions_httpd_server_modules_files
+          - file_permissions_library_dirs
+          - file_permissions_sshd_config
+          - file_permissions_sshd_drop_in_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - file_permissions_unauthorized_sgid
+          - file_permissions_unauthorized_suid
+          - file_permissions_unauthorized_world_writable
+          - file_permissions_ungroupowned
+          - file_permissions_user_cfg
+          - file_permissions_var_log_audit
+          - gnome_gdm_disable_automatic_login
+          - mount_option_boot_nodev
+          - mount_option_boot_nosuid
+          - mount_option_dev_shm_nodev
+          - mount_option_dev_shm_noexec
+          - mount_option_dev_shm_nosuid
+          - mount_option_home_nosuid
+          - mount_option_nodev_nonroot_local_partitions
+          - mount_option_nodev_removable_partitions
+          - mount_option_noexec_removable_partitions
+          - mount_option_nosuid_remote_filesystems
+          - mount_option_nosuid_removable_partitions
+          - mount_option_tmp_nodev
+          - mount_option_tmp_noexec
+          - mount_option_tmp_nosuid
+          - mount_option_var_log_audit_nodev
+          - mount_option_var_log_audit_noexec
+          - mount_option_var_log_audit_nosuid
+          - mount_option_var_log_nodev
+          - mount_option_var_log_noexec
+          - mount_option_var_log_nosuid
+          - mount_option_var_nodev
+          - mount_option_var_tmp_bind
+          - no_files_unowned_by_user
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+          - sysctl_fs_protected_fifos
+          - sysctl_fs_protected_hardlinks
+          - sysctl_fs_protected_regular
+          - sysctl_fs_protected_symlinks
+          - umask_for_daemons
+      status: automated
     - id: ac-6.2
       title: Non-privileged Access for Nonsecurity Functions
       levels:
           - moderate
       rules:
-          - package_sudo_installed
+          - sshd_disable_root_login
       status: automated
     - id: ac-6.3
       title: Network Access to Privileged Commands
@@ -461,8 +526,9 @@ controls:
       title: Privileged Accounts
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_no_uid_except_zero
+      status: automated
     - id: ac-6.6
       title: Privileged Access by Non-organizational Users
       rules: []
@@ -475,27 +541,112 @@ controls:
       status: pending
     - id: ac-6.8
       title: Privilege Levels for Code Execution
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - mount_option_noexec_remote_filesystems
+          - package_pam_apparmor_installed
+      status: automated
     - id: ac-6.9
       title: Log Use of Privileged Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_etc_group_open
+          - audit_rules_etc_group_open_by_handle_at
+          - audit_rules_etc_group_openat
+          - audit_rules_etc_gshadow_open
+          - audit_rules_etc_gshadow_open_by_handle_at
+          - audit_rules_etc_gshadow_openat
+          - audit_rules_etc_passwd_open
+          - audit_rules_etc_passwd_open_by_handle_at
+          - audit_rules_etc_passwd_openat
+          - audit_rules_etc_shadow_open
+          - audit_rules_etc_shadow_open_by_handle_at
+          - audit_rules_etc_shadow_openat
+          - audit_rules_execution_chcon
+          - audit_rules_execution_restorecon
+          - audit_rules_execution_semanage
+          - audit_rules_execution_setfiles
+          - audit_rules_execution_setsebool
+          - audit_rules_execution_seunshare
+          - audit_rules_immutable
+          - audit_rules_kernel_module_loading
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_login_events
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - audit_rules_login_events_tallylog
+          - audit_rules_media_export
+          - audit_rules_networkconfig_modification
+          - audit_rules_privileged_commands
+          - audit_rules_privileged_commands_at
+          - audit_rules_privileged_commands_chage
+          - audit_rules_privileged_commands_chsh
+          - audit_rules_privileged_commands_crontab
+          - audit_rules_privileged_commands_gpasswd
+          - audit_rules_privileged_commands_mount
+          - audit_rules_privileged_commands_newgidmap
+          - audit_rules_privileged_commands_newgrp
+          - audit_rules_privileged_commands_newuidmap
+          - audit_rules_privileged_commands_pam_timestamp_check
+          - audit_rules_privileged_commands_passwd
+          - audit_rules_privileged_commands_postdrop
+          - audit_rules_privileged_commands_postqueue
+          - audit_rules_privileged_commands_pt_chown
+          - audit_rules_privileged_commands_ssh_keysign
+          - audit_rules_privileged_commands_su
+          - audit_rules_privileged_commands_sudo
+          - audit_rules_privileged_commands_sudoedit
+          - audit_rules_privileged_commands_umount
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+          - audit_rules_privileged_commands_userhelper
+          - audit_rules_privileged_commands_usernetctl
+          - audit_rules_suid_privilege_function
+          - audit_rules_sysadmin_actions
+          - audit_rules_time_adjtimex
+          - audit_rules_time_clock_settime
+          - audit_rules_time_settimeofday
+          - audit_rules_time_stime
+          - audit_rules_time_watch_localtime
+          - audit_rules_usergroup_modification
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+          - directory_access_var_log_audit
+          - service_auditd_enabled
+      status: automated
     - id: ac-6.10
       title: Prohibit Non-privileged Users from Executing Privileged Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - mount_option_noexec_remote_filesystems
+          - package_pam_apparmor_installed
+          - selinux_confine_to_least_privilege
+          - selinux_context_elevation_for_sudo
+      status: automated
     - id: ac-7
       title: Unsuccessful Logon Attempts
       levels:
           - low
       rules:
-          - account_password_pam_faillock_password_auth
-          - account_password_pam_faillock_system_auth
+          - accounts_logon_fail_delay
+          - accounts_password_pam_retry
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_dir
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - package_audit-libs_installed
+          - package_audit_installed
       status: automated
     - id: ac-7.1
       title: Automatic Account Lock
@@ -518,8 +669,13 @@ controls:
       levels:
           - low
       rules:
+          - banner_etc_gdm_banner
+          - banner_etc_issue
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
+          - postfix_server_banner
+          - sshd_enable_warning_banner
+          - sshd_enable_warning_banner_net
       status: automated
     - id: ac-9
       title: Previous Logon Notification
@@ -527,8 +683,10 @@ controls:
       status: pending
     - id: ac-9.1
       title: Unsuccessful Logons
-      rules: []
-      status: pending
+      rules:
+          - display_login_attempts
+          - sshd_print_last_log
+      status: automated
     - id: ac-9.2
       title: Successful and Unsuccessful Logons
       rules: []
@@ -545,30 +703,37 @@ controls:
       title: Concurrent Session Control
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - accounts_max_concurrent_login_sessions
+      status: automated
     - id: ac-11
       title: Device Lock
       levels:
           - moderate
       rules:
+          - configure_tmux_lock_command
+          - dconf_gnome_screensaver_idle_activation_enabled
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
-          - dconf_gnome_screensaver_user_locks
-          - dconf_gnome_session_idle_user_locks
       status: automated
     - id: ac-11.1
       title: Pattern-hiding Displays
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_screensaver_mode_blank
+      status: automated
     - id: ac-12
       title: Session Termination
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+      status: automated
     - id: ac-12.1
       title: User-initiated Logouts
       rules: []
@@ -648,21 +813,77 @@ controls:
       levels:
           - low
       rules:
-          - configure_custom_crypto_policy_cis
-          - configure_ssh_crypto_policy
+          - directory_groupowner_sshd_config_d
+          - directory_owner_sshd_config_d
+          - directory_permissions_sshd_config_d
+          - disable_host_auth
+          - enable_ldap_client
+          - file_groupowner_sshd_config
+          - file_groupowner_sshd_drop_in_config
+          - file_owner_sshd_config
+          - file_owner_sshd_drop_in_config
+          - file_permissions_sshd_config
+          - file_permissions_sshd_drop_in_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - firewalld_sshd_port_enabled
+          - ftp_restrict_to_anon
+          - libreswan_approved_tunnels
+          - logind_session_timeout
+          - mount_option_krb_sec_remote_filesystems
+          - sshd_disable_compression
+          - sshd_disable_empty_passwords
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+          - sshd_disable_rhosts
+          - sshd_disable_rhosts_rsa
+          - sshd_disable_root_login
+          - sshd_disable_user_known_hosts
+          - sshd_do_not_permit_user_env
+          - sshd_enable_strictmodes
+          - sshd_enable_warning_banner
+          - sshd_enable_warning_banner_net
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+          - sshd_set_loglevel_info
+          - sshd_use_priv_separation
+          - use_kerberos_security_all_exports
       status: automated
     - id: ac-17.1
       title: Monitoring and Control
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - rsyslog_remote_access_monitoring
+          - sshd_set_loglevel_verbose
+      status: automated
     - id: ac-17.2
       title: Protection of Confidentiality and Integrity Using Encryption
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_crypto_policy
+          - configure_gnutls_tls_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_openssl_tls_crypto_policy
+          - configure_ssh_crypto_policy
+          - dconf_gnome_remote_access_encryption
+          - harden_ssh_client_crypto_policy
+          - harden_sshd_ciphers_openssh_conf_crypto_policy
+          - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+          - harden_sshd_crypto_policy
+          - harden_sshd_macs_openssh_conf_crypto_policy
+          - harden_sshd_macs_opensshserver_conf_crypto_policy
+          - ldap_client_start_tls
+          - sshd_allow_only_protocol2
+          - sshd_enable_x11_forwarding
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_kex_ordered_stig
+          - sshd_use_approved_macs
+      status: automated
     - id: ac-17.3
       title: Managed Access Control Points
       levels:
@@ -704,7 +925,9 @@ controls:
       levels:
           - low
       rules:
-          - wireless_disable_interfaces
+          - kernel_module_atm_disabled
+          - kernel_module_can_disabled
+          - kernel_module_firewire-core_disabled
       status: automated
     - id: ac-18.1
       title: Authentication and Encryption
@@ -720,14 +943,27 @@ controls:
       title: Disable Wireless Networking
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_bluetooth_disabled
+          - kernel_module_cfg80211_disabled
+          - kernel_module_iwlmvm_disabled
+          - kernel_module_iwlwifi_disabled
+          - kernel_module_mac80211_disabled
+          - service_bluetooth_disabled
+          - wireless_disable_in_bios
+          - wireless_disable_interfaces
+      status: automated
     - id: ac-18.4
       title: Restrict Configurations by Users
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_cfg80211_disabled
+          - kernel_module_iwlmvm_disabled
+          - kernel_module_iwlwifi_disabled
+          - kernel_module_mac80211_disabled
+          - network_nmcli_permissions
+      status: automated
     - id: ac-18.5
       title: Antennas and Transmission Power Levels
       levels:
@@ -814,8 +1050,9 @@ controls:
       status: pending
     - id: ac-23
       title: Data Mining Protection
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_disable_user_list
+      status: automated
     - id: ac-24
       title: Access Control Decisions
       rules: []

--- a/products/rhel8/controls/nist_800_53/au.yml
+++ b/products/rhel8/controls/nist_800_53/au.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 AU Family: Audit and Accountability
 controls:
     - id: au-1
       title: Policy and Procedures
@@ -11,28 +10,36 @@ controls:
       levels:
           - low
       rules:
-          - aide_build_database
-          - aide_periodic_cron_checking
-          - audit_rules_execution_chacl
-          - audit_rules_execution_chcon
-          - audit_rules_execution_setfacl
-          - audit_rules_privileged_commands_usermod
-          - auditd_data_disk_error_action
-          - auditd_data_disk_full_action
-          - auditd_data_retention_admin_space_left_action
-          - auditd_data_retention_space_left_action
-          - grub2_audit_backlog_limit_argument
-          - journald_disable_forward_to_syslog
-          - package_aide_installed
-          - package_audit-libs_installed
-          - package_audit_installed
-          - package_systemd-journal-remote_installed
-          - rsyslog_nolisten
-          - service_auditd_enabled
-          - service_rsyslog_enabled
-          - service_systemd-journal-upload_enabled
-          - service_systemd-journald_enabled
-          - socket_systemd-journal-remote_disabled
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success_aarch64
+          - audit_access_success_ppc64le
+          - audit_basic_configuration
+          - audit_create_failed
+          - audit_create_failed_aarch64
+          - audit_create_failed_ppc64le
+          - audit_create_success
+          - audit_create_success_aarch64
+          - audit_create_success_ppc64le
+          - audit_delete_failed
+          - audit_delete_failed_aarch64
+          - audit_delete_failed_ppc64le
+          - audit_delete_success
+          - audit_delete_success_aarch64
+          - audit_delete_success_ppc64le
+          - audit_immutable_login_uids
+          - audit_modify_failed
+          - audit_modify_failed_aarch64
+          - audit_modify_failed_ppc64le
+          - audit_modify_success
+          - audit_modify_success_aarch64
+          - audit_modify_success_ppc64le
+          - audit_module_load
+          - audit_module_load_ppc64le
+          - audit_ospp_general
+          - audit_ospp_general_aarch64
       status: automated
     - id: au-2.1
       title: Compilation of Audit Records from Multiple Sources
@@ -55,73 +62,22 @@ controls:
       levels:
           - low
       rules:
-          - audit_rules_dac_modification_chmod
-          - audit_rules_dac_modification_chown
-          - audit_rules_dac_modification_fchmod
-          - audit_rules_dac_modification_fchmodat
-          - audit_rules_dac_modification_fchown
-          - audit_rules_dac_modification_fchownat
-          - audit_rules_dac_modification_fremovexattr
-          - audit_rules_dac_modification_fsetxattr
-          - audit_rules_dac_modification_lchown
-          - audit_rules_dac_modification_lremovexattr
-          - audit_rules_dac_modification_lsetxattr
-          - audit_rules_dac_modification_removexattr
-          - audit_rules_dac_modification_setxattr
-          - audit_rules_kernel_module_loading_create
-          - audit_rules_kernel_module_loading_delete
-          - audit_rules_kernel_module_loading_finit
-          - audit_rules_kernel_module_loading_init
-          - audit_rules_kernel_module_loading_query
-          - audit_rules_login_events_faillock
-          - audit_rules_login_events_lastlog
-          - audit_rules_mac_modification
-          - audit_rules_mac_modification_usr_share
-          - audit_rules_networkconfig_modification
-          - audit_rules_networkconfig_modification_network_scripts
-          - audit_rules_privileged_commands
-          - audit_rules_privileged_commands_kmod
-          - audit_rules_session_events_btmp
-          - audit_rules_session_events_utmp
-          - audit_rules_session_events_wtmp
-          - audit_rules_suid_auid_privilege_function
-          - audit_rules_sysadmin_actions
-          - audit_rules_time_adjtimex
-          - audit_rules_time_clock_settime
-          - audit_rules_time_settimeofday
-          - audit_rules_time_watch_localtime
-          - audit_rules_unsuccessful_file_modification_creat
-          - audit_rules_unsuccessful_file_modification_ftruncate
-          - audit_rules_unsuccessful_file_modification_open
-          - audit_rules_unsuccessful_file_modification_openat
-          - audit_rules_unsuccessful_file_modification_truncate
-          - audit_rules_usergroup_modification_group
-          - audit_rules_usergroup_modification_gshadow
-          - audit_rules_usergroup_modification_nsswitch_conf
-          - audit_rules_usergroup_modification_opasswd
-          - audit_rules_usergroup_modification_pam_conf
-          - audit_rules_usergroup_modification_pamd
-          - audit_rules_usergroup_modification_passwd
-          - audit_rules_usergroup_modification_shadow
-          - chronyd_specify_remote_server
-          - directory_permissions_var_log_audit
-          - file_groupownership_audit_binaries
-          - file_ownership_var_log_audit_stig
-          - file_permissions_audit_binaries
-          - journald_storage
-          - package_chrony_installed
-          - sshd_set_loglevel_verbose
-          - sshd_set_max_auth_tries
-          - sudo_custom_logfile
-          - sysctl_net_ipv4_conf_all_log_martians
-          - sysctl_net_ipv4_conf_default_log_martians
+          - audit_rules_privileged_commands_chfn
+          - auditd_log_format
+          - auditd_name_format
+          - service_auditd_enabled
       status: automated
     - id: au-3.1
       title: Additional Audit Information
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_privileged_commands_insmod
+          - audit_rules_privileged_commands_kmod
+          - audit_rules_privileged_commands_modprobe
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+      status: automated
     - id: au-3.2
       title: Centralized Management of Planned Audit Record Content
       rules: []
@@ -135,40 +91,89 @@ controls:
       levels:
           - low
       rules:
-          - journald_compress
+          - partition_for_var_log
+          - partition_for_var_log_audit
       status: automated
     - id: au-4.1
       title: Transfer to Alternate Storage
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_syslog_plugin_activated
+          - auditd_overflow_action
+          - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
+          - rsyslog_encrypt_offload_actionsendstreamdrivermode
+          - rsyslog_encrypt_offload_defaultnetstreamdriver
+          - rsyslog_remote_loghost
+          - service_rsyslog_enabled
+          - service_syslogng_enabled
+      status: automated
     - id: au-5
       title: Response to Audit Logging Process Failures
       levels:
           - low
       rules:
-          - auditd_data_disk_error_action
-          - auditd_data_disk_full_action
+          - audit_rules_system_shutdown
+          - postfix_client_configure_mail_alias_postmaster
       status: automated
     - id: au-5.1
       title: Storage Capacity Warning
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.2
       title: Real-time Alerts
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_action_mail_acct
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.3
       title: Configurable Traffic Volume Thresholds
       rules: []
       status: pending
     - id: au-5.4
       title: Shutdown on Failure
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.5
       title: Alternate Audit Logging Capability
       rules: []
@@ -193,12 +198,16 @@ controls:
       title: Correlate Audit Record Repositories
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_accept_remote_messages_tcp
+          - rsyslog_accept_remote_messages_udp
+      status: automated
     - id: au-6.4
       title: Central Review and Analysis
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_accept_remote_messages_tcp
+          - rsyslog_accept_remote_messages_udp
+      status: automated
     - id: au-6.5
       title: Integrated Analysis of Audit Records
       levels:
@@ -231,40 +240,65 @@ controls:
       title: Audit Record Reduction and Report Generation
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: au-7.1
       title: Automatic Processing
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-7.2
       title: Automatic Sort and Search
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-8
       title: Time Stamps
       levels:
           - low
       rules:
-          - auditd_data_retention_max_log_file
-          - auditd_data_retention_max_log_file_action
+          - audit_rules_suid_privilege_function
       status: automated
     - id: au-8.1
       title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
+      rules:
+          - chronyd_client_only
+          - chronyd_configure_pool_and_server
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - chronyd_specify_remote_server
+          - ntpd_specify_multiple_servers
+          - ntpd_specify_remote_server
+          - service_chronyd_or_ntpd_enabled
+          - service_ntp_enabled
+          - service_ntpd_enabled
+          - service_timesyncd_enabled
+      status: automated
     - id: au-8.2
       title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      rules:
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - ntpd_specify_multiple_servers
+      status: automated
     - id: au-9
       title: Protection of Audit Information
       levels:
           - low
       rules:
-          - audit_rules_immutable
+          - directory_permissions_var_log_audit
+          - file_audit_tools_group_ownership
+          - file_audit_tools_ownership
+          - file_audit_tools_permissions
+          - permissions_local_var_log_audit
+          - selinux_policytype
+          - selinux_state
       status: automated
     - id: au-9.1
       title: Hardware Write-once Media
@@ -274,20 +308,34 @@ controls:
       title: Store on Separate Physical Systems or Components
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_remote_loghost
+      status: automated
     - id: au-9.3
       title: Cryptographic Protection
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - aide_check_audit_tools
+          - auditd_audispd_encrypt_sent_records
+          - encrypt_partitions
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+          - rsyslog_remote_tls
+      status: automated
     - id: au-9.4
       title: Access by Subset of Privileged Users
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - directory_group_ownership_var_log_audit
+          - directory_ownership_var_log_audit
+          - file_group_ownership_var_log_audit
+          - file_ownership_var_log_audit
+          - file_ownership_var_log_audit_stig
+          - file_permissions_var_log_audit
+      status: automated
     - id: au-9.5
       title: Dual Authorization
       rules: []
@@ -304,8 +352,11 @@ controls:
       title: Non-repudiation
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - service_auditd_enabled
+      status: automated
     - id: au-10.1
       title: Association of Identities
       rules: []
@@ -330,8 +381,11 @@ controls:
       title: Audit Record Retention
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - auditd_data_retention_flush
+          - auditd_data_retention_max_log_file
+          - auditd_data_retention_num_logs
+      status: automated
     - id: au-11.1
       title: Long-term Retrieval Capability
       rules: []
@@ -391,18 +445,26 @@ controls:
       title: System-wide and Time-correlated Audit Trail
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - chronyd_client_only
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - service_chronyd_or_ntpd_enabled
+      status: automated
     - id: au-12.2
       title: Standardized Formats
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-12.3
       title: Changes by Authorized Individuals
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: au-12.4
       title: Query Parameter Audits of Personally Identifiable Information
       rules: []
@@ -425,12 +487,17 @@ controls:
       status: pending
     - id: au-14
       title: Session Audit
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-14.1
       title: System Start-up
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - service_auditd_enabled
+      status: automated
     - id: au-14.2
       title: Capture and Record Content
       rules: []

--- a/products/rhel8/controls/nist_800_53/au.yml
+++ b/products/rhel8/controls/nist_800_53/au.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 AU Family: Audit and Accountability
 controls:
     - id: au-1
       title: Policy and Procedures
@@ -62,6 +63,7 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_login_events_faillog
           - audit_rules_privileged_commands_chfn
           - auditd_log_format
           - auditd_name_format
@@ -72,6 +74,11 @@ controls:
       levels:
           - moderate
       rules:
+          - audit_rules_etc_cron_d
+          - audit_rules_networkconfig_modification_etc_hosts
+          - audit_rules_networkconfig_modification_etc_issue
+          - audit_rules_networkconfig_modification_etc_issue_net
+          - audit_rules_networkconfig_modification_etc_networkmanager_system_connections
           - audit_rules_privileged_commands_insmod
           - audit_rules_privileged_commands_kmod
           - audit_rules_privileged_commands_modprobe
@@ -111,6 +118,8 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_continue_loading
+          - audit_rules_enable_syscall_auditing
           - audit_rules_system_shutdown
           - postfix_client_configure_mail_alias_postmaster
       status: automated
@@ -292,6 +301,9 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_immutable_login_uids
+          - audit_rules_mac_modification_etc_apparmor
+          - audit_rules_mac_modification_etc_apparmor_d
           - directory_permissions_var_log_audit
           - file_audit_tools_group_ownership
           - file_audit_tools_ownership
@@ -408,9 +420,16 @@ controls:
           - audit_rules_dac_modification_lsetxattr
           - audit_rules_dac_modification_removexattr
           - audit_rules_dac_modification_setxattr
+          - audit_rules_dac_modification_umount
+          - audit_rules_dac_modification_umount2
+          - audit_rules_execution_chacl
           - audit_rules_execution_chcon
+          - audit_rules_execution_chmod
+          - audit_rules_execution_rm
+          - audit_rules_execution_setfacl
           - audit_rules_file_deletion_events_rename
           - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_renameat2
           - audit_rules_file_deletion_events_unlink
           - audit_rules_file_deletion_events_unlinkat
           - audit_rules_kernel_module_loading_create

--- a/products/rhel8/controls/nist_800_53/cm.yml
+++ b/products/rhel8/controls/nist_800_53/cm.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 CM Family: Configuration Management
 controls:
     - id: cm-1
       title: Policy and Procedures
@@ -133,14 +132,19 @@ controls:
       status: pending
     - id: cm-3.5
       title: Automated Security Response
-      rules: []
-      status: pending
+      rules:
+          - aide_scan_notification
+          - package_mailx_installed
+          - package_s-nail_installed
+      status: automated
     - id: cm-3.6
       title: Cryptography Management
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - enable_fips_mode
+          - service_sshd_disabled
+      status: automated
     - id: cm-3.7
       title: Review System Changes
       rules: []
@@ -177,16 +181,27 @@ controls:
       title: Automated Access Enforcement and Audit Records
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: cm-5.2
       title: Review System Changes
       rules: []
       status: pending
     - id: cm-5.3
       title: Signed Components
-      rules: []
-      status: pending
+      rules:
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+      status: automated
     - id: cm-5.4
       title: Dual Authorization
       rules: []
@@ -197,8 +212,20 @@ controls:
       status: pending
     - id: cm-5.6
       title: Limit Library Privileges
-      rules: []
-      status: pending
+      rules:
+          - dir_group_ownership_library_dirs
+          - dir_ownership_library_dirs
+          - dir_permissions_library_dirs
+          - dir_system_commands_group_root_owned
+          - dir_system_commands_root_owned
+          - file_groupownership_system_commands_dirs
+          - file_ownership_binary_dirs
+          - file_ownership_library_dirs
+          - file_permissions_binary_dirs
+          - file_permissions_library_dirs
+          - file_permissions_system_commands_dirs
+          - root_permissions_syslibrary_files
+      status: automated
     - id: cm-5.7
       title: Automatic Implementation of Security Safeguards
       rules: []
@@ -208,84 +235,36 @@ controls:
       levels:
           - low
       rules:
-          - accounts_password_pam_pwquality_password_auth
-          - accounts_password_pam_pwquality_system_auth
-          - accounts_umask_etc_bashrc
-          - accounts_umask_etc_login_defs
-          - accounts_umask_etc_profile
-          - accounts_user_interactive_home_directory_exists
-          - audit_rules_media_export
-          - banner_etc_issue_cis
-          - banner_etc_issue_net_cis
-          - banner_etc_motd_cis
-          - coredump_disable_backtraces
-          - coredump_disable_storage
-          - dconf_gnome_disable_user_list
-          - disable_host_auth
-          - disable_users_coredumps
-          - file_groupowner_efi_grub2_cfg
-          - file_groupowner_efi_user_cfg
-          - file_groupowner_grub2_cfg
-          - file_groupowner_user_cfg
-          - file_groupownership_sshd_private_key
-          - file_groupownership_sshd_pub_key
-          - file_owner_efi_grub2_cfg
-          - file_owner_efi_user_cfg
-          - file_owner_grub2_cfg
-          - file_owner_user_cfg
-          - file_ownership_home_directories
-          - file_ownership_sshd_private_key
-          - file_ownership_sshd_pub_key
-          - file_permissions_efi_grub2_cfg
-          - file_permissions_efi_user_cfg
-          - file_permissions_grub2_cfg
-          - file_permissions_home_directories
-          - file_permissions_sshd_private_key
-          - file_permissions_sshd_pub_key
-          - file_permissions_user_cfg
-          - no_empty_passwords
-          - no_empty_passwords_etc_shadow
-          - no_files_or_dirs_ungroupowned
-          - no_files_or_dirs_unowned_by_user
-          - package_pam_pwquality_installed
-          - package_rsync_removed
-          - package_rsyslog_installed
-          - package_samba_removed
-          - package_squid_removed
-          - partition_for_tmp
-          - partition_for_var_log
-          - service_nfs_disabled
-          - service_rpcbind_disabled
-          - sshd_disable_gssapi_auth
-          - sshd_set_login_grace_time
-          - sysctl_kernel_kptr_restrict
-          - sysctl_kernel_randomize_va_space
-          - sysctl_kernel_yama_ptrace_scope
-          - sysctl_net_ipv4_conf_all_accept_redirects
-          - sysctl_net_ipv4_conf_all_accept_source_route
-          - sysctl_net_ipv4_conf_all_forwarding
-          - sysctl_net_ipv4_conf_all_log_martians
-          - sysctl_net_ipv4_conf_all_rp_filter
-          - sysctl_net_ipv4_conf_all_secure_redirects
-          - sysctl_net_ipv4_conf_all_send_redirects
-          - sysctl_net_ipv4_conf_default_accept_redirects
-          - sysctl_net_ipv4_conf_default_accept_source_route
-          - sysctl_net_ipv4_conf_default_forwarding
-          - sysctl_net_ipv4_conf_default_log_martians
-          - sysctl_net_ipv4_conf_default_rp_filter
-          - sysctl_net_ipv4_conf_default_secure_redirects
-          - sysctl_net_ipv4_conf_default_send_redirects
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-          - sysctl_net_ipv4_ip_forward
-          - sysctl_net_ipv6_conf_all_accept_ra
-          - sysctl_net_ipv6_conf_all_accept_redirects
-          - sysctl_net_ipv6_conf_all_accept_source_route
-          - sysctl_net_ipv6_conf_all_forwarding
-          - sysctl_net_ipv6_conf_default_accept_ra
-          - sysctl_net_ipv6_conf_default_accept_redirects
-          - sysctl_net_ipv6_conf_default_accept_source_route
-          - sysctl_net_ipv6_conf_default_forwarding
+          - account_disable_post_pw_expiration
+          - account_emergency_expire_date
+          - account_temp_expire_date
+          - accounts_logon_fail_delay
+          - accounts_max_concurrent_login_sessions
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_all_shadowed
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_retry
+          - accounts_password_pam_ucredit
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -372,14 +351,18 @@ controls:
       title: Periodic Review
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - chronyd_no_chronyc_network
+      status: automated
     - id: cm-7.2
       title: Prevent Program Execution
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - network_sniffer_disabled
+          - package_pam_apparmor_installed
+      status: automated
     - id: cm-7.3
       title: Registration Compliance
       rules: []
@@ -392,8 +375,10 @@ controls:
       title: Authorized Software — Allow-by-exception
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - package_pam_apparmor_installed
+      status: automated
     - id: cm-7.6
       title: Confined Environments with Limited Privileges
       rules: []
@@ -432,8 +417,13 @@ controls:
       title: Automated Unauthorized Component Detection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - usbguard_generate_policy
+      status: automated
     - id: cm-8.4
       title: Accountability Information
       levels:
@@ -485,7 +475,12 @@ controls:
       levels:
           - low
       rules:
-          - package_xorg-x11-server-Xwayland_removed
+          - clean_components_post_updating
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
       status: automated
     - id: cm-11.1
       title: Alerts for Unauthorized Installations

--- a/products/rhel8/controls/nist_800_53/cm.yml
+++ b/products/rhel8/controls/nist_800_53/cm.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 CM Family: Configuration Management
 controls:
     - id: cm-1
       title: Policy and Procedures
@@ -265,6 +266,11 @@ controls:
           - accounts_passwords_pam_faillock_interval
           - accounts_passwords_pam_faillock_unlock_time
           - accounts_passwords_pam_tally2_deny_root
+          - file_groupowner_boot_grub2
+          - file_owner_boot_grub2
+          - file_permissions_boot_grub2
+          - grub2_password
+          - grub2_uefi_password
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -323,9 +329,11 @@ controls:
           - package_httpd_removed
           - package_net-snmp_removed
           - package_nginx_removed
+          - package_nis_removed
           - package_openldap-clients_removed
           - package_telnet-server_removed
           - package_telnet_removed
+          - package_telnetd_removed
           - package_tftp-server_removed
           - package_tftp_removed
           - package_vsftpd_removed
@@ -340,10 +348,14 @@ controls:
           - partition_for_var_log_audit
           - partition_for_var_tmp
           - postfix_network_listening_disabled
+          - service_apport_disabled
           - service_bluetooth_disabled
           - service_cockpit_disabled
           - service_cups_disabled
+          - service_dhcpd_disabled
           - service_dnsmasq_disabled
+          - service_oddjobd_disabled
+          - service_quota_nld_disabled
           - sshd_disable_forwarding
           - wireless_disable_interfaces
       status: automated

--- a/products/rhel8/controls/nist_800_53/cp.yml
+++ b/products/rhel8/controls/nist_800_53/cp.yml
@@ -204,8 +204,11 @@ controls:
       title: System Backup
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_user_data_backups
+          - file_groupowner_backup_etc_shadow
+          - httpd_remove_backups
+      status: automated
     - id: cp-9.1
       title: Testing for Reliability and Integrity
       levels:

--- a/products/rhel8/controls/nist_800_53/ia.yml
+++ b/products/rhel8/controls/nist_800_53/ia.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 IA Family: Identification and Authentication
 controls:
     - id: ia-1
       title: Policy and Procedures
@@ -11,60 +10,113 @@ controls:
       levels:
           - low
       rules:
-          - account_unique_id
+          - accounts_no_uid_except_zero
+          - gid_passwd_group_same
+          - gnome_gdm_disable_guest_login
+          - no_direct_root_logins
+          - require_emergency_target_auth
+          - require_singleuser_auth
       status: automated
     - id: ia-2.1
       title: Multi-factor Authentication to Privileged Accounts
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+          - sssd_enable_pam_services
+      status: automated
     - id: ia-2.2
       title: Multi-factor Authentication to Non-privileged Accounts
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.3
       title: Local Access to Privileged Accounts
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.4
       title: Local Access to Non-privileged Accounts
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - service_sshd_disabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.5
       title: Individual Authentication with Group Authentication
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - sshd_disable_root_login
+      status: automated
     - id: ia-2.6
       title: Access to Accounts —separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.7
       title: Network Access to Non-privileged Accounts — Separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.8
       title: Access to Accounts — Replay Resistant
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_enable_smartcard_auth
+          - mount_option_krb_sec_remote_filesystems
+          - use_kerberos_security_all_exports
+      status: automated
     - id: ia-2.9
       title: Network Access to Non-privileged Accounts — Replay Resistant
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_enable_smartcard_auth
+          - mount_option_krb_sec_remote_filesystems
+          - use_kerberos_security_all_exports
+      status: automated
     - id: ia-2.10
       title: Single Sign-on
       rules: []
       status: pending
     - id: ia-2.11
       title: Remote Access — Separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+          - sssd_certificate_verification
+      status: automated
     - id: ia-2.12
       title: Acceptance of PIV Credentials
       levels:
@@ -80,9 +132,11 @@ controls:
       levels:
           - moderate
       rules:
-          - dconf_gnome_disable_automount
-          - dconf_gnome_disable_automount_open
-          - kernel_module_usb-storage_disabled
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - usbguard_generate_policy
       status: automated
     - id: ia-3.1
       title: Cryptographic Bidirectional Authentication
@@ -104,8 +158,13 @@ controls:
       title: Identifier Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - account_disable_inactivity_password_auth
+          - account_disable_inactivity_system_auth
+          - account_disable_post_pw_expiration
+          - accounts_no_uid_except_zero
+          - accounts_set_post_pw_existing
+      status: automated
     - id: ia-4.1
       title: Prohibit Account Identifiers as Public Identifiers
       rules: []
@@ -150,43 +209,85 @@ controls:
           - low
       rules:
           - accounts_password_all_shadowed
-          - accounts_password_pam_dictcheck
-          - accounts_password_pam_difok
-          - accounts_password_pam_enforce_root
-          - accounts_password_pam_maxrepeat
-          - accounts_password_pam_maxsequence
-          - accounts_password_pam_minlen
-          - accounts_password_pam_pwhistory_enforce_for_root
-          - accounts_password_pam_pwhistory_use_authtok
-          - accounts_password_pam_unix_authtok
-          - no_empty_passwords_etc_shadow
-          - set_password_hashing_algorithm_logindefs
-          - set_password_hashing_algorithm_passwordauth
-          - set_password_hashing_algorithm_systemauth
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - cracklib_accounts_password_pam_ocredit
+          - snmpd_not_default_password
       status: automated
     - id: ia-5.1
       title: Password-based Authentication
       levels:
           - low
       rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_all_shadowed_sha512
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
-          - accounts_password_pam_unix_enabled
+          - accounts_password_pam_ucredit
+          - accounts_password_pam_unix_remember
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - auditd_data_retention_action_mail_acct
+          - no_empty_passwords
+          - no_netrc_files
+          - package_rsh-server_removed
+          - package_vsftpd_removed
+          - package_ypserv_removed
+          - passwd_system-auth_substack
+          - service_rexec_disabled
+          - service_rlogin_disabled
+          - service_rsh_disabled
+          - service_telnet_disabled
+          - service_ypbind_disabled
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_yescrypt_cost_factor_logindefs
+          - sshd_allow_only_protocol2
+          - sshd_use_approved_ciphers
       status: automated
     - id: ia-5.2
       title: Public Key-based Authentication
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - ssh_private_keys_have_passcode
+      status: automated
     - id: ia-5.3
       title: In-person or Trusted External Party Registration
       rules: []
       status: pending
     - id: ia-5.4
       title: Automated Support for Password Strength Determination
-      rules: []
-      status: pending
+      rules:
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_retry
+          - accounts_password_pam_ucredit
+      status: automated
     - id: ia-5.5
       title: Change Authenticators Prior to Delivery
       rules: []
@@ -199,8 +300,9 @@ controls:
       status: pending
     - id: ia-5.7
       title: No Embedded Unencrypted Static Authenticators
-      rules: []
-      status: pending
+      rules:
+          - no_netrc_files
+      status: automated
     - id: ia-5.8
       title: Multiple System Accounts
       rules: []
@@ -211,8 +313,9 @@ controls:
       status: pending
     - id: ia-5.10
       title: Dynamic Credential Binding
-      rules: []
-      status: pending
+      rules:
+          - service_sssd_enabled
+      status: automated
     - id: ia-5.11
       title: Hardware Token-based Authentication
       rules: []
@@ -223,8 +326,11 @@ controls:
       status: pending
     - id: ia-5.13
       title: Expiration of Cached Authenticators
-      rules: []
-      status: pending
+      rules:
+          - sssd_memcache_timeout
+          - sssd_offline_cred_expiration
+          - sssd_ssh_known_hosts_timeout
+      status: automated
     - id: ia-5.14
       title: Managing Content of PKI Trust Stores
       rules: []
@@ -255,8 +361,17 @@ controls:
       title: Cryptographic Module Authentication
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - installed_OS_is_FIPS_certified
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sysctl_crypto_fips_enabled
+      status: automated
     - id: ia-8
       title: Identification and Authentication (Non-organizational Users)
       levels:
@@ -314,6 +429,10 @@ controls:
       levels:
           - low
       rules:
+          - disallow_bypass_password_sudo
+          - sudo_remove_no_authenticate
+          - sudo_remove_nopasswd
+          - sudo_require_authentication
           - sudo_require_reauthentication
       status: automated
     - id: ia-12

--- a/products/rhel8/controls/nist_800_53/ir.yml
+++ b/products/rhel8/controls/nist_800_53/ir.yml
@@ -52,8 +52,11 @@ controls:
       title: Incident Handling
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_configure_remote_server
+          - auditd_offload_logs
+          - service_postfix_enabled
+      status: automated
     - id: ir-4.1
       title: Automated Incident Handling Processes
       levels:
@@ -124,8 +127,14 @@ controls:
       title: Incident Monitoring
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_file_deletion_events
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_rmdir
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+      status: automated
     - id: ir-5.1
       title: Automated Tracking, Data Collection, and Analysis
       levels:

--- a/products/rhel8/controls/nist_800_53/ra.yml
+++ b/products/rhel8/controls/nist_800_53/ra.yml
@@ -48,8 +48,17 @@ controls:
       title: Vulnerability Monitoring and Scanning
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_cramfs_disabled
+          - kernel_module_dccp_disabled
+          - kernel_module_freevxfs_disabled
+          - kernel_module_hfs_disabled
+          - kernel_module_hfsplus_disabled
+          - kernel_module_jffs2_disabled
+          - kernel_module_rds_disabled
+          - kernel_module_sctp_disabled
+          - kernel_module_tipc_disabled
+      status: automated
     - id: ra-5.1
       title: Update Tool Capability
       rules: []

--- a/products/rhel8/controls/nist_800_53/sc.yml
+++ b/products/rhel8/controls/nist_800_53/sc.yml
@@ -71,7 +71,12 @@ controls:
       levels:
           - low
       rules:
+          - accounts_passwords_pam_faillock_root_unlock_time
           - firewalld-backend
+          - kernel_config_binfmt_misc
+          - kernel_config_modify_ldt_syscall
+          - sshd_set_max_sessions
+          - sshd_set_maxstartups
           - sysctl_net_ipv4_conf_all_accept_source_route
           - sysctl_net_ipv4_conf_all_send_redirects
           - sysctl_net_ipv4_conf_default_accept_source_route
@@ -307,6 +312,10 @@ controls:
       levels:
           - moderate
       rules:
+          - dovecot_configure_ssl_cert
+          - dovecot_configure_ssl_key
+          - dovecot_enable_ssl
+          - httpd_configure_tls
           - libreswan_approved_tunnels
       status: automated
     - id: sc-8.1
@@ -463,6 +472,8 @@ controls:
           - harden_openssl_crypto_policy
           - harden_ssh_client_crypto_policy
           - harden_sshd_crypto_policy
+          - httpd_digest_authentication
+          - httpd_require_client_certs
           - installed_OS_is_FIPS_certified
           - is_fips_mode_enabled
           - package_dracut-fips-aesni_installed
@@ -573,6 +584,9 @@ controls:
       levels:
           - low
       rules:
+          - avahi_check_ttl
+          - avahi_ip_only
+          - avahi_restrict_published_information
           - network_configure_name_resolution
       status: automated
     - id: sc-20.1

--- a/products/rhel8/controls/nist_800_53/sc.yml
+++ b/products/rhel8/controls/nist_800_53/sc.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 SC Family: System and Communications Protection
 controls:
     - id: sc-1
       title: Policy and Procedures
@@ -15,8 +14,10 @@ controls:
       status: automated
     - id: sc-2.1
       title: Interfaces for Non-privileged Users
-      rules: []
-      status: pending
+      rules:
+          - coreos_disable_interactive_boot
+          - grub2_disable_interactive_boot
+      status: automated
     - id: sc-2.2
       title: Disassociability
       rules: []
@@ -26,8 +27,7 @@ controls:
       levels:
           - high
       rules:
-          - selinux_not_disabled
-          - selinux_state
+          - grub2_init_on_free
       status: automated
     - id: sc-3.1
       title: Hardware Separation
@@ -70,20 +70,42 @@ controls:
       levels:
           - low
       rules:
-          - sysctl_net_ipv4_tcp_syncookies
+          - firewalld-backend
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv4_tcp_invalid_ratelimit
       status: automated
     - id: sc-5.1
       title: Restrict Ability to Attack Other Systems
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-5.2
       title: Capacity, Bandwidth, and Redundancy
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - partition_for_home
+          - partition_for_tmp
+          - partition_for_var
+          - partition_for_var_log
+          - partition_for_var_log_audit
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-5.3
       title: Detection and Monitoring
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-6
       title: Resource Availability
       rules: []
@@ -92,8 +114,19 @@ controls:
       title: Boundary Protection
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_ip_forward
+      status: automated
     - id: sc-7.1
       title: Physically Separated Subnetworks
       rules: []
@@ -142,8 +175,15 @@ controls:
       status: pending
     - id: sc-7.10
       title: Prevent Exfiltration
-      rules: []
-      status: pending
+      rules:
+          - disable_users_coredumps
+          - service_systemd-coredump_disabled
+          - sysctl_kernel_core_pattern
+          - sysctl_kernel_unprivileged_bpf_disabled
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - sysctl_kernel_yama_ptrace_scope
+          - sysctl_net_core_bpf_jit_harden
+      status: automated
     - id: sc-7.11
       title: Restrict Incoming Communications Traffic
       rules: []
@@ -190,16 +230,28 @@ controls:
       title: Isolation of System Components
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - configure_firewalld_ports
+          - package_pam_apparmor_installed
+          - selinux_policytype
+          - selinux_state
+          - service_firewalld_enabled
+          - service_ip6tables_enabled
+          - service_iptables_enabled
+          - set_ip6tables_default_rule
+      status: automated
     - id: sc-7.22
       title: Separate Subnets for Connecting to Different Security Domains
       rules: []
       status: pending
     - id: sc-7.23
       title: Disable Sender Feedback on Protocol Validation Failure
-      rules: []
-      status: pending
+      rules:
+          - set_firewalld_default_zone
+          - set_iptables_default_rule
+          - set_iptables_default_rule_forward
+      status: automated
     - id: sc-7.24
       title: Personally Identifiable Information
       rules: []
@@ -229,26 +281,31 @@ controls:
       levels:
           - moderate
       rules:
-          - configure_custom_crypto_policy_cis
+          - libreswan_approved_tunnels
       status: automated
     - id: sc-8.1
       title: Cryptographic Protection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - harden_openssl_crypto_policy
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.2
       title: Pre- and Post-transmission Handling
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.3
       title: Cryptographic Protection for Message Externals
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.4
       title: Conceal or Randomize Communications
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.5
       title: Protected Distribution System
       rules: []
@@ -261,8 +318,13 @@ controls:
       title: Network Disconnect
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+      status: automated
     - id: sc-11
       title: Trusted Path
       rules: []
@@ -275,8 +337,9 @@ controls:
       title: Cryptographic Key Establishment and Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - ldap_client_start_tls
+      status: automated
     - id: sc-12.1
       title: Availability
       levels:
@@ -285,12 +348,62 @@ controls:
       status: pending
     - id: sc-12.2
       title: Symmetric Keys
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-12.3
       title: Asymmetric Keys
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sssd_ldap_configure_tls_ca
+          - sssd_ldap_configure_tls_ca_dir
+          - sssd_ldap_configure_tls_reqcert
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-12.4
       title: PKI Certificates
       rules: []
@@ -307,8 +420,34 @@ controls:
       title: Cryptographic Protection
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_ssh_crypto_policy
+          - disable_prelink
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - encrypt_partitions
+          - etc_system_fips_exists
+          - fips_crypto_policy_symlinks
+          - grub2_enable_fips_mode
+          - harden_openssl_crypto_policy
+          - harden_ssh_client_crypto_policy
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_allow_only_protocol2
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-13.1
       title: FIPS-validated Cryptography
       rules: []
@@ -407,8 +546,9 @@ controls:
       title: Secure Name/Address Resolution Service (Authoritative Source)
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - network_configure_name_resolution
+      status: automated
     - id: sc-20.1
       title: Child Subspaces
       rules: []
@@ -464,6 +604,7 @@ controls:
       levels:
           - high
       rules:
+          - audit_rules_system_shutdown
           - service_systemd-journald_enabled
       status: automated
     - id: sc-25
@@ -486,14 +627,18 @@ controls:
       title: Protection of Information at Rest
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - install_mcafee_antivirus
+          - mcafee_antivirus_definitions_updated
+          - service_nails_enabled
+      status: automated
     - id: sc-28.1
       title: Cryptographic Protection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - encrypt_partitions
+      status: automated
     - id: sc-28.2
       title: Offline Storage
       rules: []
@@ -520,8 +665,10 @@ controls:
       status: pending
     - id: sc-30.2
       title: Randomness
-      rules: []
-      status: pending
+      rules:
+          - sysctl_kernel_kptr_restrict
+          - sysctl_kernel_randomize_va_space
+      status: automated
     - id: sc-30.3
       title: Change Processing and Storage Locations
       rules: []
@@ -532,8 +679,9 @@ controls:
       status: pending
     - id: sc-30.5
       title: Concealment of System Components
-      rules: []
-      status: pending
+      rules:
+          - sysctl_kernel_kptr_restrict
+      status: automated
     - id: sc-31
       title: Covert Channel Analysis
       rules: []
@@ -610,8 +758,11 @@ controls:
       title: Process Isolation
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - bios_enable_execution_restrictions
+          - sysctl_kernel_exec_shield
+          - sysctl_user_max_user_namespaces
+      status: automated
     - id: sc-39.1
       title: Hardware Separation
       rules: []

--- a/products/rhel8/controls/nist_800_53/sc.yml
+++ b/products/rhel8/controls/nist_800_53/sc.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 SC Family: System and Communications Protection
 controls:
     - id: sc-1
       title: Policy and Procedures
@@ -115,6 +116,28 @@ controls:
       levels:
           - low
       rules:
+          - ensure_firewall_rules_for_open_ports
+          - firewall_single_service_active
+          - firewalld_loopback_traffic_restricted
+          - firewalld_loopback_traffic_trusted
+          - firewalld_sshd_disabled
+          - ftp_configure_firewall
+          - httpd_configure_firewall
+          - ip6tables_rules_for_open_ports
+          - iptables_rules_for_open_ports
+          - iptables_sshd_disabled
+          - nftables_ensure_default_deny_policy
+          - package_SuSEfirewall2_installed
+          - package_firewalld_removed
+          - service_SuSEfirewall2_enabled
+          - service_firewalld_disabled
+          - set_firewalld_appropriate_zone
+          - set_iptables_outbound_n_established
+          - set_nftables_new_connections
+          - set_nftables_table
+          - set_ufw_default_rule
+          - susefirewall2_ddos_protection
+          - susefirewall2_only_required_services
           - sysctl_net_ipv4_conf_all_accept_redirects
           - sysctl_net_ipv4_conf_all_accept_source_route
           - sysctl_net_ipv4_conf_all_rp_filter
@@ -126,6 +149,9 @@ controls:
           - sysctl_net_ipv4_conf_default_secure_redirects
           - sysctl_net_ipv4_conf_default_send_redirects
           - sysctl_net_ipv4_ip_forward
+          - ufw_only_required_services
+          - ufw_rate_limit
+          - ufw_rules_for_open_ports
       status: automated
     - id: sc-7.1
       title: Physically Separated Subnetworks

--- a/products/rhel8/controls/nist_800_53/si.yml
+++ b/products/rhel8/controls/nist_800_53/si.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 SI Family: System and Information Integrity
 controls:
     - id: si-1
       title: Policy and Procedures
@@ -11,8 +12,10 @@ controls:
           - low
       rules:
           - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
           - ensure_gpgcheck_never_disabled
           - ensure_redhat_gpgkey_installed
+          - package_abrt_removed
       status: automated
     - id: si-2.1
       title: Central Management
@@ -56,7 +59,13 @@ controls:
       levels:
           - low
       rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+          - dconf_gnome_disable_autorun
           - install_mcafee_antivirus
+          - sebool_antivirus_can_scan_system
+          - sebool_antivirus_use_jit
+          - secure_boot_enabled
           - service_nails_enabled
       status: automated
     - id: si-3.1
@@ -105,10 +114,16 @@ controls:
       levels:
           - low
       rules:
+          - journald_compress
+          - journald_forward_to_syslog
+          - journald_storage
           - kernel_module_dccp_disabled
           - kernel_module_rds_disabled
           - kernel_module_sctp_disabled
           - kernel_module_tipc_disabled
+          - package_systemd-journal-remote_installed
+          - rsyslog_cron_logging
+          - rsyslog_logging_configured
           - service_avahi-daemon_disabled
       status: automated
     - id: si-4.1
@@ -392,8 +407,13 @@ controls:
       title: Information Input Validation
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - kernel_config_fortify_source
+          - kernel_config_randomize_base
+          - kernel_config_stackprotector
+          - sebool_selinuxuser_execheap
+          - sebool_selinuxuser_execstack
+      status: automated
     - id: si-10.1
       title: Manual Override Capability
       rules: []

--- a/products/rhel8/controls/nist_800_53/si.yml
+++ b/products/rhel8/controls/nist_800_53/si.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 SI Family: System and Information Integrity
 controls:
     - id: si-1
       title: Policy and Procedures
@@ -23,8 +22,10 @@ controls:
       title: Automated Flaw Remediation Status
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - agent_mfetpd_running
+          - package_mcafeetp_installed
+      status: automated
     - id: si-2.3
       title: Time to Remediate Flaws and Benchmarks for Corrective Actions
       rules: []
@@ -35,12 +36,17 @@ controls:
       status: pending
     - id: si-2.5
       title: Automatic Software and Firmware Updates
-      rules: []
-      status: pending
+      rules:
+          - dnf-automatic_apply_updates
+          - dnf-automatic_security_updates_only
+          - security_patches_up_to_date
+          - timer_dnf-automatic_enabled
+      status: automated
     - id: si-2.6
       title: Removal of Previous Versions of Software and Firmware
-      rules: []
-      status: pending
+      rules:
+          - clean_components_post_updating
+      status: automated
     - id: si-2.7
       title: Root Cause Analysis
       rules: []
@@ -50,8 +56,8 @@ controls:
       levels:
           - low
       rules:
-          - kernel_module_usb-storage_disabled
-          - service_autofs_disabled
+          - install_mcafee_antivirus
+          - service_nails_enabled
       status: automated
     - id: si-3.1
       title: Central Management
@@ -59,8 +65,9 @@ controls:
       status: pending
     - id: si-3.2
       title: Automatic Updates
-      rules: []
-      status: pending
+      rules:
+          - mcafee_antivirus_definitions_updated
+      status: automated
     - id: si-3.3
       title: Non-privileged Users
       rules: []
@@ -206,12 +213,15 @@ controls:
       title: Unauthorized Network Services
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - package_fapolicyd_installed
+          - service_fapolicyd_enabled
+      status: automated
     - id: si-4.23
       title: Host-based Devices
-      rules: []
-      status: pending
+      rules:
+          - service_auditd_enabled
+      status: automated
     - id: si-4.24
       title: Indicators of Compromise
       rules: []
@@ -254,14 +264,31 @@ controls:
       title: Software, Firmware, and Information Integrity
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+      status: automated
     - id: si-7.1
       title: Integrity Checks
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - aide_periodic_checking_systemd_timer
+          - aide_periodic_cron_checking
+          - aide_use_fips_hashes
+          - aide_verify_acls
+          - aide_verify_ext_attributes
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+      status: automated
     - id: si-7.2
       title: Automated Notifications of Integrity Violations
       levels:
@@ -284,8 +311,11 @@ controls:
       status: pending
     - id: si-7.6
       title: Cryptographic Protection
-      rules: []
-      status: pending
+      rules:
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+      status: automated
     - id: si-7.7
       title: Integration of Detection and Response
       levels:
@@ -392,8 +422,14 @@ controls:
       title: Error Handling
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - file_groupownership_lastlog
+          - file_ownership_lastlog
+          - file_permissions_lastlog
+          - permissions_local_var_log
+          - sysctl_fs_suid_dumpable
+          - sysctl_kernel_dmesg_restrict
+      status: automated
     - id: si-12
       title: Information Management and Retention
       levels:
@@ -461,7 +497,8 @@ controls:
       levels:
           - moderate
       rules:
-          - sysctl_kernel_randomize_va_space
+          - coreos_pti_kernel_argument
+          - grub2_pti_argument
       status: automated
     - id: si-17
       title: Fail-safe Procedures

--- a/products/rhel8/profiles/cis_nist.profile
+++ b/products/rhel8/profiles/cis_nist.profile
@@ -1,0 +1,10 @@
+documentation_complete: true
+metadata:
+  version: 4.0.0
+  SMEs:
+    - nist_sync_automation
+reference: https://www.cisecurity.org/benchmark/red_hat_linux/
+title: CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Server (NIST-based)
+description: "This profile defines a baseline that aligns to the \"Level 2 - Server\"\nconfiguration from the Center for Internet Security® Red Hat Enterprise\nLinux 8 Benchmark™, v4.0.0.\n\nThis profile is generated from the NIST 800-53 control file and uses\nthe unified NIST 800-53 controls that include CIS-derived rules and\nvariables from all RHEL versions.\n\nThis profile includes Center for Internet Security®\nRed Hat Enterprise Linux 8 CIS Benchmarks™ content."
+selections:
+  - nist_800_53:all

--- a/products/rhel9/controls/nist_800_53/ac.yml
+++ b/products/rhel9/controls/nist_800_53/ac.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 AC Family: Access Control
 controls:
     - id: ac-1
       title: Policy and Procedures
@@ -10,40 +9,81 @@ controls:
       title: Account Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - service_auditd_enabled
+      status: automated
     - id: ac-2.1
       title: Automated System Account Management
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_password_pam_enforce_local
+          - accounts_passwords_pam_faillock_enforce_local
+      status: automated
     - id: ac-2.2
       title: Automated Temporary and Emergency Account Management
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - account_emergency_expire_date
+          - account_temp_expire_date
+      status: automated
     - id: ac-2.3
       title: Disable Accounts
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - account_disable_post_pw_expiration
+          - account_emergency_expire_date
+          - account_temp_expire_date
+          - accounts_set_post_pw_existing
+      status: automated
     - id: ac-2.4
       title: Automated Audit Actions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_etc_group_open
+          - audit_rules_etc_group_open_by_handle_at
+          - audit_rules_etc_group_openat
+          - audit_rules_etc_gshadow_open
+          - audit_rules_etc_gshadow_open_by_handle_at
+          - audit_rules_etc_gshadow_openat
+          - audit_rules_etc_passwd_open
+          - audit_rules_etc_passwd_open_by_handle_at
+          - audit_rules_etc_passwd_openat
+          - audit_rules_etc_shadow_open
+          - audit_rules_etc_shadow_open_by_handle_at
+          - audit_rules_etc_shadow_openat
+          - audit_rules_execution_semanage
+          - audit_rules_privileged_commands
+          - audit_rules_privileged_commands_chage
+          - audit_rules_privileged_commands_chsh
+          - audit_rules_privileged_commands_gpasswd
+          - audit_rules_privileged_commands_newgidmap
+          - audit_rules_privileged_commands_newgrp
+          - audit_rules_privileged_commands_newuidmap
+          - audit_rules_privileged_commands_passwd
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+          - audit_rules_privileged_commands_usernetctl
+          - audit_rules_usergroup_modification
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+      status: automated
     - id: ac-2.5
       title: Inactivity Logout
       levels:
           - moderate
       rules:
-          - no_invalid_shell_accounts_unlocked
-          - no_password_auth_for_systemaccounts
-          - no_shelllogin_for_systemaccounts
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
       status: automated
     - id: ac-2.6
       title: Dynamic Privilege Management
@@ -51,8 +91,9 @@ controls:
       status: pending
     - id: ac-2.7
       title: Privileged User Accounts
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_sysadmin_actions
+      status: automated
     - id: ac-2.8
       title: Dynamic Account Management
       rules: []
@@ -88,142 +129,44 @@ controls:
       levels:
           - low
       rules:
-          - accounts_umask_etc_bashrc
-          - accounts_umask_etc_login_defs
-          - accounts_umask_etc_profile
-          - audit_rules_immutable
-          - dir_perms_world_writable_sticky_bits
-          - ensure_pam_wheel_group_empty
-          - file_at_allow_exists
-          - file_at_deny_not_exist
-          - file_cron_allow_exists
-          - file_cron_deny_not_exist
-          - file_etc_security_opasswd
-          - file_groupowner_at_allow
-          - file_groupowner_backup_etc_group
-          - file_groupowner_backup_etc_gshadow
-          - file_groupowner_backup_etc_passwd
-          - file_groupowner_backup_etc_shadow
-          - file_groupowner_cron_allow
-          - file_groupowner_cron_d
-          - file_groupowner_cron_daily
-          - file_groupowner_cron_hourly
-          - file_groupowner_cron_monthly
-          - file_groupowner_cron_weekly
-          - file_groupowner_crontab
-          - file_groupowner_etc_group
-          - file_groupowner_etc_gshadow
-          - file_groupowner_etc_issue
-          - file_groupowner_etc_issue_net
-          - file_groupowner_etc_motd
-          - file_groupowner_etc_passwd
-          - file_groupowner_etc_shadow
+          - disable_host_auth
+          - enable_authselect
           - file_groupowner_etc_shells
-          - file_groupowner_grub2_cfg
-          - file_groupowner_sshd_config
-          - file_groupowner_user_cfg
-          - file_groupownership_sshd_private_key
-          - file_groupownership_sshd_pub_key
-          - file_owner_at_allow
-          - file_owner_backup_etc_group
-          - file_owner_backup_etc_gshadow
-          - file_owner_backup_etc_passwd
-          - file_owner_backup_etc_shadow
-          - file_owner_cron_allow
-          - file_owner_cron_d
-          - file_owner_cron_daily
-          - file_owner_cron_hourly
-          - file_owner_cron_monthly
-          - file_owner_cron_weekly
-          - file_owner_crontab
-          - file_owner_etc_group
-          - file_owner_etc_gshadow
-          - file_owner_etc_issue
-          - file_owner_etc_issue_net
-          - file_owner_etc_motd
-          - file_owner_etc_passwd
-          - file_owner_etc_shadow
           - file_owner_etc_shells
-          - file_owner_grub2_cfg
-          - file_owner_sshd_config
-          - file_owner_user_cfg
-          - file_ownership_sshd_private_key
-          - file_ownership_sshd_pub_key
-          - file_permissions_at_allow
-          - file_permissions_backup_etc_group
-          - file_permissions_backup_etc_gshadow
-          - file_permissions_backup_etc_passwd
-          - file_permissions_backup_etc_shadow
-          - file_permissions_cron_allow
-          - file_permissions_cron_d
-          - file_permissions_cron_daily
-          - file_permissions_cron_hourly
-          - file_permissions_cron_monthly
-          - file_permissions_cron_weekly
-          - file_permissions_crontab
-          - file_permissions_etc_group
-          - file_permissions_etc_gshadow
-          - file_permissions_etc_issue
-          - file_permissions_etc_issue_net
-          - file_permissions_etc_motd
-          - file_permissions_etc_passwd
-          - file_permissions_etc_shadow
           - file_permissions_etc_shells
-          - file_permissions_grub2_cfg
-          - file_permissions_sshd_config
-          - file_permissions_sshd_private_key
-          - file_permissions_sshd_pub_key
-          - file_permissions_unauthorized_world_writable
-          - file_permissions_ungroupowned
-          - file_permissions_user_cfg
-          - grub2_enable_selinux
-          - grub2_password
-          - mount_option_dev_shm_nodev
-          - mount_option_dev_shm_noexec
-          - mount_option_dev_shm_nosuid
-          - mount_option_home_nodev
-          - mount_option_home_nosuid
-          - mount_option_tmp_noexec
-          - mount_option_tmp_nosuid
-          - mount_option_var_log_audit_nodev
-          - mount_option_var_log_audit_noexec
-          - mount_option_var_log_audit_nosuid
-          - mount_option_var_log_nodev
-          - mount_option_var_log_noexec
-          - mount_option_var_log_nosuid
-          - mount_option_var_nodev
-          - mount_option_var_nosuid
-          - mount_option_var_tmp_nodev
-          - mount_option_var_tmp_noexec
-          - mount_option_var_tmp_nosuid
-          - no_files_unowned_by_user
-          - package_libselinux_installed
-          - package_mcstrans_removed
-          - package_setroubleshoot_removed
-          - rsyslog_files_groupownership
-          - rsyslog_files_ownership
-          - rsyslog_files_permissions
-          - selinux_not_disabled
-          - selinux_policytype
+          - ftp_restrict_to_anon
+          - require_emergency_target_auth
+          - require_singleuser_auth
           - sshd_limit_user_access
-          - use_pam_wheel_group_for_su
       status: automated
     - id: ac-3.1
       title: Restricted Access to Privileged Functions
-      rules: []
-      status: pending
+      rules:
+          - grub2_password_legacy
+          - grub2_uefi_password_legacy
+      status: automated
     - id: ac-3.2
       title: Dual Authorization
       rules: []
       status: pending
     - id: ac-3.3
       title: Mandatory Access Control
-      rules: []
-      status: pending
+      rules:
+          - coreos_enable_selinux_kernel_argument
+          - grub2_enable_selinux
+          - selinux_all_devicefiles_labeled
+          - selinux_confinement_of_daemons
+          - selinux_policytype
+          - selinux_state
+      status: automated
     - id: ac-3.4
       title: Discretionary Access Control
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - package_pam_apparmor_installed
+          - selinux_confine_to_least_privilege
+          - selinux_context_elevation_for_sudo
+      status: automated
     - id: ac-3.5
       title: Security-relevant Information
       rules: []
@@ -272,8 +215,15 @@ controls:
       title: Information Flow Enforcement
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_ports
+          - libreswan_approved_tunnels
+          - service_firewalld_enabled
+          - service_ip6tables_enabled
+          - service_iptables_enabled
+          - service_rdisc_disabled
+          - set_ip6tables_default_rule
+      status: automated
     - id: ac-4.1
       title: Object Security and Privacy Attributes
       rules: []
@@ -415,23 +365,152 @@ controls:
       levels:
           - moderate
       rules:
-          - sshd_disable_root_login
-          - sudo_add_use_pty
-          - sudo_remove_no_authenticate
-          - sudo_remove_nopasswd
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
+          - restrict_serial_port_logins
+          - securetty_root_login_console_only
+          - selinux_all_devicefiles_labeled
+          - selinux_confinement_of_daemons
+          - sshd_enable_strictmodes
+          - sshd_use_priv_separation
+          - sysctl_kernel_perf_event_paranoid
+          - sysctl_kernel_unprivileged_bpf_disabled
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - tftpd_uses_secure_mode
       status: automated
     - id: ac-6.1
       title: Authorize Access to Security Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_csh_cshrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - dconf_gnome_disable_ctrlaltdel_reboot
+          - dconf_gnome_disable_restart_shutdown
+          - dir_perms_var_log_httpd
+          - dir_perms_world_writable_sticky_bits
+          - dir_perms_world_writable_system_owned
+          - dir_perms_world_writable_system_owned_group
+          - directory_group_ownership_var_log_audit
+          - directory_groupowner_sshd_config_d
+          - directory_owner_sshd_config_d
+          - directory_ownership_var_log_audit
+          - directory_permissions_sshd_config_d
+          - directory_permissions_var_log_audit
+          - disable_ctrlaltdel_burstaction
+          - disable_ctrlaltdel_reboot
+          - file_group_ownership_var_log_audit
+          - file_groupowner_cron_allow
+          - file_groupowner_cron_d
+          - file_groupowner_cron_daily
+          - file_groupowner_cron_hourly
+          - file_groupowner_cron_monthly
+          - file_groupowner_cron_weekly
+          - file_groupowner_cron_yearly
+          - file_groupowner_crontab
+          - file_groupowner_efi_grub2_cfg
+          - file_groupowner_efi_user_cfg
+          - file_groupowner_etc_group
+          - file_groupowner_etc_gshadow
+          - file_groupowner_etc_passwd
+          - file_groupowner_etc_shadow
+          - file_groupowner_grub2_cfg
+          - file_groupowner_sshd_config
+          - file_groupowner_sshd_drop_in_config
+          - file_groupowner_user_cfg
+          - file_owner_cron_allow
+          - file_owner_cron_d
+          - file_owner_cron_daily
+          - file_owner_cron_hourly
+          - file_owner_cron_monthly
+          - file_owner_cron_weekly
+          - file_owner_cron_yearly
+          - file_owner_crontab
+          - file_owner_efi_grub2_cfg
+          - file_owner_efi_user_cfg
+          - file_owner_etc_group
+          - file_owner_etc_gshadow
+          - file_owner_etc_passwd
+          - file_owner_etc_shadow
+          - file_owner_grub2_cfg
+          - file_owner_sshd_config
+          - file_owner_sshd_drop_in_config
+          - file_owner_user_cfg
+          - file_ownership_binary_dirs
+          - file_ownership_library_dirs
+          - file_ownership_var_log_audit
+          - file_ownership_var_log_audit_stig
+          - file_permissions_binary_dirs
+          - file_permissions_cron_d
+          - file_permissions_cron_daily
+          - file_permissions_cron_hourly
+          - file_permissions_cron_monthly
+          - file_permissions_cron_weekly
+          - file_permissions_cron_yearly
+          - file_permissions_crontab
+          - file_permissions_efi_grub2_cfg
+          - file_permissions_efi_user_cfg
+          - file_permissions_etc_group
+          - file_permissions_etc_gshadow
+          - file_permissions_etc_passwd
+          - file_permissions_etc_shadow
+          - file_permissions_grub2_cfg
+          - file_permissions_home_dirs
+          - file_permissions_httpd_server_conf_d_files
+          - file_permissions_httpd_server_conf_files
+          - file_permissions_httpd_server_modules_files
+          - file_permissions_library_dirs
+          - file_permissions_sshd_config
+          - file_permissions_sshd_drop_in_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - file_permissions_unauthorized_sgid
+          - file_permissions_unauthorized_suid
+          - file_permissions_unauthorized_world_writable
+          - file_permissions_ungroupowned
+          - file_permissions_user_cfg
+          - file_permissions_var_log_audit
+          - gnome_gdm_disable_automatic_login
+          - mount_option_boot_nodev
+          - mount_option_boot_nosuid
+          - mount_option_dev_shm_nodev
+          - mount_option_dev_shm_noexec
+          - mount_option_dev_shm_nosuid
+          - mount_option_home_nosuid
+          - mount_option_nodev_nonroot_local_partitions
+          - mount_option_nodev_removable_partitions
+          - mount_option_noexec_removable_partitions
+          - mount_option_nosuid_remote_filesystems
+          - mount_option_nosuid_removable_partitions
+          - mount_option_tmp_nodev
+          - mount_option_tmp_noexec
+          - mount_option_tmp_nosuid
+          - mount_option_var_log_audit_nodev
+          - mount_option_var_log_audit_noexec
+          - mount_option_var_log_audit_nosuid
+          - mount_option_var_log_nodev
+          - mount_option_var_log_noexec
+          - mount_option_var_log_nosuid
+          - mount_option_var_nodev
+          - mount_option_var_tmp_bind
+          - no_files_unowned_by_user
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+          - sysctl_fs_protected_fifos
+          - sysctl_fs_protected_hardlinks
+          - sysctl_fs_protected_regular
+          - sysctl_fs_protected_symlinks
+          - umask_for_daemons
+      status: automated
     - id: ac-6.2
       title: Non-privileged Access for Nonsecurity Functions
       levels:
           - moderate
       rules:
-          - package_sudo_installed
+          - sshd_disable_root_login
       status: automated
     - id: ac-6.3
       title: Network Access to Privileged Commands
@@ -447,8 +526,9 @@ controls:
       title: Privileged Accounts
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_no_uid_except_zero
+      status: automated
     - id: ac-6.6
       title: Privileged Access by Non-organizational Users
       rules: []
@@ -461,27 +541,112 @@ controls:
       status: pending
     - id: ac-6.8
       title: Privilege Levels for Code Execution
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - mount_option_noexec_remote_filesystems
+          - package_pam_apparmor_installed
+      status: automated
     - id: ac-6.9
       title: Log Use of Privileged Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_etc_group_open
+          - audit_rules_etc_group_open_by_handle_at
+          - audit_rules_etc_group_openat
+          - audit_rules_etc_gshadow_open
+          - audit_rules_etc_gshadow_open_by_handle_at
+          - audit_rules_etc_gshadow_openat
+          - audit_rules_etc_passwd_open
+          - audit_rules_etc_passwd_open_by_handle_at
+          - audit_rules_etc_passwd_openat
+          - audit_rules_etc_shadow_open
+          - audit_rules_etc_shadow_open_by_handle_at
+          - audit_rules_etc_shadow_openat
+          - audit_rules_execution_chcon
+          - audit_rules_execution_restorecon
+          - audit_rules_execution_semanage
+          - audit_rules_execution_setfiles
+          - audit_rules_execution_setsebool
+          - audit_rules_execution_seunshare
+          - audit_rules_immutable
+          - audit_rules_kernel_module_loading
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_login_events
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - audit_rules_login_events_tallylog
+          - audit_rules_media_export
+          - audit_rules_networkconfig_modification
+          - audit_rules_privileged_commands
+          - audit_rules_privileged_commands_at
+          - audit_rules_privileged_commands_chage
+          - audit_rules_privileged_commands_chsh
+          - audit_rules_privileged_commands_crontab
+          - audit_rules_privileged_commands_gpasswd
+          - audit_rules_privileged_commands_mount
+          - audit_rules_privileged_commands_newgidmap
+          - audit_rules_privileged_commands_newgrp
+          - audit_rules_privileged_commands_newuidmap
+          - audit_rules_privileged_commands_pam_timestamp_check
+          - audit_rules_privileged_commands_passwd
+          - audit_rules_privileged_commands_postdrop
+          - audit_rules_privileged_commands_postqueue
+          - audit_rules_privileged_commands_pt_chown
+          - audit_rules_privileged_commands_ssh_keysign
+          - audit_rules_privileged_commands_su
+          - audit_rules_privileged_commands_sudo
+          - audit_rules_privileged_commands_sudoedit
+          - audit_rules_privileged_commands_umount
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+          - audit_rules_privileged_commands_userhelper
+          - audit_rules_privileged_commands_usernetctl
+          - audit_rules_suid_privilege_function
+          - audit_rules_sysadmin_actions
+          - audit_rules_time_adjtimex
+          - audit_rules_time_clock_settime
+          - audit_rules_time_settimeofday
+          - audit_rules_time_stime
+          - audit_rules_time_watch_localtime
+          - audit_rules_usergroup_modification
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+          - directory_access_var_log_audit
+          - service_auditd_enabled
+      status: automated
     - id: ac-6.10
       title: Prohibit Non-privileged Users from Executing Privileged Functions
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - mount_option_noexec_remote_filesystems
+          - package_pam_apparmor_installed
+          - selinux_confine_to_least_privilege
+          - selinux_context_elevation_for_sudo
+      status: automated
     - id: ac-7
       title: Unsuccessful Logon Attempts
       levels:
           - low
       rules:
-          - account_password_pam_faillock_password_auth
-          - account_password_pam_faillock_system_auth
+          - accounts_logon_fail_delay
+          - accounts_password_pam_retry
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_dir
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - package_audit-libs_installed
+          - package_audit_installed
       status: automated
     - id: ac-7.1
       title: Automatic Account Lock
@@ -504,8 +669,13 @@ controls:
       levels:
           - low
       rules:
+          - banner_etc_gdm_banner
+          - banner_etc_issue
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
+          - postfix_server_banner
+          - sshd_enable_warning_banner
+          - sshd_enable_warning_banner_net
       status: automated
     - id: ac-9
       title: Previous Logon Notification
@@ -513,8 +683,10 @@ controls:
       status: pending
     - id: ac-9.1
       title: Unsuccessful Logons
-      rules: []
-      status: pending
+      rules:
+          - display_login_attempts
+          - sshd_print_last_log
+      status: automated
     - id: ac-9.2
       title: Successful and Unsuccessful Logons
       rules: []
@@ -531,30 +703,37 @@ controls:
       title: Concurrent Session Control
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - accounts_max_concurrent_login_sessions
+      status: automated
     - id: ac-11
       title: Device Lock
       levels:
           - moderate
       rules:
+          - configure_tmux_lock_command
+          - dconf_gnome_screensaver_idle_activation_enabled
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
-          - dconf_gnome_screensaver_user_locks
-          - dconf_gnome_session_idle_user_locks
       status: automated
     - id: ac-11.1
       title: Pattern-hiding Displays
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_screensaver_mode_blank
+      status: automated
     - id: ac-12
       title: Session Termination
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+      status: automated
     - id: ac-12.1
       title: User-initiated Logouts
       rules: []
@@ -634,20 +813,77 @@ controls:
       levels:
           - low
       rules:
-          - configure_custom_crypto_policy_cis
+          - directory_groupowner_sshd_config_d
+          - directory_owner_sshd_config_d
+          - directory_permissions_sshd_config_d
+          - disable_host_auth
+          - enable_ldap_client
+          - file_groupowner_sshd_config
+          - file_groupowner_sshd_drop_in_config
+          - file_owner_sshd_config
+          - file_owner_sshd_drop_in_config
+          - file_permissions_sshd_config
+          - file_permissions_sshd_drop_in_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - firewalld_sshd_port_enabled
+          - ftp_restrict_to_anon
+          - libreswan_approved_tunnels
+          - logind_session_timeout
+          - mount_option_krb_sec_remote_filesystems
+          - sshd_disable_compression
+          - sshd_disable_empty_passwords
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+          - sshd_disable_rhosts
+          - sshd_disable_rhosts_rsa
+          - sshd_disable_root_login
+          - sshd_disable_user_known_hosts
+          - sshd_do_not_permit_user_env
+          - sshd_enable_strictmodes
+          - sshd_enable_warning_banner
+          - sshd_enable_warning_banner_net
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+          - sshd_set_loglevel_info
+          - sshd_use_priv_separation
+          - use_kerberos_security_all_exports
       status: automated
     - id: ac-17.1
       title: Monitoring and Control
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - rsyslog_remote_access_monitoring
+          - sshd_set_loglevel_verbose
+      status: automated
     - id: ac-17.2
       title: Protection of Confidentiality and Integrity Using Encryption
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_crypto_policy
+          - configure_gnutls_tls_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_openssl_tls_crypto_policy
+          - configure_ssh_crypto_policy
+          - dconf_gnome_remote_access_encryption
+          - harden_ssh_client_crypto_policy
+          - harden_sshd_ciphers_openssh_conf_crypto_policy
+          - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+          - harden_sshd_crypto_policy
+          - harden_sshd_macs_openssh_conf_crypto_policy
+          - harden_sshd_macs_opensshserver_conf_crypto_policy
+          - ldap_client_start_tls
+          - sshd_allow_only_protocol2
+          - sshd_enable_x11_forwarding
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_kex_ordered_stig
+          - sshd_use_approved_macs
+      status: automated
     - id: ac-17.3
       title: Managed Access Control Points
       levels:
@@ -689,7 +925,9 @@ controls:
       levels:
           - low
       rules:
-          - wireless_disable_interfaces
+          - kernel_module_atm_disabled
+          - kernel_module_can_disabled
+          - kernel_module_firewire-core_disabled
       status: automated
     - id: ac-18.1
       title: Authentication and Encryption
@@ -705,14 +943,27 @@ controls:
       title: Disable Wireless Networking
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_bluetooth_disabled
+          - kernel_module_cfg80211_disabled
+          - kernel_module_iwlmvm_disabled
+          - kernel_module_iwlwifi_disabled
+          - kernel_module_mac80211_disabled
+          - service_bluetooth_disabled
+          - wireless_disable_in_bios
+          - wireless_disable_interfaces
+      status: automated
     - id: ac-18.4
       title: Restrict Configurations by Users
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_cfg80211_disabled
+          - kernel_module_iwlmvm_disabled
+          - kernel_module_iwlwifi_disabled
+          - kernel_module_mac80211_disabled
+          - network_nmcli_permissions
+      status: automated
     - id: ac-18.5
       title: Antennas and Transmission Power Levels
       levels:
@@ -799,8 +1050,9 @@ controls:
       status: pending
     - id: ac-23
       title: Data Mining Protection
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_disable_user_list
+      status: automated
     - id: ac-24
       title: Access Control Decisions
       rules: []

--- a/products/rhel9/controls/nist_800_53/au.yml
+++ b/products/rhel9/controls/nist_800_53/au.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 AU Family: Audit and Accountability
 controls:
     - id: au-1
       title: Policy and Procedures
@@ -11,25 +10,36 @@ controls:
       levels:
           - low
       rules:
-          - aide_build_database
-          - aide_periodic_cron_checking
-          - audit_rules_execution_chacl
-          - audit_rules_execution_chcon
-          - audit_rules_execution_setfacl
-          - audit_rules_privileged_commands_usermod
-          - auditd_data_disk_error_action
-          - auditd_data_disk_full_action
-          - auditd_data_retention_action_mail_acct
-          - auditd_data_retention_admin_space_left_action
-          - auditd_data_retention_space_left_action
-          - grub2_audit_backlog_limit_argument
-          - package_aide_installed
-          - package_audit-libs_installed
-          - package_audit_installed
-          - package_systemd-journal-remote_installed
-          - service_auditd_enabled
-          - service_systemd-journald_enabled
-          - socket_systemd-journal-remote_disabled
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success_aarch64
+          - audit_access_success_ppc64le
+          - audit_basic_configuration
+          - audit_create_failed
+          - audit_create_failed_aarch64
+          - audit_create_failed_ppc64le
+          - audit_create_success
+          - audit_create_success_aarch64
+          - audit_create_success_ppc64le
+          - audit_delete_failed
+          - audit_delete_failed_aarch64
+          - audit_delete_failed_ppc64le
+          - audit_delete_success
+          - audit_delete_success_aarch64
+          - audit_delete_success_ppc64le
+          - audit_immutable_login_uids
+          - audit_modify_failed
+          - audit_modify_failed_aarch64
+          - audit_modify_failed_ppc64le
+          - audit_modify_success
+          - audit_modify_success_aarch64
+          - audit_modify_success_ppc64le
+          - audit_module_load
+          - audit_module_load_ppc64le
+          - audit_ospp_general
+          - audit_ospp_general_aarch64
       status: automated
     - id: au-2.1
       title: Compilation of Audit Records from Multiple Sources
@@ -52,75 +62,22 @@ controls:
       levels:
           - low
       rules:
-          - audit_rules_dac_modification_chmod
-          - audit_rules_dac_modification_chown
-          - audit_rules_dac_modification_fchmod
-          - audit_rules_dac_modification_fchmodat
-          - audit_rules_dac_modification_fchown
-          - audit_rules_dac_modification_fchownat
-          - audit_rules_dac_modification_fremovexattr
-          - audit_rules_dac_modification_fsetxattr
-          - audit_rules_dac_modification_lchown
-          - audit_rules_dac_modification_lremovexattr
-          - audit_rules_dac_modification_lsetxattr
-          - audit_rules_dac_modification_removexattr
-          - audit_rules_dac_modification_setxattr
-          - audit_rules_kernel_module_loading_create
-          - audit_rules_kernel_module_loading_delete
-          - audit_rules_kernel_module_loading_finit
-          - audit_rules_kernel_module_loading_init
-          - audit_rules_kernel_module_loading_query
-          - audit_rules_login_events_faillock
-          - audit_rules_login_events_lastlog
-          - audit_rules_mac_modification
-          - audit_rules_mac_modification_usr_share
-          - audit_rules_networkconfig_modification
-          - audit_rules_networkconfig_modification_hostname_file
-          - audit_rules_networkconfig_modification_network_scripts
-          - audit_rules_networkconfig_modification_networkmanager
-          - audit_rules_privileged_commands
-          - audit_rules_privileged_commands_kmod
-          - audit_rules_session_events_btmp
-          - audit_rules_session_events_utmp
-          - audit_rules_session_events_wtmp
-          - audit_rules_suid_auid_privilege_function
-          - audit_rules_sysadmin_actions
-          - audit_rules_time_adjtimex
-          - audit_rules_time_clock_settime
-          - audit_rules_time_settimeofday
-          - audit_rules_time_watch_localtime
-          - audit_rules_unsuccessful_file_modification_creat
-          - audit_rules_unsuccessful_file_modification_ftruncate
-          - audit_rules_unsuccessful_file_modification_open
-          - audit_rules_unsuccessful_file_modification_openat
-          - audit_rules_unsuccessful_file_modification_truncate
-          - audit_rules_usergroup_modification_group
-          - audit_rules_usergroup_modification_gshadow
-          - audit_rules_usergroup_modification_nsswitch_conf
-          - audit_rules_usergroup_modification_opasswd
-          - audit_rules_usergroup_modification_pam_conf
-          - audit_rules_usergroup_modification_pamd
-          - audit_rules_usergroup_modification_passwd
-          - audit_rules_usergroup_modification_shadow
-          - chronyd_specify_remote_server
-          - directory_permissions_var_log_audit
-          - file_groupownership_audit_binaries
-          - file_ownership_var_log_audit_stig
-          - file_permissions_audit_binaries
-          - journald_storage
-          - package_chrony_installed
-          - sshd_set_loglevel_verbose
-          - sshd_set_max_auth_tries
-          - sudo_custom_logfile
-          - sysctl_net_ipv4_conf_all_log_martians
-          - sysctl_net_ipv4_conf_default_log_martians
+          - audit_rules_privileged_commands_chfn
+          - auditd_log_format
+          - auditd_name_format
+          - service_auditd_enabled
       status: automated
     - id: au-3.1
       title: Additional Audit Information
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_privileged_commands_insmod
+          - audit_rules_privileged_commands_kmod
+          - audit_rules_privileged_commands_modprobe
+          - audit_rules_privileged_commands_unix2_chkpwd
+          - audit_rules_privileged_commands_unix_chkpwd
+      status: automated
     - id: au-3.2
       title: Centralized Management of Planned Audit Record Content
       rules: []
@@ -134,40 +91,89 @@ controls:
       levels:
           - low
       rules:
-          - journald_compress
+          - partition_for_var_log
+          - partition_for_var_log_audit
       status: automated
     - id: au-4.1
       title: Transfer to Alternate Storage
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_syslog_plugin_activated
+          - auditd_overflow_action
+          - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
+          - rsyslog_encrypt_offload_actionsendstreamdrivermode
+          - rsyslog_encrypt_offload_defaultnetstreamdriver
+          - rsyslog_remote_loghost
+          - service_rsyslog_enabled
+          - service_syslogng_enabled
+      status: automated
     - id: au-5
       title: Response to Audit Logging Process Failures
       levels:
           - low
       rules:
-          - auditd_data_disk_error_action
-          - auditd_data_disk_full_action
+          - audit_rules_system_shutdown
+          - postfix_client_configure_mail_alias_postmaster
       status: automated
     - id: au-5.1
       title: Storage Capacity Warning
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.2
       title: Real-time Alerts
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_action_mail_acct
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.3
       title: Configurable Traffic Volume Thresholds
       rules: []
       status: pending
     - id: au-5.4
       title: Shutdown on Failure
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_disk_full_action
+          - auditd_audispd_network_failure_action
+          - auditd_data_disk_error_action
+          - auditd_data_disk_error_action_stig
+          - auditd_data_disk_full_action
+          - auditd_data_disk_full_action_stig
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_admin_space_left_percentage
+          - auditd_data_retention_max_log_file_action
+          - auditd_data_retention_max_log_file_action_stig
+          - auditd_data_retention_space_left
+          - auditd_data_retention_space_left_action
+          - auditd_data_retention_space_left_percentage
+      status: automated
     - id: au-5.5
       title: Alternate Audit Logging Capability
       rules: []
@@ -192,12 +198,16 @@ controls:
       title: Correlate Audit Record Repositories
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_accept_remote_messages_tcp
+          - rsyslog_accept_remote_messages_udp
+      status: automated
     - id: au-6.4
       title: Central Review and Analysis
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_accept_remote_messages_tcp
+          - rsyslog_accept_remote_messages_udp
+      status: automated
     - id: au-6.5
       title: Integrated Analysis of Audit Records
       levels:
@@ -230,40 +240,65 @@ controls:
       title: Audit Record Reduction and Report Generation
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: au-7.1
       title: Automatic Processing
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-7.2
       title: Automatic Sort and Search
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-8
       title: Time Stamps
       levels:
           - low
       rules:
-          - auditd_data_retention_max_log_file
-          - auditd_data_retention_max_log_file_action
+          - audit_rules_suid_privilege_function
       status: automated
     - id: au-8.1
       title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
+      rules:
+          - chronyd_client_only
+          - chronyd_configure_pool_and_server
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - chronyd_specify_remote_server
+          - ntpd_specify_multiple_servers
+          - ntpd_specify_remote_server
+          - service_chronyd_or_ntpd_enabled
+          - service_ntp_enabled
+          - service_ntpd_enabled
+          - service_timesyncd_enabled
+      status: automated
     - id: au-8.2
       title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      rules:
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - ntpd_specify_multiple_servers
+      status: automated
     - id: au-9
       title: Protection of Audit Information
       levels:
           - low
       rules:
-          - audit_rules_immutable
+          - directory_permissions_var_log_audit
+          - file_audit_tools_group_ownership
+          - file_audit_tools_ownership
+          - file_audit_tools_permissions
+          - permissions_local_var_log_audit
+          - selinux_policytype
+          - selinux_state
       status: automated
     - id: au-9.1
       title: Hardware Write-once Media
@@ -273,20 +308,34 @@ controls:
       title: Store on Separate Physical Systems or Components
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - rsyslog_remote_loghost
+      status: automated
     - id: au-9.3
       title: Cryptographic Protection
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - aide_check_audit_tools
+          - auditd_audispd_encrypt_sent_records
+          - encrypt_partitions
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+          - rsyslog_remote_tls
+      status: automated
     - id: au-9.4
       title: Access by Subset of Privileged Users
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - directory_group_ownership_var_log_audit
+          - directory_ownership_var_log_audit
+          - file_group_ownership_var_log_audit
+          - file_ownership_var_log_audit
+          - file_ownership_var_log_audit_stig
+          - file_permissions_var_log_audit
+      status: automated
     - id: au-9.5
       title: Dual Authorization
       rules: []
@@ -303,8 +352,11 @@ controls:
       title: Non-repudiation
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - service_auditd_enabled
+      status: automated
     - id: au-10.1
       title: Association of Identities
       rules: []
@@ -329,8 +381,11 @@ controls:
       title: Audit Record Retention
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - auditd_data_retention_flush
+          - auditd_data_retention_max_log_file
+          - auditd_data_retention_num_logs
+      status: automated
     - id: au-11.1
       title: Long-term Retrieval Capability
       rules: []
@@ -390,18 +445,26 @@ controls:
       title: System-wide and Time-correlated Audit Trail
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - chronyd_client_only
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_or_ntpd_specify_remote_server
+          - service_chronyd_or_ntpd_enabled
+      status: automated
     - id: au-12.2
       title: Standardized Formats
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-12.3
       title: Changes by Authorized Individuals
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: au-12.4
       title: Query Parameter Audits of Personally Identifiable Information
       rules: []
@@ -424,12 +487,17 @@ controls:
       status: pending
     - id: au-14
       title: Session Audit
-      rules: []
-      status: pending
+      rules:
+          - package_audit-libs_installed
+          - package_audit_installed
+      status: automated
     - id: au-14.1
       title: System Start-up
-      rules: []
-      status: pending
+      rules:
+          - coreos_audit_option
+          - grub2_audit_argument
+          - service_auditd_enabled
+      status: automated
     - id: au-14.2
       title: Capture and Record Content
       rules: []

--- a/products/rhel9/controls/nist_800_53/au.yml
+++ b/products/rhel9/controls/nist_800_53/au.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 AU Family: Audit and Accountability
 controls:
     - id: au-1
       title: Policy and Procedures
@@ -62,6 +63,7 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_login_events_faillog
           - audit_rules_privileged_commands_chfn
           - auditd_log_format
           - auditd_name_format
@@ -72,6 +74,11 @@ controls:
       levels:
           - moderate
       rules:
+          - audit_rules_etc_cron_d
+          - audit_rules_networkconfig_modification_etc_hosts
+          - audit_rules_networkconfig_modification_etc_issue
+          - audit_rules_networkconfig_modification_etc_issue_net
+          - audit_rules_networkconfig_modification_etc_networkmanager_system_connections
           - audit_rules_privileged_commands_insmod
           - audit_rules_privileged_commands_kmod
           - audit_rules_privileged_commands_modprobe
@@ -111,6 +118,8 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_continue_loading
+          - audit_rules_enable_syscall_auditing
           - audit_rules_system_shutdown
           - postfix_client_configure_mail_alias_postmaster
       status: automated
@@ -292,6 +301,9 @@ controls:
       levels:
           - low
       rules:
+          - audit_rules_immutable_login_uids
+          - audit_rules_mac_modification_etc_apparmor
+          - audit_rules_mac_modification_etc_apparmor_d
           - directory_permissions_var_log_audit
           - file_audit_tools_group_ownership
           - file_audit_tools_ownership
@@ -408,9 +420,16 @@ controls:
           - audit_rules_dac_modification_lsetxattr
           - audit_rules_dac_modification_removexattr
           - audit_rules_dac_modification_setxattr
+          - audit_rules_dac_modification_umount
+          - audit_rules_dac_modification_umount2
+          - audit_rules_execution_chacl
           - audit_rules_execution_chcon
+          - audit_rules_execution_chmod
+          - audit_rules_execution_rm
+          - audit_rules_execution_setfacl
           - audit_rules_file_deletion_events_rename
           - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_renameat2
           - audit_rules_file_deletion_events_unlink
           - audit_rules_file_deletion_events_unlinkat
           - audit_rules_kernel_module_loading_create

--- a/products/rhel9/controls/nist_800_53/cm.yml
+++ b/products/rhel9/controls/nist_800_53/cm.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 CM Family: Configuration Management
 controls:
     - id: cm-1
       title: Policy and Procedures
@@ -265,6 +266,11 @@ controls:
           - accounts_passwords_pam_faillock_interval
           - accounts_passwords_pam_faillock_unlock_time
           - accounts_passwords_pam_tally2_deny_root
+          - file_groupowner_boot_grub2
+          - file_owner_boot_grub2
+          - file_permissions_boot_grub2
+          - grub2_password
+          - grub2_uefi_password
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -319,9 +325,11 @@ controls:
           - package_httpd_removed
           - package_net-snmp_removed
           - package_nginx_removed
+          - package_nis_removed
           - package_openldap-clients_removed
           - package_telnet-server_removed
           - package_telnet_removed
+          - package_telnetd_removed
           - package_tftp-server_removed
           - package_tftp_removed
           - package_vsftpd_removed
@@ -333,9 +341,14 @@ controls:
           - partition_for_var_log_audit
           - partition_for_var_tmp
           - postfix_network_listening_disabled
+          - service_apport_disabled
           - service_bluetooth_disabled
+          - service_cockpit_disabled
           - service_cups_disabled
+          - service_dhcpd_disabled
           - service_dnsmasq_disabled
+          - service_oddjobd_disabled
+          - service_quota_nld_disabled
           - sshd_disable_forwarding
           - wireless_disable_interfaces
       status: automated

--- a/products/rhel9/controls/nist_800_53/cm.yml
+++ b/products/rhel9/controls/nist_800_53/cm.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 CM Family: Configuration Management
 controls:
     - id: cm-1
       title: Policy and Procedures
@@ -133,14 +132,19 @@ controls:
       status: pending
     - id: cm-3.5
       title: Automated Security Response
-      rules: []
-      status: pending
+      rules:
+          - aide_scan_notification
+          - package_mailx_installed
+          - package_s-nail_installed
+      status: automated
     - id: cm-3.6
       title: Cryptography Management
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - enable_fips_mode
+          - service_sshd_disabled
+      status: automated
     - id: cm-3.7
       title: Review System Changes
       rules: []
@@ -177,16 +181,27 @@ controls:
       title: Automated Access Enforcement and Audit Records
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
     - id: cm-5.2
       title: Review System Changes
       rules: []
       status: pending
     - id: cm-5.3
       title: Signed Components
-      rules: []
-      status: pending
+      rules:
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+      status: automated
     - id: cm-5.4
       title: Dual Authorization
       rules: []
@@ -197,8 +212,20 @@ controls:
       status: pending
     - id: cm-5.6
       title: Limit Library Privileges
-      rules: []
-      status: pending
+      rules:
+          - dir_group_ownership_library_dirs
+          - dir_ownership_library_dirs
+          - dir_permissions_library_dirs
+          - dir_system_commands_group_root_owned
+          - dir_system_commands_root_owned
+          - file_groupownership_system_commands_dirs
+          - file_ownership_binary_dirs
+          - file_ownership_library_dirs
+          - file_permissions_binary_dirs
+          - file_permissions_library_dirs
+          - file_permissions_system_commands_dirs
+          - root_permissions_syslibrary_files
+      status: automated
     - id: cm-5.7
       title: Automatic Implementation of Security Safeguards
       rules: []
@@ -208,68 +235,36 @@ controls:
       levels:
           - low
       rules:
-          - accounts_umask_etc_bashrc
-          - accounts_umask_etc_login_defs
-          - accounts_umask_etc_profile
-          - accounts_user_interactive_home_directory_exists
-          - audit_rules_media_export
-          - banner_etc_issue_cis
-          - banner_etc_issue_net_cis
-          - banner_etc_motd_cis
-          - coredump_disable_backtraces
-          - coredump_disable_storage
-          - dconf_gnome_disable_user_list
-          - disable_host_auth
-          - file_groupowner_grub2_cfg
-          - file_groupowner_user_cfg
-          - file_groupownership_sshd_private_key
-          - file_groupownership_sshd_pub_key
-          - file_owner_grub2_cfg
-          - file_owner_user_cfg
-          - file_ownership_home_directories
-          - file_ownership_sshd_private_key
-          - file_ownership_sshd_pub_key
-          - file_permissions_grub2_cfg
-          - file_permissions_home_directories
-          - file_permissions_sshd_private_key
-          - file_permissions_sshd_pub_key
-          - file_permissions_user_cfg
-          - no_empty_passwords
-          - no_empty_passwords_etc_shadow
-          - package_pam_pwquality_installed
-          - package_rsync_removed
-          - package_samba_removed
-          - package_squid_removed
-          - partition_for_tmp
-          - partition_for_var_log
-          - service_nfs_disabled
-          - service_rpcbind_disabled
-          - sshd_disable_gssapi_auth
-          - sshd_set_login_grace_time
-          - sysctl_kernel_randomize_va_space
-          - sysctl_kernel_yama_ptrace_scope
-          - sysctl_net_ipv4_conf_all_accept_redirects
-          - sysctl_net_ipv4_conf_all_accept_source_route
-          - sysctl_net_ipv4_conf_all_log_martians
-          - sysctl_net_ipv4_conf_all_rp_filter
-          - sysctl_net_ipv4_conf_all_secure_redirects
-          - sysctl_net_ipv4_conf_all_send_redirects
-          - sysctl_net_ipv4_conf_default_accept_redirects
-          - sysctl_net_ipv4_conf_default_accept_source_route
-          - sysctl_net_ipv4_conf_default_log_martians
-          - sysctl_net_ipv4_conf_default_rp_filter
-          - sysctl_net_ipv4_conf_default_secure_redirects
-          - sysctl_net_ipv4_conf_default_send_redirects
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-          - sysctl_net_ipv4_ip_forward
-          - sysctl_net_ipv6_conf_all_accept_ra
-          - sysctl_net_ipv6_conf_all_accept_redirects
-          - sysctl_net_ipv6_conf_all_accept_source_route
-          - sysctl_net_ipv6_conf_all_forwarding
-          - sysctl_net_ipv6_conf_default_accept_ra
-          - sysctl_net_ipv6_conf_default_accept_redirects
-          - sysctl_net_ipv6_conf_default_accept_source_route
+          - account_disable_post_pw_expiration
+          - account_emergency_expire_date
+          - account_temp_expire_date
+          - accounts_logon_fail_delay
+          - accounts_max_concurrent_login_sessions
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_all_shadowed
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_retry
+          - accounts_password_pam_ucredit
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -348,14 +343,18 @@ controls:
       title: Periodic Review
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - chronyd_no_chronyc_network
+      status: automated
     - id: cm-7.2
       title: Prevent Program Execution
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - network_sniffer_disabled
+          - package_pam_apparmor_installed
+      status: automated
     - id: cm-7.3
       title: Registration Compliance
       rules: []
@@ -368,8 +367,10 @@ controls:
       title: Authorized Software — Allow-by-exception
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - package_pam_apparmor_installed
+      status: automated
     - id: cm-7.6
       title: Confined Environments with Limited Privileges
       rules: []
@@ -408,8 +409,13 @@ controls:
       title: Automated Unauthorized Component Detection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - usbguard_generate_policy
+      status: automated
     - id: cm-8.4
       title: Accountability Information
       levels:
@@ -461,8 +467,12 @@ controls:
       levels:
           - low
       rules:
-          - package_xorg-x11-server-common_removed
-          - xwindows_runlevel_target
+          - clean_components_post_updating
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
       status: automated
     - id: cm-11.1
       title: Alerts for Unauthorized Installations

--- a/products/rhel9/controls/nist_800_53/cp.yml
+++ b/products/rhel9/controls/nist_800_53/cp.yml
@@ -204,8 +204,11 @@ controls:
       title: System Backup
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_user_data_backups
+          - file_groupowner_backup_etc_shadow
+          - httpd_remove_backups
+      status: automated
     - id: cp-9.1
       title: Testing for Reliability and Integrity
       levels:

--- a/products/rhel9/controls/nist_800_53/ia.yml
+++ b/products/rhel9/controls/nist_800_53/ia.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 IA Family: Identification and Authentication
 controls:
     - id: ia-1
       title: Policy and Procedures
@@ -11,60 +10,113 @@ controls:
       levels:
           - low
       rules:
-          - account_unique_id
+          - accounts_no_uid_except_zero
+          - gid_passwd_group_same
+          - gnome_gdm_disable_guest_login
+          - no_direct_root_logins
+          - require_emergency_target_auth
+          - require_singleuser_auth
       status: automated
     - id: ia-2.1
       title: Multi-factor Authentication to Privileged Accounts
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+          - sssd_enable_pam_services
+      status: automated
     - id: ia-2.2
       title: Multi-factor Authentication to Non-privileged Accounts
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.3
       title: Local Access to Privileged Accounts
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.4
       title: Local Access to Non-privileged Accounts
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - service_sshd_disabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.5
       title: Individual Authentication with Group Authentication
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - sshd_disable_root_login
+      status: automated
     - id: ia-2.6
       title: Access to Accounts —separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.7
       title: Network Access to Non-privileged Accounts — Separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+      status: automated
     - id: ia-2.8
       title: Access to Accounts — Replay Resistant
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_enable_smartcard_auth
+          - mount_option_krb_sec_remote_filesystems
+          - use_kerberos_security_all_exports
+      status: automated
     - id: ia-2.9
       title: Network Access to Non-privileged Accounts — Replay Resistant
-      rules: []
-      status: pending
+      rules:
+          - dconf_gnome_enable_smartcard_auth
+          - mount_option_krb_sec_remote_filesystems
+          - use_kerberos_security_all_exports
+      status: automated
     - id: ia-2.10
       title: Single Sign-on
       rules: []
       status: pending
     - id: ia-2.11
       title: Remote Access — Separate Device
-      rules: []
-      status: pending
+      rules:
+          - configure_opensc_card_drivers
+          - configure_opensc_nss_db
+          - dconf_gnome_enable_smartcard_auth
+          - force_opensc_card_drivers
+          - service_pcscd_enabled
+          - smartcard_auth
+          - sssd_certificate_verification
+      status: automated
     - id: ia-2.12
       title: Acceptance of PIV Credentials
       levels:
@@ -80,9 +132,11 @@ controls:
       levels:
           - moderate
       rules:
-          - dconf_gnome_disable_automount
-          - dconf_gnome_disable_automount_open
-          - kernel_module_usb-storage_disabled
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - usbguard_generate_policy
       status: automated
     - id: ia-3.1
       title: Cryptographic Bidirectional Authentication
@@ -104,8 +158,13 @@ controls:
       title: Identifier Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - account_disable_inactivity_password_auth
+          - account_disable_inactivity_system_auth
+          - account_disable_post_pw_expiration
+          - accounts_no_uid_except_zero
+          - accounts_set_post_pw_existing
+      status: automated
     - id: ia-4.1
       title: Prohibit Account Identifiers as Public Identifiers
       rules: []
@@ -149,45 +208,86 @@ controls:
       levels:
           - low
       rules:
-          - accounts_minimum_age_login_defs
           - accounts_password_all_shadowed
-          - accounts_password_pam_dictcheck
-          - accounts_password_pam_difok
-          - accounts_password_pam_enforce_root
-          - accounts_password_pam_maxrepeat
-          - accounts_password_pam_maxsequence
-          - accounts_password_pam_minclass
-          - accounts_password_pam_minlen
-          - accounts_password_pam_pwhistory_enforce_for_root
-          - accounts_password_set_min_life_existing
-          - no_empty_passwords_etc_shadow
-          - set_password_hashing_algorithm_libuserconf
-          - set_password_hashing_algorithm_logindefs
-          - set_password_hashing_algorithm_passwordauth
-          - set_password_hashing_algorithm_systemauth
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - cracklib_accounts_password_pam_ocredit
+          - snmpd_not_default_password
       status: automated
     - id: ia-5.1
       title: Password-based Authentication
       levels:
           - low
       rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_all_shadowed_sha512
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
+          - accounts_password_pam_ucredit
+          - accounts_password_pam_unix_remember
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - auditd_data_retention_action_mail_acct
+          - no_empty_passwords
+          - no_netrc_files
+          - package_rsh-server_removed
+          - package_vsftpd_removed
+          - package_ypserv_removed
+          - passwd_system-auth_substack
+          - service_rexec_disabled
+          - service_rlogin_disabled
+          - service_rsh_disabled
+          - service_telnet_disabled
+          - service_ypbind_disabled
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_yescrypt_cost_factor_logindefs
+          - sshd_allow_only_protocol2
+          - sshd_use_approved_ciphers
       status: automated
     - id: ia-5.2
       title: Public Key-based Authentication
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - ssh_private_keys_have_passcode
+      status: automated
     - id: ia-5.3
       title: In-person or Trusted External Party Registration
       rules: []
       status: pending
     - id: ia-5.4
       title: Automated Support for Password Strength Determination
-      rules: []
-      status: pending
+      rules:
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_dictcheck
+          - accounts_password_pam_difok
+          - accounts_password_pam_enforce_root
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_maxclassrepeat
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_retry
+          - accounts_password_pam_ucredit
+      status: automated
     - id: ia-5.5
       title: Change Authenticators Prior to Delivery
       rules: []
@@ -200,8 +300,9 @@ controls:
       status: pending
     - id: ia-5.7
       title: No Embedded Unencrypted Static Authenticators
-      rules: []
-      status: pending
+      rules:
+          - no_netrc_files
+      status: automated
     - id: ia-5.8
       title: Multiple System Accounts
       rules: []
@@ -212,8 +313,9 @@ controls:
       status: pending
     - id: ia-5.10
       title: Dynamic Credential Binding
-      rules: []
-      status: pending
+      rules:
+          - service_sssd_enabled
+      status: automated
     - id: ia-5.11
       title: Hardware Token-based Authentication
       rules: []
@@ -224,8 +326,11 @@ controls:
       status: pending
     - id: ia-5.13
       title: Expiration of Cached Authenticators
-      rules: []
-      status: pending
+      rules:
+          - sssd_memcache_timeout
+          - sssd_offline_cred_expiration
+          - sssd_ssh_known_hosts_timeout
+      status: automated
     - id: ia-5.14
       title: Managing Content of PKI Trust Stores
       rules: []
@@ -256,8 +361,17 @@ controls:
       title: Cryptographic Module Authentication
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - installed_OS_is_FIPS_certified
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sysctl_crypto_fips_enabled
+      status: automated
     - id: ia-8
       title: Identification and Authentication (Non-organizational Users)
       levels:
@@ -315,6 +429,10 @@ controls:
       levels:
           - low
       rules:
+          - disallow_bypass_password_sudo
+          - sudo_remove_no_authenticate
+          - sudo_remove_nopasswd
+          - sudo_require_authentication
           - sudo_require_reauthentication
       status: automated
     - id: ia-12

--- a/products/rhel9/controls/nist_800_53/ir.yml
+++ b/products/rhel9/controls/nist_800_53/ir.yml
@@ -52,8 +52,11 @@ controls:
       title: Incident Handling
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - auditd_audispd_configure_remote_server
+          - auditd_offload_logs
+          - service_postfix_enabled
+      status: automated
     - id: ir-4.1
       title: Automated Incident Handling Processes
       levels:
@@ -124,8 +127,14 @@ controls:
       title: Incident Monitoring
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - audit_rules_file_deletion_events
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_rmdir
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+      status: automated
     - id: ir-5.1
       title: Automated Tracking, Data Collection, and Analysis
       levels:

--- a/products/rhel9/controls/nist_800_53/ra.yml
+++ b/products/rhel9/controls/nist_800_53/ra.yml
@@ -48,8 +48,17 @@ controls:
       title: Vulnerability Monitoring and Scanning
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - kernel_module_cramfs_disabled
+          - kernel_module_dccp_disabled
+          - kernel_module_freevxfs_disabled
+          - kernel_module_hfs_disabled
+          - kernel_module_hfsplus_disabled
+          - kernel_module_jffs2_disabled
+          - kernel_module_rds_disabled
+          - kernel_module_sctp_disabled
+          - kernel_module_tipc_disabled
+      status: automated
     - id: ra-5.1
       title: Update Tool Capability
       rules: []

--- a/products/rhel9/controls/nist_800_53/sc.yml
+++ b/products/rhel9/controls/nist_800_53/sc.yml
@@ -70,7 +70,12 @@ controls:
       levels:
           - low
       rules:
+          - accounts_passwords_pam_faillock_root_unlock_time
           - firewalld-backend
+          - kernel_config_binfmt_misc
+          - kernel_config_modify_ldt_syscall
+          - sshd_set_max_sessions
+          - sshd_set_maxstartups
           - sysctl_net_ipv4_conf_all_accept_source_route
           - sysctl_net_ipv4_conf_all_send_redirects
           - sysctl_net_ipv4_conf_default_accept_source_route
@@ -306,6 +311,10 @@ controls:
       levels:
           - moderate
       rules:
+          - dovecot_configure_ssl_cert
+          - dovecot_configure_ssl_key
+          - dovecot_enable_ssl
+          - httpd_configure_tls
           - libreswan_approved_tunnels
       status: automated
     - id: sc-8.1
@@ -462,6 +471,8 @@ controls:
           - harden_openssl_crypto_policy
           - harden_ssh_client_crypto_policy
           - harden_sshd_crypto_policy
+          - httpd_digest_authentication
+          - httpd_require_client_certs
           - installed_OS_is_FIPS_certified
           - is_fips_mode_enabled
           - package_dracut-fips-aesni_installed
@@ -572,6 +583,9 @@ controls:
       levels:
           - low
       rules:
+          - avahi_check_ttl
+          - avahi_ip_only
+          - avahi_restrict_published_information
           - network_configure_name_resolution
       status: automated
     - id: sc-20.1

--- a/products/rhel9/controls/nist_800_53/sc.yml
+++ b/products/rhel9/controls/nist_800_53/sc.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 SC Family: System and Communications Protection
 controls:
     - id: sc-1
       title: Policy and Procedures
@@ -14,8 +13,10 @@ controls:
       status: pending
     - id: sc-2.1
       title: Interfaces for Non-privileged Users
-      rules: []
-      status: pending
+      rules:
+          - coreos_disable_interactive_boot
+          - grub2_disable_interactive_boot
+      status: automated
     - id: sc-2.2
       title: Disassociability
       rules: []
@@ -25,8 +26,7 @@ controls:
       levels:
           - high
       rules:
-          - selinux_not_disabled
-          - selinux_state
+          - grub2_init_on_free
       status: automated
     - id: sc-3.1
       title: Hardware Separation
@@ -69,20 +69,42 @@ controls:
       levels:
           - low
       rules:
-          - sysctl_net_ipv4_tcp_syncookies
+          - firewalld-backend
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv4_tcp_invalid_ratelimit
       status: automated
     - id: sc-5.1
       title: Restrict Ability to Attack Other Systems
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-5.2
       title: Capacity, Bandwidth, and Redundancy
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - partition_for_home
+          - partition_for_tmp
+          - partition_for_var
+          - partition_for_var_log
+          - partition_for_var_log_audit
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-5.3
       title: Detection and Monitoring
-      rules: []
-      status: pending
+      rules:
+          - configure_firewalld_rate_limiting
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
     - id: sc-6
       title: Resource Availability
       rules: []
@@ -91,8 +113,19 @@ controls:
       title: Boundary Protection
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_ip_forward
+      status: automated
     - id: sc-7.1
       title: Physically Separated Subnetworks
       rules: []
@@ -141,8 +174,15 @@ controls:
       status: pending
     - id: sc-7.10
       title: Prevent Exfiltration
-      rules: []
-      status: pending
+      rules:
+          - disable_users_coredumps
+          - service_systemd-coredump_disabled
+          - sysctl_kernel_core_pattern
+          - sysctl_kernel_unprivileged_bpf_disabled
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - sysctl_kernel_yama_ptrace_scope
+          - sysctl_net_core_bpf_jit_harden
+      status: automated
     - id: sc-7.11
       title: Restrict Incoming Communications Traffic
       rules: []
@@ -189,16 +229,28 @@ controls:
       title: Isolation of System Components
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - apparmor_configured
+          - configure_firewalld_ports
+          - package_pam_apparmor_installed
+          - selinux_policytype
+          - selinux_state
+          - service_firewalld_enabled
+          - service_ip6tables_enabled
+          - service_iptables_enabled
+          - set_ip6tables_default_rule
+      status: automated
     - id: sc-7.22
       title: Separate Subnets for Connecting to Different Security Domains
       rules: []
       status: pending
     - id: sc-7.23
       title: Disable Sender Feedback on Protocol Validation Failure
-      rules: []
-      status: pending
+      rules:
+          - set_firewalld_default_zone
+          - set_iptables_default_rule
+          - set_iptables_default_rule_forward
+      status: automated
     - id: sc-7.24
       title: Personally Identifiable Information
       rules: []
@@ -228,26 +280,31 @@ controls:
       levels:
           - moderate
       rules:
-          - configure_custom_crypto_policy_cis
+          - libreswan_approved_tunnels
       status: automated
     - id: sc-8.1
       title: Cryptographic Protection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - harden_openssl_crypto_policy
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.2
       title: Pre- and Post-transmission Handling
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.3
       title: Cryptographic Protection for Message Externals
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.4
       title: Conceal or Randomize Communications
-      rules: []
-      status: pending
+      rules:
+          - service_sshd_enabled
+      status: automated
     - id: sc-8.5
       title: Protected Distribution System
       rules: []
@@ -260,8 +317,13 @@ controls:
       title: Network Disconnect
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - accounts_tmout
+          - logind_session_timeout
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - sshd_set_keepalive_0
+      status: automated
     - id: sc-11
       title: Trusted Path
       rules: []
@@ -274,8 +336,9 @@ controls:
       title: Cryptographic Key Establishment and Management
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - ldap_client_start_tls
+      status: automated
     - id: sc-12.1
       title: Availability
       levels:
@@ -284,12 +347,62 @@ controls:
       status: pending
     - id: sc-12.2
       title: Symmetric Keys
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-12.3
       title: Asymmetric Keys
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+          - etc_system_fips_exists
+          - grub2_enable_fips_mode
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sssd_ldap_configure_tls_ca
+          - sssd_ldap_configure_tls_ca_dir
+          - sssd_ldap_configure_tls_reqcert
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-12.4
       title: PKI Certificates
       rules: []
@@ -306,8 +419,34 @@ controls:
       title: Cryptographic Protection
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_ssh_crypto_policy
+          - disable_prelink
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - encrypt_partitions
+          - etc_system_fips_exists
+          - fips_crypto_policy_symlinks
+          - grub2_enable_fips_mode
+          - harden_openssl_crypto_policy
+          - harden_ssh_client_crypto_policy
+          - harden_sshd_crypto_policy
+          - installed_OS_is_FIPS_certified
+          - is_fips_mode_enabled
+          - package_dracut-fips-aesni_installed
+          - package_dracut-fips_installed
+          - sebool_fips_mode
+          - sshd_allow_only_protocol2
+          - sshd_use_approved_ciphers
+          - sshd_use_approved_macs
+          - sysctl_crypto_fips_enabled
+          - system_booted_in_fips_mode
+      status: automated
     - id: sc-13.1
       title: FIPS-validated Cryptography
       rules: []
@@ -406,8 +545,9 @@ controls:
       title: Secure Name/Address Resolution Service (Authoritative Source)
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - network_configure_name_resolution
+      status: automated
     - id: sc-20.1
       title: Child Subspaces
       rules: []
@@ -463,6 +603,7 @@ controls:
       levels:
           - high
       rules:
+          - audit_rules_system_shutdown
           - service_systemd-journald_enabled
       status: automated
     - id: sc-25
@@ -485,14 +626,18 @@ controls:
       title: Protection of Information at Rest
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - install_mcafee_antivirus
+          - mcafee_antivirus_definitions_updated
+          - service_nails_enabled
+      status: automated
     - id: sc-28.1
       title: Cryptographic Protection
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - encrypt_partitions
+      status: automated
     - id: sc-28.2
       title: Offline Storage
       rules: []
@@ -519,8 +664,10 @@ controls:
       status: pending
     - id: sc-30.2
       title: Randomness
-      rules: []
-      status: pending
+      rules:
+          - sysctl_kernel_kptr_restrict
+          - sysctl_kernel_randomize_va_space
+      status: automated
     - id: sc-30.3
       title: Change Processing and Storage Locations
       rules: []
@@ -531,8 +678,9 @@ controls:
       status: pending
     - id: sc-30.5
       title: Concealment of System Components
-      rules: []
-      status: pending
+      rules:
+          - sysctl_kernel_kptr_restrict
+      status: automated
     - id: sc-31
       title: Covert Channel Analysis
       rules: []
@@ -609,8 +757,11 @@ controls:
       title: Process Isolation
       levels:
           - low
-      rules: []
-      status: pending
+      rules:
+          - bios_enable_execution_restrictions
+          - sysctl_kernel_exec_shield
+          - sysctl_user_max_user_namespaces
+      status: automated
     - id: sc-39.1
       title: Hardware Separation
       rules: []

--- a/products/rhel9/controls/nist_800_53/sc.yml
+++ b/products/rhel9/controls/nist_800_53/sc.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 SC Family: System and Communications Protection
 controls:
     - id: sc-1
       title: Policy and Procedures
@@ -114,6 +115,28 @@ controls:
       levels:
           - low
       rules:
+          - ensure_firewall_rules_for_open_ports
+          - firewall_single_service_active
+          - firewalld_loopback_traffic_restricted
+          - firewalld_loopback_traffic_trusted
+          - firewalld_sshd_disabled
+          - ftp_configure_firewall
+          - httpd_configure_firewall
+          - ip6tables_rules_for_open_ports
+          - iptables_rules_for_open_ports
+          - iptables_sshd_disabled
+          - nftables_ensure_default_deny_policy
+          - package_SuSEfirewall2_installed
+          - package_firewalld_removed
+          - service_SuSEfirewall2_enabled
+          - service_firewalld_disabled
+          - set_firewalld_appropriate_zone
+          - set_iptables_outbound_n_established
+          - set_nftables_new_connections
+          - set_nftables_table
+          - set_ufw_default_rule
+          - susefirewall2_ddos_protection
+          - susefirewall2_only_required_services
           - sysctl_net_ipv4_conf_all_accept_redirects
           - sysctl_net_ipv4_conf_all_accept_source_route
           - sysctl_net_ipv4_conf_all_rp_filter
@@ -125,6 +148,9 @@ controls:
           - sysctl_net_ipv4_conf_default_secure_redirects
           - sysctl_net_ipv4_conf_default_send_redirects
           - sysctl_net_ipv4_ip_forward
+          - ufw_only_required_services
+          - ufw_rate_limit
+          - ufw_rules_for_open_ports
       status: automated
     - id: sc-7.1
       title: Physically Separated Subnetworks

--- a/products/rhel9/controls/nist_800_53/si.yml
+++ b/products/rhel9/controls/nist_800_53/si.yml
@@ -1,3 +1,4 @@
+# NIST 800-53 SI Family: System and Information Integrity
 controls:
     - id: si-1
       title: Policy and Procedures
@@ -11,8 +12,10 @@ controls:
           - low
       rules:
           - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
           - ensure_gpgcheck_never_disabled
           - ensure_redhat_gpgkey_installed
+          - package_abrt_removed
       status: automated
     - id: si-2.1
       title: Central Management
@@ -56,7 +59,13 @@ controls:
       levels:
           - low
       rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+          - dconf_gnome_disable_autorun
           - install_mcafee_antivirus
+          - sebool_antivirus_can_scan_system
+          - sebool_antivirus_use_jit
+          - secure_boot_enabled
           - service_nails_enabled
       status: automated
     - id: si-3.1
@@ -105,10 +114,16 @@ controls:
       levels:
           - low
       rules:
+          - journald_compress
+          - journald_forward_to_syslog
+          - journald_storage
           - kernel_module_dccp_disabled
           - kernel_module_rds_disabled
           - kernel_module_sctp_disabled
           - kernel_module_tipc_disabled
+          - package_systemd-journal-remote_installed
+          - rsyslog_cron_logging
+          - rsyslog_logging_configured
           - service_avahi-daemon_disabled
       status: automated
     - id: si-4.1
@@ -392,8 +407,13 @@ controls:
       title: Information Input Validation
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - kernel_config_fortify_source
+          - kernel_config_randomize_base
+          - kernel_config_stackprotector
+          - sebool_selinuxuser_execheap
+          - sebool_selinuxuser_execstack
+      status: automated
     - id: si-10.1
       title: Manual Override Capability
       rules: []

--- a/products/rhel9/controls/nist_800_53/si.yml
+++ b/products/rhel9/controls/nist_800_53/si.yml
@@ -1,4 +1,3 @@
-# NIST 800-53 SI Family: System and Information Integrity
 controls:
     - id: si-1
       title: Policy and Procedures
@@ -23,8 +22,10 @@ controls:
       title: Automated Flaw Remediation Status
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - agent_mfetpd_running
+          - package_mcafeetp_installed
+      status: automated
     - id: si-2.3
       title: Time to Remediate Flaws and Benchmarks for Corrective Actions
       rules: []
@@ -35,12 +36,17 @@ controls:
       status: pending
     - id: si-2.5
       title: Automatic Software and Firmware Updates
-      rules: []
-      status: pending
+      rules:
+          - dnf-automatic_apply_updates
+          - dnf-automatic_security_updates_only
+          - security_patches_up_to_date
+          - timer_dnf-automatic_enabled
+      status: automated
     - id: si-2.6
       title: Removal of Previous Versions of Software and Firmware
-      rules: []
-      status: pending
+      rules:
+          - clean_components_post_updating
+      status: automated
     - id: si-2.7
       title: Root Cause Analysis
       rules: []
@@ -50,8 +56,8 @@ controls:
       levels:
           - low
       rules:
-          - kernel_module_usb-storage_disabled
-          - service_autofs_disabled
+          - install_mcafee_antivirus
+          - service_nails_enabled
       status: automated
     - id: si-3.1
       title: Central Management
@@ -59,8 +65,9 @@ controls:
       status: pending
     - id: si-3.2
       title: Automatic Updates
-      rules: []
-      status: pending
+      rules:
+          - mcafee_antivirus_definitions_updated
+      status: automated
     - id: si-3.3
       title: Non-privileged Users
       rules: []
@@ -206,12 +213,15 @@ controls:
       title: Unauthorized Network Services
       levels:
           - high
-      rules: []
-      status: pending
+      rules:
+          - package_fapolicyd_installed
+          - service_fapolicyd_enabled
+      status: automated
     - id: si-4.23
       title: Host-based Devices
-      rules: []
-      status: pending
+      rules:
+          - service_auditd_enabled
+      status: automated
     - id: si-4.24
       title: Indicators of Compromise
       rules: []
@@ -254,14 +264,31 @@ controls:
       title: Software, Firmware, and Information Integrity
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - ensure_almalinux_gpgkey_installed
+          - ensure_amazon_gpgkey_installed
+          - ensure_fedora_gpgkey_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+          - ensure_gpgcheck_repo_metadata
+          - ensure_oracle_gpgkey_installed
+          - ensure_redhat_gpgkey_installed
+          - ensure_suse_gpgkey_installed
+      status: automated
     - id: si-7.1
       title: Integrity Checks
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - aide_periodic_checking_systemd_timer
+          - aide_periodic_cron_checking
+          - aide_use_fips_hashes
+          - aide_verify_acls
+          - aide_verify_ext_attributes
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+      status: automated
     - id: si-7.2
       title: Automated Notifications of Integrity Violations
       levels:
@@ -284,8 +311,11 @@ controls:
       status: pending
     - id: si-7.6
       title: Cryptographic Protection
-      rules: []
-      status: pending
+      rules:
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
+      status: automated
     - id: si-7.7
       title: Integration of Detection and Response
       levels:
@@ -392,8 +422,14 @@ controls:
       title: Error Handling
       levels:
           - moderate
-      rules: []
-      status: pending
+      rules:
+          - file_groupownership_lastlog
+          - file_ownership_lastlog
+          - file_permissions_lastlog
+          - permissions_local_var_log
+          - sysctl_fs_suid_dumpable
+          - sysctl_kernel_dmesg_restrict
+      status: automated
     - id: si-12
       title: Information Management and Retention
       levels:
@@ -461,7 +497,8 @@ controls:
       levels:
           - moderate
       rules:
-          - sysctl_kernel_randomize_va_space
+          - coreos_pti_kernel_argument
+          - grub2_pti_argument
       status: automated
     - id: si-17
       title: Fail-safe Procedures

--- a/products/rhel9/profiles/cis_nist.profile
+++ b/products/rhel9/profiles/cis_nist.profile
@@ -1,0 +1,13 @@
+documentation_complete: true
+metadata:
+  version: 2.0.0
+  SMEs:
+    - nist_sync_automation
+reference: https://www.cisecurity.org/benchmark/red_hat_linux/
+title: CIS Red Hat Enterprise Linux 9 Benchmark for Level 2 - Server (NIST-based)
+description: "This profile defines a baseline that aligns to the \"Level 2 - Server\"\nconfiguration from the Center for Internet Security® Red Hat Enterprise\nLinux 9 Benchmark™, v2.0.0.\n\nThis profile is generated from the NIST 800-53 control file and uses\nthe unified NIST 800-53 controls that include CIS-derived rules and\nvariables from all RHEL versions.\n\nThis profile includes Center for Internet Security®\nRed Hat Enterprise Linux 9 CIS Benchmarks™ content."
+selections:
+  - nist_800_53:all
+  - '!file_ownership_home_directories'
+  - '!group_unique_name'
+  - '!file_owner_at_allow'


### PR DESCRIPTION
#### Description:

Add NIST 800-53 / CIS synchronization toolkit and product-specific control files for rhel8, rhel9, and rhel10.

This PR introduces:
- Toolkit for generating NIST 800-53 control files from CIS benchmark mappings
- Product-specific NIST 800-53 Revision 5 control files organized into 21 family files (AC, AU, CM, IA, SC, SI, etc.)
- Weekly GitHub Actions automation to keep control files up to date
- Documentation explaining the architecture and workflows

Each product (rhel8, rhel9, rhel10) now has dedicated NIST 800-53 control files in `products/{product}/controls/nist_800_53/` that map CIS benchmark requirements to NIST controls.

#### Rationale:

Enable NIST 800-53 compliance profiles based on CIS benchmark mappings. This allows users to assess and remediate systems against NIST 800-53 controls using the existing CIS benchmark rule base.

The product-specific architecture ensures:
- Clean control files without conditional logic
- Each product can evolve independently
- Only rules actually available for each product are included

#### Review Hints:

This PR consists of two commits that should be reviewed sequentially:

1. **Infrastructure commit** (`aec333de6d`): Toolkit scripts, documentation, and GitHub Actions workflow
   - Key files: `utils/nist_sync/sync_nist_split.py`, `utils/nist_sync/README.md`, `controls/README_nist_800_53.md`
   - Review the generation logic and documentation for clarity

2. **Control files commit** (`645e5aaaf9`): Generated NIST 800-53 control files
   - 132 files total (3 products × 22 files each for product + reference files)
   - Spot-check a few family files (e.g., `products/rhel9/controls/nist_800_53/au.yml`) to verify format

**Testing the toolkit locally:**
```bash
cd utils/nist_sync
./test_workflow_local.sh