### PR TITLE
Improve Claude Skills front matter

### DIFF
--- a/.claude/skills/find-rule/SKILL.md
+++ b/.claude/skills/find-rule/SKILL.md
@@ -1,5 +1,6 @@
 ---
-disable-model-invocation: true
+name: find-rule
+description: Search for existing rules that match a given requirement text. Identify rules that implement a specific control.
 ---
 
 Search for existing rules that match the following requirement:

--- a/.claude/skills/manage-profile/SKILL.md
+++ b/.claude/skills/manage-profile/SKILL.md
@@ -1,4 +1,6 @@
 ---
+name: manage-profile
+description: Create or update a versioned profile pair (versioned + unversioned extends pattern).
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
Add name and description to find-rule and manage-profile skills because the description field is used by Claude to decide when to use a skill, and it also determines how it's presented in the skill listing.

Remove `disable-model-invocation: true` from find-rule because find-rule is a pure search/lookup skill with zero side effects: it only reads files and presents results. Setting `disable-model-invocation: true` prevents Claude from automatically using it when a user asks something like "are there any rules for SSH timeout?" This defeats the purpose. It should be auto-invocable.


