### PR TITLE
Remove wrong remediation metadata from test scenario

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_d_missing_main_conf_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_d_missing_main_conf_misconfigured.fail.sh
@@ -2,7 +2,6 @@
 # packages = chrony
 # variables = var_time_service_set_maxpoll=16
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
-# remediation = bash,ansible
 
 {{{ bash_package_remove("ntp") }}}
 


### PR DESCRIPTION
#### Description:

- Remove wrong remediation metadata from test scenario.
#### Rationale:
- Related to https://github.com/ComplianceAsCode/content/pull/14638/
- Fixes:

```
unknown remediation type: bash,ansible
```
