### PR TITLE
Prevent Ansible Playbook termination in check mode

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
@@ -57,6 +57,6 @@
     name: auditd.service
     state: restarted
   when:
-    - ansible_facts.services["auditd.service"].state == "running"
+    - '"auditd.service" in ansible_facts.services and ansible_facts.services["auditd.service"].state == "running"'
     - (augenrules_syscall_auditing_rule_update_result.changed or
        auditctl_syscall_auditing_rule_update_result.changed)

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
@@ -57,6 +57,7 @@
     name: auditd.service
     state: restarted
   when:
-    - '"auditd.service" in ansible_facts.services and ansible_facts.services["auditd.service"].state == "running"'
+    - ("auditd.service" in ansible_facts.services and
+       ansible_facts.services["auditd.service"].state == "running")
     - (augenrules_syscall_auditing_rule_update_result.changed or
        auditctl_syscall_auditing_rule_update_result.changed)

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
@@ -67,4 +67,4 @@
   when:
     - (augenrules_audit_rules_privilege_function_update_result.changed or
        auditctl_audit_rules_privilege_function_update_result.changed)
-    - ansible_facts.services["auditd.service"].state == "running"
+    - '"auditd.service" in ansible_facts.services and ansible_facts.services["auditd.service"].state == "running"'

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
@@ -67,4 +67,5 @@
   when:
     - (augenrules_audit_rules_privilege_function_update_result.changed or
        auditctl_audit_rules_privilege_function_update_result.changed)
-    - '"auditd.service" in ansible_facts.services and ansible_facts.services["auditd.service"].state == "running"'
+    - ("auditd.service" in ansible_facts.services and
+       ansible_facts.services["auditd.service"].state == "running")

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -68,4 +68,5 @@
   when:
     - (augenrules_audit_rules_privilege_function_update_result.changed or
        auditctl_audit_rules_privilege_function_update_result.changed)
-    - '"auditd.service" in ansible_facts.services and ansible_facts.services["auditd.service"].state == "running"'
+    - ("auditd.service" in ansible_facts.services and
+       ansible_facts.services["auditd.service"].state == "running")

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -68,4 +68,4 @@
   when:
     - (augenrules_audit_rules_privilege_function_update_result.changed or
        auditctl_audit_rules_privilege_function_update_result.changed)
-    - ansible_facts.services["auditd.service"].state == "running"
+    - '"auditd.service" in ansible_facts.services and ansible_facts.services["auditd.service"].state == "running"'

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
@@ -20,4 +20,5 @@
   ansible.builtin.systemd:
     name: vsftpd.service
     state: restarted
-  when: banner_file_update_result.changed and "vsftpd.service" in ansible_facts.services and ansible_facts.services["vsftpd.service"].state == "running"
+  when: (banner_file_update_result.changed and "vsftpd.service" in ansible_facts.services
+         and ansible_facts.services["vsftpd.service"].state == "running")

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
@@ -20,4 +20,4 @@
   ansible.builtin.systemd:
     name: vsftpd.service
     state: restarted
-  when: banner_file_update_result.changed and ansible_facts.services["vsftpd.service"].state == "running"
+  when: banner_file_update_result.changed and "vsftpd.service" in ansible_facts.services and ansible_facts.services["vsftpd.service"].state == "running"

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -17,7 +17,8 @@
 - name: '{{{ rule_title }}} - Collect facts about system services'
   ansible.builtin.service_facts:
 
-- name: '{{{ rule_title }}} - Remediation is applicable if firewalld and NetworkManager services are running'
+- name: '{{{ rule_title }}} - Remediation is applicable if firewalld and
+    NetworkManager services are running'
   block:
     - name: '{{{ rule_title }}} - Collect NetworkManager connections names'
       ansible.builtin.shell:
@@ -34,7 +35,7 @@
       changed_when: false
       failed_when: false
       with_items:
-          - "{{ result_nmcli_cmd_connections_names.stdout_lines | default([]) }}"
+        - "{{ result_nmcli_cmd_connections_names.stdout_lines | default([]) }}"
       when:
         - result_nmcli_cmd_connections_names.stdout_lines is defined
         - result_nmcli_cmd_connections_names.stdout_lines | length > 0
