### PR TITLE
Remove unused metadata from test scenario

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = authselect,pam
 # platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
-# remediation = ansible
 
 authselect create-profile test_profile -b sssd
 authselect select "custom/test_profile" --force


### PR DESCRIPTION

#### Description:
- Remove unused metadata from test scenario
- Rule: account_password_pam_faillock_password_auth
Test: linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value_with_features.pass.sh


#### Rationale:

- Fix:
  - `account_password_pam_faillock_password_auth/correct_value_with_features.pass`
    - `remediation=ansible doesn't make sense for a .pass.sh test`
- Follow up of https://github.com/ComplianceAsCode/content/pull/14659/