### PR TITLE
Allow whitespace in rsyslog configuration files

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/ansible/shared.yml
@@ -9,6 +9,6 @@
 {{{ ansible_remove_rainerscript_block_entries(rule_title, "action", "StreamDriverAuthMode") }}}
 
 {{{ ansible_set_config_file_dir(msg, "/etc/rsyslog.conf", "/etc/rsyslog.d", "/etc/rsyslog.conf", 
-                                "$ActionSendStreamDriverAuthMode", separator=' ', separator_regex='\s',
+                                "$ActionSendStreamDriverAuthMode", separator=' ',
                                 value="x509/name", create='yes', rule_title=rule_title)
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/bash/shared.sh
@@ -6,5 +6,5 @@
 {{{ setup_rsyslog_encrypt_offload_actionsendstreamdriverauthmode() }}}
 
 {{{ set_config_file(path="$RSYSLOG_D_CONF",
-             parameter="\$ActionSendStreamDriverAuthMode", value="x509/name", create=true, separator=" ", separator_regex=" ", rule_id=rule_id)
+             parameter="\$ActionSendStreamDriverAuthMode", value="x509/name", create=true, separator=" ", rule_id=rule_id)
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/oval/shared.xml
@@ -15,7 +15,7 @@
         </criteria>
     </definition>
 
-{{% set legacy_regex = "^\\$ActionSendStreamDriverAuthMode x509/name$" %}}
+{{% set legacy_regex = "^\\s*\\$ActionSendStreamDriverAuthMode\\s+x509/name\\s*$" %}}
 {{% set rainer_script_regex = "(?ms)^\\s*action\\(.*(?i)\\btype\\b(?-i)=\"omfwd\".*(?i)\\bStreamDriverAuthMode\\b(?-i)=\"x509/name\".*\\)\\s*$" %}}
 
     <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/tests/rsyslog_extra_spaces.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/tests/rsyslog_extra_spaces.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+{{{ setup_rsyslog_encrypt_offload_actionsendstreamdriverauthmode() }}}
+
+echo "\$ActionSendStreamDriverAuthMode    x509/name" >> $RSYSLOG_CONF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/tests/rsyslog_leading_whitespace.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/tests/rsyslog_leading_whitespace.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+{{{ setup_rsyslog_encrypt_offload_actionsendstreamdriverauthmode() }}}
+
+echo "  \$ActionSendStreamDriverAuthMode x509/name" >> $RSYSLOG_CONF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/ansible/shared.yml
@@ -10,5 +10,5 @@
 
 {{{ ansible_set_config_file_dir(msg, "/etc/rsyslog.conf", "/etc/rsyslog.d", "/etc/rsyslog.conf",
                                   parameter="$ActionSendStreamDriverMode", value="1", create=true, separator=" ",
-                                  separator_regex=" ", rule_title=rule_title)
+                                  rule_title=rule_title)
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/bash/shared.sh
@@ -2,5 +2,5 @@
 {{{ setup_rsyslog_encrypt_offload_actionsendstreamdrivermode() }}}
 
 {{{ set_config_file(path="$RSYSLOG_D_CONF",
-             parameter="\$ActionSendStreamDriverMode", value="1", create=true, separator=" ", separator_regex=" ", rule_id=rule_id)
+             parameter="\$ActionSendStreamDriverMode", value="1", create=true, separator=" ", rule_id=rule_id)
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/oval/shared.xml
@@ -16,7 +16,7 @@
         </criteria>
     </definition>
 
-{{% set legacy_regex = "^\\$ActionSendStreamDriverMode 1$" %}}
+{{% set legacy_regex = "^\\s*\\$ActionSendStreamDriverMode\\s+1\\s*$" %}}
 {{% set rainer_script_regex = "(?ms)^\\s*action\\(.*(?i)\\btype\\b(?-i)=\"omfwd\".*(?i)\\bStreamDriverMode\\b(?-i)=\"1\".*\\)\\s*$" %}}
 
     <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/tests/rsyslog_extra_spaces.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/tests/rsyslog_extra_spaces.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+{{{ setup_rsyslog_encrypt_offload_actionsendstreamdrivermode() }}}
+
+echo "\$ActionSendStreamDriverMode    1" >> $RSYSLOG_CONF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/tests/rsyslog_leading_whitespace.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/tests/rsyslog_leading_whitespace.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+{{{ setup_rsyslog_encrypt_offload_actionsendstreamdrivermode() }}}
+
+echo "  \$ActionSendStreamDriverMode 1" >> $RSYSLOG_CONF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/ansible/shared.yml
@@ -10,5 +10,5 @@
 
 {{{ ansible_set_config_file_dir(msg, "/etc/rsyslog.conf", "/etc/rsyslog.d", "/etc/rsyslog.conf",
                                 parameter="$DefaultNetstreamDriver", value="gtls", create=true,
-                                separator=" ", separator_regex=" ", rule_title=rule_title)
+                                separator=" ", rule_title=rule_title)
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/bash/shared.sh
@@ -2,5 +2,5 @@
 {{{ setup_rsyslog_encrypt_offload_defaultnetstreamdriver() }}}
 
 {{{ set_config_file(path="$RSYSLOG_D_CONF",
-                    parameter="\$DefaultNetstreamDriver", value="gtls", create=true, separator=" ", separator_regex=" ", rule_id=rule_id)
+                    parameter="\$DefaultNetstreamDriver", value="gtls", create=true, separator=" ", rule_id=rule_id)
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/oval/shared.xml
@@ -16,7 +16,7 @@
         </criteria>
     </definition>
 
-{{% set legacy_regex = "^\\$DefaultNetstreamDriver gtls$" %}}
+{{% set legacy_regex = "^\\s*\\$DefaultNetstreamDriver\\s+gtls\\s*$" %}}
 {{% set rainer_script_regex = "(?ms)^\\s*global\\(.*(?i)\\bDefaultNetStreamDriver\\b(?-i)=\"gtls\".*\\)\\s*$" %}}
 
     <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/tests/rsyslog_extra_spaces.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/tests/rsyslog_extra_spaces.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+{{{ setup_rsyslog_encrypt_offload_defaultnetstreamdriver() }}}
+
+echo "\$DefaultNetstreamDriver    gtls" >> $RSYSLOG_CONF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/tests/rsyslog_leading_whitespace.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/tests/rsyslog_leading_whitespace.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+{{{ setup_rsyslog_encrypt_offload_defaultnetstreamdriver() }}}
+
+echo "  \$DefaultNetstreamDriver gtls" >> $RSYSLOG_CONF


### PR DESCRIPTION
Some `rsyslog` rules required exactly one space between the configuration option and value. That is too strict, having more spaces is valid and accepted by `rsyslog`. The rules have been fixed so that more spaces are passing the checks. Also, test scenarios that cover the fixed issue have been introduced.

These rules have been fixed:
- rsyslog_encrypt_offload_actionsendstreamdriverauthmode
- rsyslog_encrypt_offload_actionsendstreamdrivermode
- rsyslog_encrypt_offload_defaultnetstreamdriver

Fixes: https://github.com/ComplianceAsCode/content/issues/14554