@@ -59,7 +60,8 @@
       when:
         - result_nmcli_cmd_zone_assignment is defined
         - result_nmcli_cmd_zone_assignment is changed
-        - result_nmcli_cmd_zone_assignment.results | selectattr('changed', 'equalto', true) | list | length > 0
+        - (result_nmcli_cmd_zone_assignment.results | selectattr('changed', 'equalto', true) |
+           list | length > 0)
 
     - name: '{{{ rule_title }}} - Collect firewalld active zones'
       ansible.builtin.shell:
@@ -82,17 +84,22 @@
         - result_firewall_cmd_zones_names.stdout_lines is defined
         - result_firewall_cmd_zones_names.stdout_lines | length > 0
   when:
-    - "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
-    - "'NetworkManager.service' in ansible_facts.services and ansible_facts.services['NetworkManager.service'].state == 'running'"
+    - ('firewalld.service' in ansible_facts.services and
+       ansible_facts.services['firewalld.service'].state == 'running')
+    - ('NetworkManager.service' in ansible_facts.services and
+       ansible_facts.services['NetworkManager.service'].state == 'running')
 
 - name: '{{{ rule_title }}} - Informative message based on services states'
   ansible.builtin.assert:
     that:
-      - "ansible_check_mode or ('firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running')"
-      - "ansible_check_mode or ('NetworkManager.service' in ansible_facts.services and ansible_facts.services['NetworkManager.service'].state == 'running')"
+      - (ansible_check_mode or ('firewalld.service' in ansible_facts.services and
+         ansible_facts.services['firewalld.service'].state == 'running'))
+      - (ansible_check_mode or ('NetworkManager.service' in ansible_facts.services and
+         ansible_facts.services['NetworkManager.service'].state == 'running'))
     fail_msg:
       - firewalld and NetworkManager services are not active. Remediation aborted!
-      - This remediation could not be applied because it depends on firewalld and NetworkManager services running.
+      - This remediation could not be applied because it depends on firewalld
+      - and NetworkManager services running.
       - The service is not started by this remediation in order to prevent connection issues.
     success_msg:
       - {{{ rule_title }}} remediation successfully executed

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -82,14 +82,14 @@
         - result_firewall_cmd_zones_names.stdout_lines is defined
         - result_firewall_cmd_zones_names.stdout_lines | length > 0
   when:
-    - ansible_facts.services['firewalld.service'].state == 'running'
-    - ansible_facts.services['NetworkManager.service'].state == 'running'
+    - "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
+    - "'NetworkManager.service' in ansible_facts.services and ansible_facts.services['NetworkManager.service'].state == 'running'"
 
 - name: '{{{ rule_title }}} - Informative message based on services states'
   ansible.builtin.assert:
     that:
-      - ansible_check_mode or ansible_facts.services['firewalld.service'].state == 'running'
-      - ansible_check_mode or ansible_facts.services['NetworkManager.service'].state == 'running'
+      - "ansible_check_mode or ('firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running')"
+      - "ansible_check_mode or ('NetworkManager.service' in ansible_facts.services and ansible_facts.services['NetworkManager.service'].state == 'running')"
     fail_msg:
       - firewalld and NetworkManager services are not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld and NetworkManager services running.

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
@@ -38,12 +38,12 @@
       when:
         - result_trusted_ipv4_restriction is changed or result_trusted_ipv6_restriction is changed
   when:
-    - ansible_facts.services['firewalld.service'].state == 'running'
+    - "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
 
 - name: '{{{ rule_title }}} - Informative Message Based on Service State'
   ansible.builtin.assert:
     that:
-      - ansible_check_mode or ansible_facts.services['firewalld.service'].state == 'running'
+      - "ansible_check_mode or ('firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running')"
     fail_msg:
       - firewalld service is not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld service running.

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
@@ -25,7 +25,7 @@
           destination not address="127.0.0.1" drop'
       register: result_trusted_ipv4_restriction
       changed_when:
