### PR TITLE
Add rule package_rsyslog-gnutls_installed to ISM_O

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -475,6 +475,7 @@ controls:
           - package_fapolicyd_installed
           - package_firewalld_installed
           - package_rsyslog_installed
+          - package_rsyslog-gnutls_installed
           - package_squid_removed
           - package_telnet_removed
           - package_telnet-server_removed

--- a/tests/data/profile_stability/rhel10/ism_o.profile
+++ b/tests/data/profile_stability/rhel10/ism_o.profile
@@ -100,6 +100,7 @@ package_libdnf-plugin-subscription-manager_installed
 package_opensc_installed
 package_pcsc-lite-ccid_installed
 package_pcsc-lite_installed
+package_rsyslog-gnutls_installed
 package_rsyslog_installed
 package_sequoia-sq_installed
 package_squid_removed

--- a/tests/data/profile_stability/rhel10/ism_o_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_secret.profile
@@ -100,6 +100,7 @@ package_libdnf-plugin-subscription-manager_installed
 package_opensc_installed
 package_pcsc-lite-ccid_installed
 package_pcsc-lite_installed
+package_rsyslog-gnutls_installed
 package_rsyslog_installed
 package_sequoia-sq_installed
 package_squid_removed

--- a/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
@@ -100,6 +100,7 @@ package_libdnf-plugin-subscription-manager_installed
 package_opensc_installed
 package_pcsc-lite-ccid_installed
 package_pcsc-lite_installed
+package_rsyslog-gnutls_installed
 package_rsyslog_installed
 package_sequoia-sq_installed
 package_squid_removed

--- a/tests/data/profile_stability/rhel8/ism_o.profile
+++ b/tests/data/profile_stability/rhel8/ism_o.profile
@@ -80,6 +80,7 @@ package_chrony_installed
 package_fapolicyd_installed
 package_firewalld_installed
 package_rear_installed
+package_rsyslog-gnutls_installed
 package_rsyslog_installed
 package_squid_removed
 package_sudo_installed

--- a/tests/data/profile_stability/rhel9/ism_o.profile
+++ b/tests/data/profile_stability/rhel9/ism_o.profile
@@ -79,6 +79,7 @@ package_chrony_installed
 package_fapolicyd_installed
 package_firewalld_installed
 package_rear_installed
+package_rsyslog-gnutls_installed
 package_rsyslog_installed
 package_squid_removed
 package_sudo_installed


### PR DESCRIPTION
Install the package rsyslog-gnutls to provide the lmnsd_gtls module.

Fixes: https://github.com/ComplianceAsCode/content/issues/14564

Addressing:

```
rsyslogd: could not load module 'lmnsd_gtls', errors: trying to load module /usr/lib64/rsyslog/lmnsd_gtls.so: /usr/lib64/rsyslog/lmnsd_gtls.so: cannot open shared object file: No such file or directory [v8.2510.0-2.el9 try https://www.rsyslog.com/e/2066 ]
```

#### Review Hints:

Run contest test `/scanning/boot-errors/ism_o` on RHEL 9.8 using a custom GitLab pipeline. Verify that the aforementioned message isn't present in the test results. Note that there will be messages about unset remote loghost and CA certificate - these messages are caused by rules `rsyslog_remote_loghost` and `rsyslog_remote_tls_cacert`.