### PR TITLE
account_password_pam_faillock_password_auth: strip test metadata

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = authselect,pam
 # platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
-# remediation = ansible
 
 authselect create-profile test_profile -b sssd
 authselect select "custom/test_profile" --force


### PR DESCRIPTION
#### Description:

- remove redundant metadata from a test scenario

#### Rationale:

- this was discovered by our productization test
- a test scenario which is expecting "pass" does not need a remediation metadata, because the remediation will actually be never executed