-          - "'ALREADY_ENABLED' not in result_trusted_ipv4_restriction.stderr"
+        - "'ALREADY_ENABLED' not in result_trusted_ipv4_restriction.stderr"
 
     - name: '{{{ rule_title }}} - Ensure firewalld trusted Zone Restricts IPv6 Loopback Traffic'
       ansible.builtin.command:
@@ -35,7 +35,7 @@
           destination not address="::1" drop'
       register: result_trusted_ipv6_restriction
       changed_when:
-          - "'ALREADY_ENABLED' not in result_trusted_ipv6_restriction.stderr"
+        - "'ALREADY_ENABLED' not in result_trusted_ipv6_restriction.stderr"
 
     - name: '{{{ rule_title }}} - Ensure firewalld Changes are Applied'
       ansible.builtin.service:

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
@@ -19,14 +19,20 @@
   block:
     - name: '{{{ rule_title }}} - Ensure firewalld trusted Zone Restricts IPv4 Loopback Traffic'
       ansible.builtin.command:
-        cmd: firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'
+        cmd: >-
+          firewall-cmd --permanent --zone=trusted
+          --add-rich-rule='rule family=ipv4 source address="127.0.0.1"
+          destination not address="127.0.0.1" drop'
       register: result_trusted_ipv4_restriction
       changed_when:
           - "'ALREADY_ENABLED' not in result_trusted_ipv4_restriction.stderr"
 
     - name: '{{{ rule_title }}} - Ensure firewalld trusted Zone Restricts IPv6 Loopback Traffic'
       ansible.builtin.command:
-        cmd: firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv6 source address="::1" destination not address="::1" drop'
+        cmd: >-
+          firewall-cmd --permanent --zone=trusted
+          --add-rich-rule='rule family=ipv6 source address="::1"
+          destination not address="::1" drop'
       register: result_trusted_ipv6_restriction
       changed_when:
           - "'ALREADY_ENABLED' not in result_trusted_ipv6_restriction.stderr"
@@ -38,12 +44,14 @@
       when:
         - result_trusted_ipv4_restriction is changed or result_trusted_ipv6_restriction is changed
   when:
-    - "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
+    - ('firewalld.service' in ansible_facts.services
+       and ansible_facts.services['firewalld.service'].state == 'running')
 
 - name: '{{{ rule_title }}} - Informative Message Based on Service State'
   ansible.builtin.assert:
     that:
-      - "ansible_check_mode or ('firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running')"
+      - (ansible_check_mode or ('firewalld.service' in ansible_facts.services and
+         ansible_facts.services['firewalld.service'].state == 'running'))
     fail_msg:
       - firewalld service is not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld service running.

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
@@ -21,7 +21,7 @@
         cmd: firewall-cmd --permanent --zone=trusted --add-interface=lo
       register: result_lo_interface_assignment
       changed_when:
-          - "'ALREADY_ENABLED' not in result_lo_interface_assignment.stderr"
+        - "'ALREADY_ENABLED' not in result_lo_interface_assignment.stderr"
 
     - name: '{{{ rule_title }}} - Ensure firewalld Changes are Applied'
       ansible.builtin.service:

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
@@ -30,12 +30,14 @@
       when:
         - result_lo_interface_assignment is changed
   when:
-    - "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
+    - ('firewalld.service' in ansible_facts.services and
+       ansible_facts.services['firewalld.service'].state == 'running')
 
 - name: '{{{ rule_title }}} - Informative Message Based on Service State'
   ansible.builtin.assert:
     that:
-      - "ansible_check_mode or ('firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running')"
+      - (ansible_check_mode or ('firewalld.service' in ansible_facts.services
+         and ansible_facts.services['firewalld.service'].state == 'running'))
     fail_msg:
       - firewalld service is not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld service running.

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
@@ -30,12 +30,12 @@
       when:
         - result_lo_interface_assignment is changed
   when:
-    - ansible_facts.services['firewalld.service'].state == 'running'
+    - "'firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running'"
 
 - name: '{{{ rule_title }}} - Informative Message Based on Service State'
   ansible.builtin.assert:
     that:
