### PR TITLE
Fix authselect remediation with multiple features

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
+# remediation = ansible
+
+authselect create-profile test_profile -b sssd
+authselect select "custom/test_profile" --force
+
+# Enable multiple features to test the scenario where "authselect current --raw"
+# returns a string with spaces (e.g., "custom/test_profile with-faillock with-fingerprint")
+authselect enable-feature with-faillock
+authselect enable-feature with-fingerprint
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/no_faillock_with_other_features.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/no_faillock_with_other_features.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
+
+authselect create-profile test_profile -b sssd
+authselect select "custom/test_profile" --force
+
+# Enable other features but not with-faillock to simulate a system
+# that has authselect configured with features, but missing the required faillock
+authselect enable-feature with-fingerprint
+authselect enable-feature with-silent-lastlog
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/sssd_profile_with_features.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/sssd_profile_with_features.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
+
+# Simulate a real RHEL system with sssd profile and multiple features enabled
+# This is the scenario reported in issue #14600 where "authselect current --raw"
+# returns "sssd with-fingerprint with-silent-lastlog"
+authselect select sssd --force
+authselect enable-feature with-faillock
+authselect enable-feature with-fingerprint
+authselect enable-feature with-silent-lastlog
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/sssd_single_feature_no_faillock.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/sssd_single_feature_no_faillock.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
+
+# Test with sssd profile and one feature (not faillock) enabled
+# This simulates a system where "authselect current --raw" returns "sssd with-fingerprint"
+authselect select sssd --force
+authselect enable-feature with-fingerprint
+
+authselect apply-changes

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -930,9 +930,15 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 
 #}}
 {{% macro ansible_authselect_force_reselect(rule_title=None) -%}}
+- name: '{{{ rule_title }}} - Get current authselect profile'
+  ansible.builtin.command:
+    cmd: authselect current --raw
+  register: authselect_current_profile
+  changed_when: false
+
 - name: '{{{ rule_title }}} - Force reselect authselect profile'
-  ansible.builtin.shell:
-    cmd: authselect select "$(authselect current --raw)" --force
+  ansible.builtin.command:
+    cmd: "authselect select {{ authselect_current_profile.stdout }} --force"
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2484,7 +2484,8 @@ fi
 
 #}}
 {{% macro bash_authselect_force_reselect() -%}}
-authselect select "$(authselect current --raw)" --force
+read -ra authselect_args < <(authselect current --raw)
+authselect select "${authselect_args[@]}" --force
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
The ansible_authselect_force_reselect and bash_authselect_force_reselect macros were using quoted command substitution which caused failures when authselect profiles had additional features enabled.

When "authselect current --raw" returns a profile with features (e.g., "sssd with-faillock with-fingerprint"), the quotes merged it into a single argument. This caused authselect to fail with: [error] Unable to get profile information [2]: No such file or directory

The fix removes the quotes, allowing the shell to properly expand the output into multiple arguments so authselect can correctly parse the profile name and features.

Added test scenarios covering:
- Custom profile with multiple features and faillock enabled
- SSSD profile with multiple features (real-world RHEL 9.7 scenario)
- Multiple features without faillock (remediation needed)
- Single feature without faillock (remediation needed)

Fixes: #14600 