### PR TITLE
Change status of CIS control 5.4.2.2 for Hummingbird

### DIFF
--- a/products/hummingbird/controls/cis_hummingbird.yml
+++ b/products/hummingbird/controls/cis_hummingbird.yml
@@ -1608,11 +1608,7 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: automated
-      notes: |-
-          There is assessment but no automated remediation for this rule and this sounds reasonable.
-      rules:
-          - accounts_root_gid_zero
+      status: not applicable
 
     - id: 5.4.2.3
       title: Ensure group root is the only GID 0 group (Automated)


### PR DESCRIPTION
The selected rule `accounts_root_gid_zero` is marked with platform `system_with_kernel` which makes it notapplicable on container images.

