### PR TITLE
Enable more Packit-based Contest testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,6 +43,10 @@ jobs:
   tmt_plan: /plans/upstream-parallel/ansible
   identifier: contest-ansible
 
+- <<: *contest-oscap
+  tmt_plan: /plans/upstream-parallel/other
+  identifier: contest-other
+
 # when modifying anything below, modify also tests/tmt/
 
 - job: tests


### PR DESCRIPTION
#### Description:

The original Contest upstream-parallel plan had `/static-checks`, but that was never executed because I forgot to add a third Packit job last time in https://github.com/ComplianceAsCode/content/pull/14392 (adding them only for oscap/ansible remediation).

Instead of having a job specifically for `/static-checks`, I extended the additional testing to include more plans, and grouped them all under `/other`, adding a new Packit job for the category.

See https://github.com/RHSecurityCompliance/contest/commit/3f808bbb3c6a7af83994740f9b811965585cf836 .

#### Rationale:

These tests would have caught several recent issues with unit test metadata and at least one recent rule-identifiers issue.

#### Review Hints:

Given that these currently find Content bugs, we should avoid marking the new job as "required" for now, until the bugs are fixed.