### PR TITLE
Fix MCP server name

### DIFF
--- a/.claude/skills/build-product/SKILL.md
+++ b/.claude/skills/build-product/SKILL.md
@@ -11,16 +11,16 @@ Build a ComplianceAsCode product.
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 ## Phase 1: Validate Product
 
 1. **Check if product is valid**:
-   Use `mcp__content-mcp__get_product_details` with `product_id=$ARGUMENTS` to validate the product exists and get its metadata.
+   Use `mcp__content-agent__get_product_details` with `product_id=$ARGUMENTS` to validate the product exists and get its metadata.
    **Fallback**: Read `products/$ARGUMENTS/product.yml` directly. If the file doesn't exist, the product is invalid.
 
 2. **If product not found**, list available products:
-   Use `mcp__content-mcp__list_products` to get all available products.
+   Use `mcp__content-agent__list_products` to get all available products.
    **Fallback**: Run `ls products/` to list available product directories.
 
 3. **If no product specified**, ask user using AskUserQuestion:
@@ -72,7 +72,7 @@ Expected artifacts in `build/`:
    - Non-zero = Build failed
 
 2. **Verify key artifacts exist**:
-   Use `mcp__content-mcp__get_datastream_info` with `product=$ARGUMENTS` to verify the datastream was built successfully and get artifact details.
+   Use `mcp__content-agent__get_datastream_info` with `product=$ARGUMENTS` to verify the datastream was built successfully and get artifact details.
    **Fallback**: Check files directly:
    ```bash
    ls -la build/ssg-$ARGUMENTS-ds.xml

--- a/.claude/skills/create-rule/SKILL.md
+++ b/.claude/skills/create-rule/SKILL.md
@@ -11,7 +11,7 @@ Create a new security rule for ComplianceAsCode. This skill handles both templat
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 ## Phase 1: Validate Input
 
@@ -20,7 +20,7 @@ This skill uses `mcp__content-mcp__*` tools when available (preferred — determ
    - Example valid IDs: `sshd_max_auth_tries`, `accounts_password_minlen`
 
 2. **Check if rule already exists**:
-   Use `mcp__content-mcp__search_rules` with `query=$ARGUMENTS` to check if a rule with this ID already exists.
+   Use `mcp__content-agent__search_rules` with `query=$ARGUMENTS` to check if a rule with this ID already exists.
    **Fallback**: Use `Glob` to search for `**/$ARGUMENTS/rule.yml`.
    - If rule exists, inform user and ask if they want to modify it instead
 
@@ -42,14 +42,14 @@ Use AskUserQuestion to ask the user:
 
 If user chose templated rule:
 
-1. **List available templates** using `mcp__content-mcp__list_templates` to get all available templates with their descriptions.
+1. **List available templates** using `mcp__content-agent__list_templates` to get all available templates with their descriptions.
    **Fallback**: Run `ls shared/templates/` to list available template directories.
 
 2. **Present available templates** from the list obtained in step 1 and help the user select the right one based on their use case.
 
 3. **Ask for template selection** using AskUserQuestion
 
-4. **Get template parameter schema** using `mcp__content-mcp__get_template_schema` with `template_name=<selected_template>` to get the full parameter schema, supported languages, and documentation.
+4. **Get template parameter schema** using `mcp__content-agent__get_template_schema` with `template_name=<selected_template>` to get the full parameter schema, supported languages, and documentation.
    **Fallback**: Read `shared/templates/<template_name>/template.yml` or `template.py` for parameter definitions. Check existing rules using this template for usage examples.
 
 5. **Collect template variables**:
@@ -110,7 +110,7 @@ Collect the following information using AskUserQuestion or prompts:
 
 ### For Templated Rules
 
-Use `mcp__content-mcp__generate_rule_from_template` with:
+Use `mcp__content-agent__generate_rule_from_template` with:
 - `template_name`: The selected template name
 - `parameters`: Template variables collected from the user
 - `rule_id`: $ARGUMENTS
@@ -122,7 +122,7 @@ This generates the rule directory and rule.yml with the template configuration a
 
 ### For Non-Templated Rules
 
-Use `mcp__content-mcp__generate_rule_boilerplate` with:
+Use `mcp__content-agent__generate_rule_boilerplate` with:
 - `rule_id`: $ARGUMENTS
 - `title`: The rule title
 - `description`: The rule description
@@ -323,7 +323,7 @@ Most profiles in the project reference control files rather than listing rules d
 
 ### Step 1: List Available Profiles
 
-Use `mcp__content-mcp__list_profiles` with `product=<product>` to list all available profiles for each target product.
+Use `mcp__content-agent__list_profiles` with `product=<product>` to list all available profiles for each target product.
    **Fallback**: Run `ls products/<product>/profiles/*.profile` to list profiles.
 
 ### Step 2: Ask User Which Profile(s)
@@ -472,7 +472,7 @@ ls tests/data/profile_stability/
    cat <rule_directory>/rule.yml
    ```
 
-2. **Validate rule YAML** using `mcp__content-mcp__validate_rule_yaml` with the content of the generated rule.yml. This validates syntax, structure, and reference formats.
+2. **Validate rule YAML** using `mcp__content-agent__validate_rule_yaml` with the content of the generated rule.yml. This validates syntax, structure, and reference formats.
    **Fallback**: Validate against the JSON schema:
    ```bash
    python3 -c "
@@ -488,7 +488,7 @@ ls tests/data/profile_stability/
    " <path_to_rule.yml>
    ```
 
-   For control files, use `mcp__content-mcp__validate_control_file` with the control file path.
+   For control files, use `mcp__content-agent__validate_control_file` with the control file path.
    **Fallback**: Validate against the control schema:
    ```bash
    python3 -c "

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -9,7 +9,7 @@ Generate a pull request description for the current branch by analyzing commits 
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 ## Phase 1: Gather Branch Data
 
@@ -64,10 +64,10 @@ Look for product indicators:
 ### 2.3 Read Key Changed Files
 
 For significant changed files, use MCP functions to get structured metadata:
-- **Rules**: Use `mcp__content-mcp__get_rule_details` with the rule ID to get title, description, rationale, template, severity, references, and platform info
-- **Profiles**: Use `mcp__content-mcp__get_profile_details` with product and profile ID to get profile structure and rule selections
-- **Controls**: Use `mcp__content-mcp__get_control_details` to understand control framework structure
-- **Templates**: Use `mcp__content-mcp__get_template_schema` to get template parameter info
+- **Rules**: Use `mcp__content-agent__get_rule_details` with the rule ID to get title, description, rationale, template, severity, references, and platform info
+- **Profiles**: Use `mcp__content-agent__get_profile_details` with product and profile ID to get profile structure and rule selections
+- **Controls**: Use `mcp__content-agent__get_control_details` to understand control framework structure
+- **Templates**: Use `mcp__content-agent__get_template_schema` to get template parameter info
 
 **Fallback**: Read the files directly — `rule.yml`, `.profile`, control YAML, and template files in `shared/templates/<name>/`.
 

--- a/.claude/skills/inspect-control/SKILL.md
+++ b/.claude/skills/inspect-control/SKILL.md
@@ -11,14 +11,14 @@ Analyze a control file and report its current state: how many requirements are m
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 ## Phase 1: Validate and Load Control File
 
 1. **Parse arguments**: Extract control_id from `$ARGUMENTS`.
 
-2. **Validate control exists**: Call `mcp__content-mcp__get_control_stats` with `control_id=$ARGUMENTS`.
-   - If the tool returns an error (control not found), call `mcp__content-mcp__list_controls` and present available control files via `AskUserQuestion`:
+2. **Validate control exists**: Call `mcp__content-agent__get_control_stats` with `control_id=$ARGUMENTS`.
+   - If the tool returns an error (control not found), call `mcp__content-agent__list_controls` and present available control files via `AskUserQuestion`:
      - "Control file '$ARGUMENTS' not found. Which control file do you want to inspect?"
      - Options: top 4 most relevant from the list + Other
    - **Fallback**: Look for `controls/$ARGUMENTS.yml` or `products/**/controls/$ARGUMENTS.yml`. If not found, run `ls controls/*.yml` and `ls products/*/controls/*.yml` to list available control files. To compute stats, read the control YAML and count requirements grouped by `status` field.
@@ -51,7 +51,7 @@ Only show status rows that have non-zero counts.
 
 ## Phase 3: List Unmapped Requirements
 
-1. Call `mcp__content-mcp__list_unmapped_requirements` with `control_id` and default `status_filter` (pending).
+1. Call `mcp__content-agent__list_unmapped_requirements` with `control_id` and default `status_filter` (pending).
    **Fallback**: Read the control YAML and filter requirements where `status` is `pending` or where `rules:` is empty/missing.
 
 2. Present the unmapped work queue:
@@ -86,7 +86,7 @@ Present actionable next steps based on the analysis:
 
 - To map all unmapped requirements interactively: `/map-controls {control_id} --product <product>`
 - To map a single requirement: `/map-requirement {control_id} <requirement_id> --product <product>`
-- To view full control details: use `mcp__content-mcp__get_control_details`
+- To view full control details: use `mcp__content-agent__get_control_details`
 
 **Tip**: If you have the source security policy document (PDF, Markdown, or HTML), pass it with `--policy <path>` to enrich mapping with the original requirement text. This improves cross-framework matching by using the full policy context instead of just the control file's summary. Example:
   `/map-controls {control_id} --product <product> --policy security_policies/<file>`

--- a/.claude/skills/map-controls/SKILL.md
+++ b/.claude/skills/map-controls/SKILL.md
@@ -11,7 +11,7 @@ This skill orchestrates `/inspect-control` for setup and `/map-requirement` logi
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 **Without MCP server**: Cross-framework similarity search is unavailable. Candidate rules will be found by keyword search only, which may miss semantically similar but differently-worded requirements.
 
@@ -27,16 +27,16 @@ Examples:
 
 1. **Parse arguments**: Extract `control_id`, optional `--product`, and optional `--policy` from `$ARGUMENTS`.
 
-2. **Load control stats**: Call `mcp__content-mcp__get_control_stats` with `control_id`.
-   - If not found, call `mcp__content-mcp__list_controls` and present options via `AskUserQuestion`.
+2. **Load control stats**: Call `mcp__content-agent__get_control_stats` with `control_id`.
+   - If not found, call `mcp__content-agent__list_controls` and present options via `AskUserQuestion`.
    - **Fallback**: Read `controls/<control_id>.yml` or `products/**/controls/<control_id>.yml`. Count requirements by status manually. List controls with `ls controls/*.yml` and `ls products/*/controls/*.yml`.
 
 3. **If no `--product` specified**, discover available products and ask user via `AskUserQuestion`:
-   - Run `ls products/` (or call `mcp__content-mcp__list_products`) to get the list of available products
+   - Run `ls products/` (or call `mcp__content-agent__list_products`) to get the list of available products
    - "Which product are you mapping rules for?"
    - Options: present the most common products from the discovered list + Other
 
-4. **Check build artifacts**: Call `mcp__content-mcp__list_built_products`.
+4. **Check build artifacts**: Call `mcp__content-agent__list_built_products`.
    - If the target product is NOT in the built list, ask the user via `AskUserQuestion`:
      - "Product '{product}' has not been built yet. Rule search works best with build artifacts (expanded Jinja templates). Build it now?"
      - Options:
@@ -60,7 +60,7 @@ Examples:
 6. **If no `--policy` specified**, inform the user:
    > **Tip**: You can enrich mapping with the original security policy document by adding `--policy <path>` (supports PDF, Markdown, HTML). This provides full policy context for each requirement, improving cross-framework matching accuracy.
 
-7. **Get work queue**: Call `mcp__content-mcp__list_unmapped_requirements` with `control_id`.
+7. **Get work queue**: Call `mcp__content-agent__list_unmapped_requirements` with `control_id`.
    **Fallback**: Read the control YAML and filter requirements where `status` is `pending` or `rules:` is empty/missing.
 
 8. **Ask user scope** via `AskUserQuestion`:
@@ -93,7 +93,7 @@ Display:
 
 If `--policy` was provided:
 1. **Infer document type** from the file extension (`.md` → `markdown`, `.pdf` → `pdf`, `.html` → `html`, otherwise → `text`)
-2. Call `mcp__content-mcp__parse_policy_document` with `source`, `document_type`, and `requirement_id` for the current requirement.
+2. Call `mcp__content-agent__parse_policy_document` with `source`, `document_type`, and `requirement_id` for the current requirement.
    **Fallback**: For markdown/text, read the file and search for the requirement ID. For PDF, inform user that PDF parsing requires the MCP server.
 3. If sections returned, display the policy context:
    ```
@@ -105,7 +105,7 @@ If `--policy` was provided:
 
 #### Step 2b: Cross-Framework Search
 
-Call `mcp__content-mcp__find_similar_requirements` with:
+Call `mcp__content-agent__find_similar_requirements` with:
 - `requirement_text`: if `policy_text` is available, use it; otherwise use the requirement's title + " " + description
 - `exclude_control_id`: current control_id
 - `max_results`: 10
@@ -125,7 +125,7 @@ Extract the union of all rules as cross-framework candidates.
 Search for candidate rules using rendered build artifacts (Jinja-expanded, product-specific):
 
 1. Extract 3-5 key terms from the requirement title and description.
-2. For each key term, call `mcp__content-mcp__search_rendered_content` with:
+2. For each key term, call `mcp__content-agent__search_rendered_content` with:
    - `query`: the key term
    - `product`: the target product from Phase 1
    - `limit`: 15
@@ -133,7 +133,7 @@ Search for candidate rules using rendered build artifacts (Jinja-expanded, produ
 
 3. Deduplicate results across all term searches. Combine with cross-framework candidates from Step 2b.
 
-4. For each candidate rule, use `mcp__content-mcp__get_rendered_rule` (or `get_rule_details`) to read its title and description. Reason about which rules best match the requirement semantically.
+4. For each candidate rule, use `mcp__content-agent__get_rendered_rule` (or `get_rule_details`) to read its title and description. Reason about which rules best match the requirement semantically.
 
 5. Present the top candidates in a table:
    ```
@@ -146,7 +146,7 @@ Search for candidate rules using rendered build artifacts (Jinja-expanded, produ
 
 #### Step 2d: Product Availability Check
 
-Since `search_rendered_content` only returns rules present in the target product's build, all search results are already confirmed available. For cross-framework candidates (from Step 2b) that did NOT appear in the rendered search, call `mcp__content-mcp__get_rule_product_availability` to verify availability.
+Since `search_rendered_content` only returns rules present in the target product's build, all search results are already confirmed available. For cross-framework candidates (from Step 2b) that did NOT appear in the rendered search, call `mcp__content-agent__get_rule_product_availability` to verify availability.
 **Fallback**: Check each rule's `rule.yml` for `cce@<product>` entries and grep for the rule ID in target product profiles/controls.
 
 Flag rules NOT available for the target product. Assess portability:
@@ -173,9 +173,9 @@ Flag rules NOT available for the target product. Assess portability:
 
 #### Step 2f: Write Selection
 
-- **If rules selected**: Call `mcp__content-mcp__update_requirement_rules` with `control_id`, `requirement_id`, `rules`, and appropriate `status`.
+- **If rules selected**: Call `mcp__content-agent__update_requirement_rules` with `control_id`, `requirement_id`, `rules`, and appropriate `status`.
   **Fallback**: Find and edit the requirement's YAML file directly using `Edit` tool.
-- **If not applicable**: Call `mcp__content-mcp__update_requirement_rules` with empty rules and `status="not_applicable"`.
+- **If not applicable**: Call `mcp__content-agent__update_requirement_rules` with empty rules and `status="not_applicable"`.
   **Fallback**: Edit the requirement's YAML file to set `status: not_applicable` and `rules: []`.
 - **If create new rule**: Add to the "new rules needed" list for Phase 3.
 - **If skipped**: Record as skipped, move to next.
@@ -189,7 +189,7 @@ For requirements where the author chose "Create new rule":
 1. For each gap requirement, use LLM analysis to:
    - Decompose the requirement into atomic checks (one config change per rule)
    - Suggest rule IDs following naming conventions (lowercase, underscores)
-   - Suggest which template might apply (call `mcp__content-mcp__list_templates` and match; **Fallback**: `ls shared/templates/`)
+   - Suggest which template might apply (call `mcp__content-agent__list_templates` and match; **Fallback**: `ls shared/templates/`)
    - Suggest severity based on the requirement
 
 2. Present the decomposition:
@@ -234,7 +234,7 @@ Present a complete summary of the mapping session:
 ### Updated Stats
 ```
 
-Call `mcp__content-mcp__get_control_stats` again to show the updated coverage.
+Call `mcp__content-agent__get_control_stats` again to show the updated coverage.
 **Fallback**: Re-read the control YAML and recount requirements by status.
 ```
 | Status   | Before | After |

--- a/.claude/skills/map-requirement/SKILL.md
+++ b/.claude/skills/map-requirement/SKILL.md
@@ -9,7 +9,7 @@ Map rules to a single requirement in a control file. This is the atomic unit of 
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 **Without MCP server**: Cross-framework similarity search is unavailable. Candidate rules will be found by keyword search only, which may miss semantically similar but differently-worded requirements.
 
@@ -26,11 +26,11 @@ Examples:
 1. **Parse arguments**: Extract `control_id`, `requirement_id`, `--product` flag, and optional `--policy` flag from `$ARGUMENTS`.
 
 2. **If no `--product` specified**, discover available products and ask the user via `AskUserQuestion`:
-   - Run `ls products/` (or call `mcp__content-mcp__list_products`) to get the list of available products
+   - Run `ls products/` (or call `mcp__content-agent__list_products`) to get the list of available products
    - "Which product are you mapping rules for?"
    - Options: present the most common products from the discovered list + Other
 
-3. **Check build artifacts**: Call `mcp__content-mcp__list_built_products`.
+3. **Check build artifacts**: Call `mcp__content-agent__list_built_products`.
    - If the target product is NOT in the built list, ask the user via `AskUserQuestion`:
      - "Product '{product}' has not been built yet. Rule search works best with build artifacts (expanded Jinja templates). Build it now?"
      - Options:
@@ -39,8 +39,8 @@ Examples:
    - If user chooses to build, invoke the `build-product` skill: `Skill(skill="build-product", args="{product} --datastream-only")`. Wait for the build to complete before continuing.
    - **Fallback**: Check if `build/{product}/rules/` directory exists. If not, offer the build prompt above.
 
-4. **Load the requirement**: Call `mcp__content-mcp__get_control_details` with `control_id`.
-   - If control not found, call `mcp__content-mcp__list_controls` and show options.
+4. **Load the requirement**: Call `mcp__content-agent__get_control_details` with `control_id`.
+   - If control not found, call `mcp__content-agent__list_controls` and show options.
    - Find the requirement matching `requirement_id` in the controls list.
    - If requirement not found, list available requirement IDs and ask user to pick.
    - **Fallback**: Read the control YAML directly from `controls/<control_id>.yml` or `products/<product>/controls/<control_id>.yml`. If the file has `controls_dir:`, read individual requirement files from that directory. To list controls, run `ls controls/*.yml` and `ls products/*/controls/*.yml`.
@@ -67,7 +67,7 @@ If `--policy` was specified:
    - `.html` → `html`
    - Otherwise → `text`
 
-2. **Call `mcp__content-mcp__parse_policy_document`** with:
+2. **Call `mcp__content-agent__parse_policy_document`** with:
    - `source`: the policy path
    - `document_type`: inferred from extension
    - `requirement_id`: the requirement ID from Phase 1
@@ -89,7 +89,7 @@ Execute steps 2a-2c to build a candidate list from multiple sources.
 
 ### Step 2a: Cross-Framework Search
 
-Call `mcp__content-mcp__find_similar_requirements` with:
+Call `mcp__content-agent__find_similar_requirements` with:
 - `requirement_text`: if `policy_text` is available, use it; otherwise use the requirement's title + " " + description
 - `exclude_control_id`: current control_id
 - `max_results`: 10
@@ -111,7 +111,7 @@ Extract the union of all rules from similar requirements as "cross-framework can
 Search for candidate rules using rendered build artifacts (Jinja-expanded, product-specific):
 
 1. Extract 3-5 key terms from the requirement title and description.
-2. For each key term, call `mcp__content-mcp__search_rendered_content` with:
+2. For each key term, call `mcp__content-agent__search_rendered_content` with:
    - `query`: the key term
    - `product`: the target product from Phase 1
    - `limit`: 15
@@ -119,7 +119,7 @@ Search for candidate rules using rendered build artifacts (Jinja-expanded, produ
 
 3. Deduplicate results across all term searches. Combine with cross-framework candidates from Step 2a.
 
-4. For each candidate rule, use `mcp__content-mcp__get_rendered_rule` (or `get_rule_details`) to read its title and description. Reason about which rules best match the requirement:
+4. For each candidate rule, use `mcp__content-agent__get_rendered_rule` (or `get_rule_details`) to read its title and description. Reason about which rules best match the requirement:
    - Look for rules whose title/description semantically matches the requirement
    - Prioritize rules that also appeared in Step 2a cross-framework results
    - Consider rule severity alignment with the requirement's intent
@@ -136,7 +136,7 @@ Search for candidate rules using rendered build artifacts (Jinja-expanded, produ
 
 ### Step 2c: Product Availability Check
 
-Since `search_rendered_content` only returns rules present in the target product's build, all search results are already confirmed available. For cross-framework candidates (from Step 2a) that did NOT appear in the rendered search, call `mcp__content-mcp__get_rule_product_availability` to verify availability.
+Since `search_rendered_content` only returns rules present in the target product's build, all search results are already confirmed available. For cross-framework candidates (from Step 2a) that did NOT appear in the rendered search, call `mcp__content-agent__get_rule_product_availability` to verify availability.
 **Fallback**: For each rule, find its `rule.yml` and check the `identifiers:` section for `cce@<product>` entries. Also grep for the rule ID in `products/<target_product>/profiles/*.profile` and `products/<target_product>/controls/*.yml`.
 
 Flag rules that are NOT available for the target product:
@@ -148,7 +148,7 @@ Warning: Rule '{rule_id}' has identifiers for {other_products} but NOT for {targ
 For rules missing from the target product, use LLM judgment to assess portability:
 - If the rule uses a template (`template` is not None in get_rule_details), it's likely portable
 - If it has platform constraints mentioning specific products, note the constraint
-- Optionally call `mcp__content-mcp__get_rule_details` with `rendered_detail=full` and `product=<a product that has it>` to read the actual OVAL/remediation and assess whether it's product-specific
+- Optionally call `mcp__content-agent__get_rule_details` with `rendered_detail=full` and `product=<a product that has it>` to read the actual OVAL/remediation and assess whether it's product-specific
 
 ## Phase 3: Author Decision
 
@@ -173,7 +173,7 @@ Based on author's decision:
 
 ### If rules were selected (automated or partially_automated):
 
-1. Call `mcp__content-mcp__update_requirement_rules` with:
+1. Call `mcp__content-agent__update_requirement_rules` with:
    - `control_id`: the control file ID
    - `requirement_id`: the requirement ID
    - `rules`: the selected rule IDs
@@ -194,7 +194,7 @@ Based on author's decision:
 
 ### If marked not applicable:
 
-1. Call `mcp__content-mcp__update_requirement_rules` with:
+1. Call `mcp__content-agent__update_requirement_rules` with:
    - `control_id`: the control file ID
    - `requirement_id`: the requirement ID
    - `rules`: [] (empty list)
@@ -227,6 +227,6 @@ Next steps:
 
 ## Error Handling
 
-- If `update_requirement_rules` fails, display the error message and suggest the user manually edit the file. Use `mcp__content-mcp__get_requirement_file_path` to find the correct file, or **Fallback**: locate it by reading the control YAML's `controls_dir:` field or searching for the requirement in the inline `controls:` list.
+- If `update_requirement_rules` fails, display the error message and suggest the user manually edit the file. Use `mcp__content-agent__get_requirement_file_path` to find the correct file, or **Fallback**: locate it by reading the control YAML's `controls_dir:` field or searching for the requirement in the inline `controls:` list.
 - If rule search returns no results, rely only on cross-framework candidates from step 2a.
 - If no candidates are found from any source, inform the user and offer options: "Skip", "Enter rule IDs manually", "Create new rule (use /create-rule)".

--- a/.claude/skills/onboard-control/SKILL.md
+++ b/.claude/skills/onboard-control/SKILL.md
@@ -9,7 +9,7 @@ Parse a security policy document (PDF, Markdown, HTML, or text), create a Compli
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 **Without MCP server**: PDF parsing is unavailable (use markdown/text instead). Control file generation and validation must be done manually. Cross-framework similarity search for auto-mapping is unavailable; keyword-based search is used instead.
 
@@ -31,18 +31,18 @@ Examples:
    - `.html` / `.htm` → `html`
    - Otherwise → `text`
 
-3. **Validate product** (if specified): Call `mcp__content-mcp__get_product_details` with `product_id`.
-   - If not found, call `mcp__content-mcp__list_products` and present options via `AskUserQuestion`:
+3. **Validate product** (if specified): Call `mcp__content-agent__get_product_details` with `product_id`.
+   - If not found, call `mcp__content-agent__list_products` and present options via `AskUserQuestion`:
      - "Product '{product_id}' not found. Which product is this control for?"
      - Options: top 4 relevant products + Other
    - **Fallback**: Check if `products/<product_id>/product.yml` exists. List products with `ls products/`.
 
 4. **If no `--product` specified**, discover available products and ask the user via `AskUserQuestion`:
-   - Run `ls products/` (or call `mcp__content-mcp__list_products`) to get the list of available products
+   - Run `ls products/` (or call `mcp__content-agent__list_products`) to get the list of available products
    - "Which product is this control file for? (optional — leave blank for product-agnostic)"
    - Options: present the most common products from the discovered list + "Product-agnostic (global controls/)" + Other
 
-5. **Check for existing control**: If `--id` was provided, call `mcp__content-mcp__get_control_stats` with `control_id` to check whether a control file with this ID already exists.
+5. **Check for existing control**: If `--id` was provided, call `mcp__content-agent__get_control_stats` with `control_id` to check whether a control file with this ID already exists.
    **Fallback**: Check if `controls/<policy_id>.yml` or `products/<product>/controls/<policy_id>.yml` exists.
    - If it already exists, warn the user via `AskUserQuestion`:
      - "Control file '{policy_id}' already exists with {total} requirements. What would you like to do?"
@@ -53,7 +53,7 @@ Examples:
 
 ## Phase 2: Parse the Policy Document
 
-1. **Parse document**: Call `mcp__content-mcp__parse_policy_document` with:
+1. **Parse document**: Call `mcp__content-agent__parse_policy_document` with:
    - `source`: document_path
    - `document_type`: inferred type from Phase 1
    - **Fallback**: For markdown/text/HTML files, read the file directly and extract structure by splitting on headings. Identify requirements from numbered sections, bullet lists, or tables. For PDF files, inform the user that PDF parsing requires the MCP server and ask for a text/markdown alternative.
@@ -109,7 +109,7 @@ Examples:
        - Other
 
 2. **Ask for additional metadata** via `AskUserQuestion`:
-   - Check existing control files for common level patterns: `grep -h 'id:' controls/*.yml products/*/controls/*.yml | grep -A5 'levels:' | head -20` or call `mcp__content-mcp__list_controls` to see level schemes used in other frameworks
+   - Check existing control files for common level patterns: `grep -h 'id:' controls/*.yml products/*/controls/*.yml | grep -A5 'levels:' | head -20` or call `mcp__content-agent__list_controls` to see level schemes used in other frameworks
    - "Does this policy define compliance levels (e.g., high/medium/low, Level 1/Level 2)?"
    - Options: present common level schemes discovered from existing control files + "No levels" + Other
 
@@ -139,7 +139,7 @@ Examples:
    }
    ```
 
-3. **Generate control files**: Call `mcp__content-mcp__generate_control_files` with:
+3. **Generate control files**: Call `mcp__content-agent__generate_control_files` with:
    - `policy_id`: from Phase 3
    - `policy_title`: from parsed document title
    - `format`: `"directory"` or `"inline"` based on user choice
@@ -174,7 +174,7 @@ Examples:
 
    If there are errors, display them and ask if the user wants to continue or abort.
 
-4. **Validate generated files**: Call `mcp__content-mcp__validate_control_file` with the generated parent file path.
+4. **Validate generated files**: Call `mcp__content-agent__validate_control_file` with the generated parent file path.
    **Fallback**: Validate against the JSON schema:
    ```bash
    python3 -c "
@@ -222,7 +222,7 @@ If `--no-map` was NOT specified, offer to do an initial mapping pass.
 3. **If "Yes, quick auto-map only"**: Perform automatic mapping:
 
    For each requirement:
-   a. Call `mcp__content-mcp__find_similar_requirements` with:
+   a. Call `mcp__content-agent__find_similar_requirements` with:
       - `requirement_text`: requirement title + " " + description
       - `exclude_control_id`: current policy_id
       - `max_results`: 5
@@ -231,11 +231,11 @@ If `--no-map` was NOT specified, offer to do an initial mapping pass.
 
    b. Collect all rules from similar requirements across frameworks.
 
-   c. If the target product is specified, call `mcp__content-mcp__get_rule_product_availability` for the top candidate rules to verify they're available for the product.
+   c. If the target product is specified, call `mcp__content-agent__get_rule_product_availability` for the top candidate rules to verify they're available for the product.
       **Fallback**: Check each rule's `rule.yml` for `cce@<product>` identifiers.
 
    d. If confident matches found (rules appear in 2+ other frameworks for the same concept):
-      - Call `mcp__content-mcp__update_requirement_rules` with the matched rules and `status="automated"`.
+      - Call `mcp__content-agent__update_requirement_rules` with the matched rules and `status="automated"`.
         **Fallback**: Edit the requirement YAML directly using `Edit` tool.
 
    e. Track auto-mapped vs. skipped requirements.
@@ -275,7 +275,7 @@ Present a summary of the onboarding:
 ### Mapping Status
 ```
 
-Call `mcp__content-mcp__get_control_stats` with the new `control_id` (and `product` if specified) to show current state.
+Call `mcp__content-agent__get_control_stats` with the new `control_id` (and `product` if specified) to show current state.
 **Fallback**: Read the generated control YAML and count requirements by status.
 
 ```

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -9,12 +9,12 @@ Run the ctest validation suite against built content in `build/`.
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 ## Phase 1: Verify Build Exists
 
 1. **Check that the build directory exists and contains content**:
-   Use `mcp__content-mcp__list_built_products` to check which products have been built and have artifacts available.
+   Use `mcp__content-agent__list_built_products` to check which products have been built and have artifacts available.
    **Fallback**: Run `ls build/ssg-*-ds.xml 2>/dev/null` to check for built datastreams.
 
 2. **If no build artifacts found**, inform the user:

--- a/.claude/skills/shared/mcp_fallbacks.md
+++ b/.claude/skills/shared/mcp_fallbacks.md
@@ -1,6 +1,6 @@
 # MCP Fallback Reference
 
-When the `mcp__content-mcp__*` tools are not available, use these filesystem-based alternatives.
+When the `mcp__content-agent__*` tools are not available, use these filesystem-based alternatives.
 
 ## Simple Lookups
 
@@ -125,7 +125,7 @@ This is less precise than the MCP tool's text similarity but catches most obviou
 - **Markdown/text files**: Read the file directly. Split by headings (`#`, `##`, etc.) to identify sections. Extract requirement IDs from section headers or numbered lists.
 - **HTML files**: Read the file. The markup is usually readable enough to extract structure.
 - **PDF files**: Cannot be parsed without the MCP server. Inform the user:
-  > PDF parsing requires the content-mcp server. Please convert the PDF to markdown or text first, or configure the MCP server.
+  > PDF parsing requires the content-agent server. Please convert the PDF to markdown or text first, or configure the MCP server.
 
 ### update_requirement_rules
 

--- a/.claude/skills/test-rule/SKILL.md
+++ b/.claude/skills/test-rule/SKILL.md
@@ -11,17 +11,17 @@ Run Automatus tests for a ComplianceAsCode security rule.
 
 ## Tool Strategy
 
-This skill uses `mcp__content-mcp__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
+This skill uses `mcp__content-agent__*` tools when available (preferred — deterministic, structured results). When the MCP server is not configured, fall back to filesystem-based alternatives noted as **Fallback** in each step. See `.claude/skills/shared/mcp_fallbacks.md` for detailed fallback procedures. The skill must complete successfully either way.
 
 ## Phase 1: Validate Rule Exists
 
-1. **Find the rule** using `mcp__content-mcp__get_rule_details` with `rule_id=$ARGUMENTS`:
+1. **Find the rule** using `mcp__content-agent__get_rule_details` with `rule_id=$ARGUMENTS`:
    - This returns the full rule metadata including template info, CCE identifiers, remediation types, and file location.
-   - If the rule is not found, also use `mcp__content-mcp__search_rules` with `query=$ARGUMENTS` to check for similar rule IDs.
+   - If the rule is not found, also use `mcp__content-agent__search_rules` with `query=$ARGUMENTS` to check for similar rule IDs.
    - **Fallback**: Use `Glob` to find `**/$ARGUMENTS/rule.yml`, then read the file to extract metadata. For similar rule search, use `Grep` to search for `$ARGUMENTS` across rule.yml files.
 
 2. **If rule not found**:
-   - Use `mcp__content-mcp__list_templates` to check if it's a template name instead.
+   - Use `mcp__content-agent__list_templates` to check if it's a template name instead.
    **Fallback**: Run `ls shared/templates/` to check for template names.
    - Inform user and exit if not found
 
@@ -98,11 +98,11 @@ Store the mapping of product → VM name for Phase 5.
 ## Phase 4: Verify Prerequisites
 
 1. **Check for existing datastreams**:
-   Use `mcp__content-mcp__list_built_products` to see which products have been built.
+   Use `mcp__content-agent__list_built_products` to see which products have been built.
    **Fallback**: Run `ls build/ssg-*-ds.xml 2>/dev/null` to list built datastreams.
 
 2. **For each selected product**, check if datastream exists and get details:
-   Use `mcp__content-mcp__get_datastream_info` with `product=<product>` to verify the datastream exists and get its details.
+   Use `mcp__content-agent__get_datastream_info` with `product=<product>` to verify the datastream exists and get its details.
    **Fallback**: Run `ls -la build/ssg-<product>-ds.xml` to check if the datastream exists.
 
 3. **Build datastreams if needed**:


### PR DESCRIPTION
Currently, Claude Code complains that it won't use the MCP server because of the incorrect name and it falls back to the fall back option, which is less efficient.

Because the skills reference tools that don't exist (mcp__content-mcp__*), when a skill runs it will never find the MCP tools and will always fall back to the slower, less precise filesystem-based alternatives. The skills still work due to the fallback mechanism, but they miss the benefits of the MCP server (structured results, semantic search via find_similar_requirements, PDF parsing, etc.).

The correct name is `content-agent`.
See https://github.com/ComplianceAsCode/content-mcp/blob/main/README.md



#### Review Hints:

Ask Claude to verify that it can successfully use the MCP when using the Claude Skills.