-      - ansible_check_mode or ansible_facts.services['firewalld.service'].state == 'running'
+      - "ansible_check_mode or ('firewalld.service' in ansible_facts.services and ansible_facts.services['firewalld.service'].state == 'running')"
     fail_msg:
       - firewalld service is not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld service running.

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -13,7 +13,8 @@
   ansible.builtin.command: wicked ifdown {{ item }}
   loop: '{{ ansible_facts.interfaces }}'
   when:
-    - "'wickedd.service' in ansible_facts.services and ansible_facts.services['wickedd.service'].state == 'running'"
+    - ('wickedd.service' in ansible_facts.services and
+       ansible_facts.services['wickedd.service'].state == 'running')
     - 'item.startswith("wl")'
 
 - name: "{{{ rule_title }}} - Wicked Disable Wireless Network Interfaces"
@@ -23,7 +24,8 @@
     line: STARTMODE=off
   loop: '{{ ansible_facts.interfaces }}'
   when:
-    - "'wickedd.service' in ansible_facts.services and ansible_facts.services['wickedd.service'].state == 'running'"
+    - ('wickedd.service' in ansible_facts.services and
+       ansible_facts.services['wickedd.service'].state == 'running')
     - 'item.startswith("wl")'
 {{%- else %}}
 
@@ -40,4 +42,5 @@
   ansible.builtin.command: nmcli radio wifi off
   when:
     - "'NetworkManager' in ansible_facts.packages"
-    - "'NetworkManager.service' in ansible_facts.services and ansible_facts.services['NetworkManager.service'].state == 'running'"
+    - ('NetworkManager.service' in ansible_facts.services and
+       ansible_facts.services['NetworkManager.service'].state == 'running')

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -13,7 +13,7 @@
   ansible.builtin.command: wicked ifdown {{ item }}
   loop: '{{ ansible_facts.interfaces }}'
   when:
-    - ansible_facts.services['wickedd.service'].state == 'running'
+    - "'wickedd.service' in ansible_facts.services and ansible_facts.services['wickedd.service'].state == 'running'"
     - 'item.startswith("wl")'
 
 - name: "{{{ rule_title }}} - Wicked Disable Wireless Network Interfaces"
@@ -23,7 +23,7 @@
     line: STARTMODE=off
   loop: '{{ ansible_facts.interfaces }}'
   when:
-    - ansible_facts.services['wickedd.service'].state == 'running'
+    - "'wickedd.service' in ansible_facts.services and ansible_facts.services['wickedd.service'].state == 'running'"
     - 'item.startswith("wl")'
 {{%- else %}}
 
@@ -40,4 +40,4 @@
   ansible.builtin.command: nmcli radio wifi off
   when:
     - "'NetworkManager' in ansible_facts.packages"
-    - ansible_facts.services['NetworkManager.service'].state == 'running'
+    - "'NetworkManager.service' in ansible_facts.services and ansible_facts.services['NetworkManager.service'].state == 'running'"


### PR DESCRIPTION
Some Ansible Playbooks are terminating prematurely on some Ansible Tasks where the `when` statement assumes that a systemd service is installed. In normal mode, the installation is performed by other tasks, but in check mode, the installation isn't executed and the service isn't installed at the moment of checking the service state. This manifests in the test
`/scanning/host-os/ansible-check/check-mode`.

Addressing:
```
Configure Firewalld to Restrict Loopback Traffic - Ensure firewalld
trusted Zone Restricts IPv4 Loopback Traffic ({"msg": "The conditional
check 'ansible_facts.services['firewalld.service'].state == 'running''
failed. The error was: error while evaluating conditional
(ansible_facts.services['firewalld.service'].state == 'running'): 'dict
object' has no attribute 'firewalld.service'. 'dict object' has no
attribute 'firewalld.service'\n\nThe error appears to be in
'/usr/share/scap-security-guide/ansible/centos8-playbook-pci-dss.yml':
line 10070, column 7, but may\nbe elsewhere in the file depending on the
exact syntax problem.\n\nThe offending line appears to be:\n\n\n    -
name: Configure Firewalld to Restrict Loopback Traffic - Ensure
firewalld trusted\n      ^ here\n"})
```


#### Review Hints:

Check that the tests testing-farm:centos-stream-{8,9,10}-x86_64:contest-other pass.
