### PR TITLE
Update HIPAA URL references

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -25,7 +25,7 @@ SSG_REF_URIS = {
     'pcidss': 'https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf',
     'pcidss4': 'https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf',
     'ospp': 'https://www.niap-ccevs.org/Profile/PP.cfm',
-    'hipaa': 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
+    'hipaa': 'https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
     'ism': 'https://www.cyber.gov.au/acsc/view-all-content/ism',
     'iso27001-2013': 'https://www.iso.org/contents/data/standard/05/45/54534.html',
     'nerc-cip': 'https://www.nerc.com/standards/reliability-standards/cip',
@@ -93,7 +93,7 @@ cce_uri = "https://ncp.nist.gov/cce"
 stig_ns = "https://www.cyber.mil/stigs/srg-stig-tools/"
 ccn_ns = "https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html"
 cis_ns = "https://www.cisecurity.org/benchmark/red_hat_linux/"
-hipaa_ns = "https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf"
+hipaa_ns = "https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf"
 anssi_ns = "https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf"
 ospp_ns = "https://www.niap-ccevs.org/Profile/PP.cfm"
 pcidss4_ns = "https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf"

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -76,7 +76,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -76,7 +76,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/anolis23.yml
+++ b/tests/data/product_stability/anolis23.yml
@@ -75,7 +75,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -75,7 +75,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -85,7 +85,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -87,7 +87,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/debian13.yml
+++ b/tests/data/product_stability/debian13.yml
@@ -87,7 +87,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -83,7 +83,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -77,7 +77,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -121,7 +121,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -72,7 +72,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -183,7 +183,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -86,7 +86,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -59,7 +59,7 @@ reference_uris: {anssi: 'https://cyber.gouv.fr/sites/default/files/document/linu
   cis: 'https://www.cisecurity.org/benchmark/oracle_linux/', cis-csc: 'https://www.cisecurity.org/controls/',
   cjis: 'https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf',
   cobit5: 'https://www.isaca.org/resources/cobit', cui: 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf',
-  dcid: not_officially_available, disa: 'https://www.cyber.mil/stigs/cci/', hipaa: 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
+  dcid: not_officially_available, disa: 'https://www.cyber.mil/stigs/cci/', hipaa: 'https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
   isa-62443-2009: 'https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat',
   isa-62443-2013: 'https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu',
   ism: 'https://www.cyber.gov.au/acsc/view-all-content/ism', iso27001-2013: 'https://www.iso.org/contents/data/standard/05/45/54534.html',

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -62,7 +62,7 @@ reference_uris: {anssi: 'https://cyber.gouv.fr/sites/default/files/document/linu
   ccn: 'https://www.ccn-cert.cni.es/es/guias-de-acceso-publico-ccn-stic/6669-ccn-stic-620-guia-de-aplicaciones-de-perfilado-de-seguridad-para-oracle-linux/file.html',
   cis: '', cis-csc: 'https://www.cisecurity.org/controls/', cjis: 'https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf',
   cobit5: 'https://www.isaca.org/resources/cobit', cui: 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf',
-  dcid: not_officially_available, disa: 'https://www.cyber.mil/stigs/cci/', hipaa: 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
+  dcid: not_officially_available, disa: 'https://www.cyber.mil/stigs/cci/', hipaa: 'https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
   isa-62443-2009: 'https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat',
   isa-62443-2013: 'https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu',
   ism: 'https://www.cyber.gov.au/acsc/view-all-content/ism', iso27001-2013: 'https://www.iso.org/contents/data/standard/05/45/54534.html',

--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -88,7 +88,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -84,7 +84,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -80,7 +80,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/rhel10.yml
+++ b/tests/data/product_stability/rhel10.yml
@@ -90,7 +90,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -137,7 +137,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -94,7 +94,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -85,7 +85,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -86,7 +86,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -90,7 +90,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -98,7 +98,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -99,7 +99,7 @@ reference_uris:
   cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
   dcid: not_officially_available
   disa: https://www.cyber.mil/stigs/cci/
-  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  hipaa: https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
   isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
   isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
   ism: https://www.cyber.gov.au/acsc/view-all-content/ism


### PR DESCRIPTION
#### Description:

- This PR updates HIPAA reference URL from deprecated `fdsys` to `govinfo`
