### PR TITLE
add hipaa reference to rule package_postfix_installed

### DIFF
--- a/linux_os/guide/services/mail/package_postfix_installed/rule.yml
+++ b/linux_os/guide/services/mail/package_postfix_installed/rule.yml
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel10: CCE-86466-0
 
 references:
+    hipaa: 164.312(a)(2)(ii)
     srg: SRG-OS-000046-GPOS-00022
 
 {{{ complete_ocil_entry_package_installed("postfix") }}}


### PR DESCRIPTION
#### Description:

- add missing rference

#### Rationale:

- test /static-checks/rule-identifiers from the Contest test suite was failing
- and of course the reference was missing from the guide and report

#### Review Hints:

- build the product and check guide