### PR TITLE
SLE16 fix ensure_logrotate_activated to work with /etc configuration

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -4,10 +4,9 @@
 # complexity = low
 # disruption = low
 
-{{% if product == 'sle16' %}}
-{{% set LOGROTATE_CONF_FILE="/usr/etc/logrotate.conf" %}}
-{{% else %}}
 {{% set LOGROTATE_CONF_FILE="/etc/logrotate.conf" %}}
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ ansible_copy_distro_defaults('/usr/etc/logrotate.conf', LOGROTATE_CONF_FILE, rule_title) }}}
 {{% endif %}}
 
 - name: "Configure daily log rotation in {{{ LOGROTATE_CONF_FILE }}}"

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -1,10 +1,11 @@
 # platform = multi_platform_all
 
-{{% if product == 'sle16' %}}
-LOGROTATE_CONF_FILE='/usr/etc/logrotate.conf'
-{{% else %}}
 LOGROTATE_CONF_FILE='/etc/logrotate.conf'
+
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults('/usr/etc/logrotate.conf', "${LOGROTATE_CONF_FILE}") }}}
 {{% endif %}}
+
 {{% if 'sle' in product or product == 'slmicro5' %}}
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 {{% else %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
@@ -25,11 +25,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_logrotate_conf_daily_setting" version="2">
-{{% if product == 'sle16' %}}
-    <ind:filepath>/usr/etc/logrotate.conf</ind:filepath>
-{{% else %}}
     <ind:filepath>/etc/logrotate.conf</ind:filepath>
-{{% endif %}}
     <ind:pattern operation="pattern match">^\s*daily[\s#]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -41,11 +37,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_logrotate_conf_no_other_keyword" version="2">
-{{% if product == 'sle16' %}}
-    <ind:filepath>/usr/etc/logrotate.conf</ind:filepath>
-{{% else %}}
     <ind:filepath>/etc/logrotate.conf</ind:filepath>
-{{% endif %}}
     <ind:pattern operation="pattern match">^\s*(weekly|monthly|yearly)[\s#]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_extra_monthly.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_extra_monthly.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # packages = logrotate,crontabs
+LOGROTATE_CONF_FILE="/etc/logrotate.conf"
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults('/usr/etc/logrotate.conf', "${LOGROTATE_CONF_FILE}") }}}
+{{% endif %}}
 
-sed -i "s/weekly/daily/g" /etc/logrotate.conf
-echo "monthly" >> /etc/logrotate.conf
+sed -i "s/weekly/daily/g" "${LOGROTATE_CONF_FILE}"
+echo "monthly" >> "${LOGROTATE_CONF_FILE}"

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_weekly.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_weekly.fail.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-{{% if product == 'sle16' %}}
-LOGROTATE_CONF_FILE="/usr/etc/logrotate.conf"
-{{% else %}}
 LOGROTATE_CONF_FILE="/etc/logrotate.conf"
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults('/usr/etc/logrotate.conf', "${LOGROTATE_CONF_FILE}") }}}
 {{% endif %}}
 sed -i "s/daily/weekly/" "${LOGROTATE_CONF_FILE}"

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# platform = Oracle Linux 7,Oracle Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,SUSE Linux Enterprise 16
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults('/usr/etc/logrotate.conf', '/etc/logrotate.conf') }}}
+{{% endif %}}
 # fix logrotate config
 sed -i "s/\(weekly\|monthly\|yearly\)/daily/" /etc/logrotate.conf
 

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_missing.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+
+if [ -e "/etc/logrotate.conf" ] ; then
+    rm "/etc/logrotate.conf"
+fi

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_config.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_config.fail.sh
@@ -2,5 +2,9 @@
 
 # packages = logrotate,crontabs
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults('/usr/etc/logrotate.conf', '/etc/logrotate.conf') }}}
+{{% endif %}}
+
 sed -i "/^\s*(daily|weekly|monthly|yearly)/d" /etc/logrotate.conf
 rm -f /etc/cron.daily/logrotate

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily_no_timer.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily_no_timer.fail.sh
@@ -2,10 +2,10 @@
 
 # packages = logrotate,crontabs
 
-{{% if product == 'sle16' %}}
-LOGROTATE_CONF_FILE="/usr/etc/logrotate.conf"
-{{% else %}}
 LOGROTATE_CONF_FILE="/etc/logrotate.conf"
+
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults('/usr/etc/logrotate.conf', "${LOGROTATE_CONF_FILE}") }}}
 {{% endif %}}
 
 # disable the timer


### PR DESCRIPTION
#### Description:

- Make sure on sle16 we use /etc to apply and verify compliance to the rule, while /usr/etc maight be use only in case /etc files do not exist

#### Rationale:

- Change oval to work with /etc folder
- add test of missing configuration file in /etc folder
- make sure remediations copy defulat config from /usr/etc but apply in /etc

#### Review Hints:

Needs PR #14438 to be integrated to use the appropriate macros
