### PR TITLE
Change crypto policy requirement for Hummingbird images

### DIFF
--- a/components/crypto-policies.yml
+++ b/components/crypto-policies.yml
@@ -13,6 +13,7 @@ rules:
 - configure_openssl_tls_crypto_policy
 - configure_ssh_crypto_policy
 - configure_custom_crypto_policy_cis
+- crypto_policy_not_legacy
 - harden_openssl_crypto_policy
 - harden_ssh_client_crypto_policy
 - harden_sshd_ciphers_openssh_conf_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/crypto_policy_not_legacy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/crypto_policy_not_legacy/oval/shared.xml
@@ -1,0 +1,86 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure crypto policy is correctly configured in /etc/crypto-policies/config, and the policy is current.", rule_title=rule_title) }}}
+    <criteria operator="AND">
+      <criterion comment="check for crypto policy correctly configured in /etc/crypto-policy/config"
+      test_ref="test_{{{ rule_id }}}" />
+      <criterion comment="check for crypto policy correctly configured in /etc/crypto-policy/state/current"
+      test_ref="test_{{{ rule_id }}}_current" />
+      <criterion comment="Check if update-crypto-policies has been run after config update" test_ref="test_{{{ rule_id }}}_crypto_policies_updated" />
+      <criterion comment="Check if /etc/crypto-policies/back-ends/nss.config exists" test_ref="test_{{{ rule_id }}}_crypto_policy_nss_config" />
+    </criteria>
+  </definition>
+
+  <unix:file_object id="object_{{{ rule_id }}}_current_file" comment="crypto-policies current state" version="1">
+    <unix:filepath>/etc/crypto-policies/state/current</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_object id="object_{{{ rule_id }}}_crypto_policies_config_file" comment="crypto-policies config state" version="1">
+    <unix:filepath datatype="string">/etc/crypto-policies/config</unix:filepath>
+  </unix:file_object>
+
+  <local_variable id="variable_{{{ rule_id }}}_current_file_timestamp" version="1" comment="Age of /etc/crypto-policies/state/current" datatype="int">
+    <object_component object_ref="object_{{{ rule_id }}}_current_file" item_field="m_time"/>
+  </local_variable>
+
+  <local_variable id="variable_{{{ rule_id }}}_crypto_policies_config_file_timestamp" version="1" comment="Age of /etc/crypto-policies/config" datatype="int">
+    <object_component object_ref="object_{{{ rule_id }}}_crypto_policies_config_file" item_field="m_time"/>
+  </local_variable>
+
+  <ind:variable_test check="all" check_existence="all_exist" id="test_{{{ rule_id }}}_crypto_policies_updated" version="1" comment="Check if update-crypto-policies has been run">
+    <ind:object object_ref="object_{{{ rule_id }}}_crypto_policies_config_file_modified_time" />
+    <ind:state state_ref="state_{{{ rule_id }}}_crypto_current_file_newer_than_config_file" />
+  </ind:variable_test>
+
+  <ind:variable_object comment="Crypto policy current file timestamp"
+id="object_{{{ rule_id }}}_crypto_policies_config_file_modified_time" version="1">
+     <ind:var_ref>variable_{{{ rule_id }}}_crypto_policies_config_file_timestamp</ind:var_ref>
+   </ind:variable_object>
+
+  <ind:variable_state id="state_{{{ rule_id }}}_crypto_current_file_newer_than_config_file" version="1">
+    <ind:value datatype="int" operation="less than or equal" var_check="all"
+    var_ref="variable_{{{ rule_id }}}_current_file_timestamp" />
+  </ind:variable_state>
+
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}"
+  comment="check for crypto policy correctly configured in /etc/crypto-policies/config"
+  check="all" check_existence="only_one_exists" version="1">
+    <ind:object object_ref="object_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/crypto-policies/config</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!#)(\S+)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
+    <ind:subexpression operation="not equal">LEGACY</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+    <ind:textfilecontent54_test id="test_{{{ rule_id }}}_current"
+  comment="check for crypto policy correctly configured in /etc/crypto-policies/state/current"
+  check="all" check_existence="only_one_exists" version="1">
+    <ind:object object_ref="object_{{{ rule_id }}}_current" />
+    <ind:state state_ref="state_{{{ rule_id }}}_current" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}_current" version="1">
+    <ind:filepath>/etc/crypto-policies/state/current</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!#)(\S+)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_current" version="1">
+    <ind:subexpression operation="not equal">LEGACY</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /etc/crypto-policies/back-ends/nss.config exists" id="test_{{{ rule_id }}}_crypto_policy_nss_config" version="1">
+    <unix:object object_ref="object_{{{ rule_id }}}_crypto_policy_nss_config" />
+  </unix:file_test>
+  <unix:file_object id="object_{{{ rule_id }}}_crypto_policy_nss_config" version="1">
+    <unix:filepath>/etc/crypto-policies/back-ends/nss.config</unix:filepath>
+  </unix:file_object>
+
+</def-group>

--- a/linux_os/guide/system/software/integrity/crypto/crypto_policy_not_legacy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/crypto_policy_not_legacy/rule.yml
@@ -1,0 +1,68 @@
+documentation_complete: true
+
+title: Ensure system wide crypto policy is not set to legacy
+
+description: >-
+    When a system-wide policy is set up, the default behavior of applications will be to
+    follow the policy. Applications will be unable to use algorithms and protocols that do not
+    meet the policy, unless you explicitly request the application to do so.
+
+    The system-wide crypto-policies followed by the crypto core components allow
+    consistently deprecating and disabling algorithms system-wide.
+    The <tt>LEGACY</tt> policy ensures maximum compatibility with legacy systems at the cost
+    of being less secure. It allows the TLS 1.2, and TLS 1.3 protocols, as well as IKEv2 and
+    SSH2. DSA is not allowed, while RSA and Diffie-Hellman parameters are accepted if no
+    less than 2048 bits. This policy provides at least 80-bit security.
+
+    The rule checks if settings for selected crypto policy are configured as expected.
+    Configuration files in the <tt>/etc/crypto-policies/back-ends</tt> are either symlinks
+    to correct files provided by crypto-policies package or they are regular files in case
+    crypto policy customizations are applied. Crypto policies may be customized by crypto
+    policy modules, in which case it is delimited from the base policy using a colon.
+
+rationale: >-
+    Centralized cryptographic policies simplify applying secure ciphers across an operating system and
+    the applications that run on that operating system. Use of weak or untested encryption algorithms
+    undermines the purposes of utilizing encryption to protect data.
+    The <tt>LEGACY</tt> system-wide crypto policy includes support for outdated and weakened
+    algorithms to ensure maximum compatibility with Red Hat Enterprise Linux 6 and
+    earlier; it is less secure due to an increased attack surface.
+
+severity: high
+
+ocil_clause: 'cryptographic policy is set to LEGACY'
+
+ocil: |-
+    To verify that cryptography policy has been configured correctly, run the
+    following command:
+    <pre>$ update-crypto-policies --show</pre>
+    The output should not return <pre>LEGACY</pre>.
+    Run the command to check if the policy is correctly applied:
+    <pre>$ update-crypto-policies --is-applied</pre>
+    The output should be <pre>The configured policy is applied</pre>.
+    Moreover, check if settings for selected crypto policy are as expected.
+    List all libraries for which it holds that their crypto policies do not have
+    symbolic link in <pre>/etc/crypto-policies/back-ends</pre>.
+    <pre>$ ls -l /etc/crypto-policies/back-ends/ | grep '^[^l]' | tail -n +2 | awk -F' ' '{print $NF}' | awk -F'.' '{print $1}' | sort</pre>
+    Subsequently, check if matching libraries have drop in files in the <pre>/etc/crypto-policies/local.d</pre> directory.
+    <pre>$ ls /etc/crypto-policies/local.d/ | awk -F'-' '{print $1}' | uniq | sort</pre>
+    Outputs of two previous commands should match.
+
+warnings:
+    - regulatory: |-
+        System Crypto Modules must be provided by a vendor that undergoes
+        FIPS-140 certifications.
+        FIPS-140 is applicable to all Federal agencies that use
+        cryptographic-based security systems to protect sensitive information
+        in computer and telecommunication systems (including voice systems) as
+        defined in Section 5131 of the Information Technology Management Reform
+        Act of 1996, Public Law 104-106. This standard shall be used in
+        designing and implementing cryptographic modules that Federal
+        departments and agencies operate or are operated for them under
+        contract. See <b>{{{ weblink(link="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf") }}}</b>
+        To meet this, the system has to have cryptographic software provided by
+        a vendor that has undergone this certification. This means providing
+        documentation, test results, design information, and independent third
+        party review by an accredited lab. While open source software is
+        capable of meeting this, it does not meet FIPS-140 unless the vendor
+        submits to this process.

--- a/products/hummingbird/controls/cis_hummingbird.yml
+++ b/products/hummingbird/controls/cis_hummingbird.yml
@@ -474,8 +474,7 @@ controls:
           - l1_workstation
       status: automated
       rules:
-          - configure_crypto_policy
-          - var_system_crypto_policy=default_policy
+          - crypto_policy_not_legacy
 
     - id: 1.6.2
       title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
@@ -484,8 +483,7 @@ controls:
           - l1_workstation
       status: automated
       rules:
-          - configure_crypto_policy
-          - var_system_crypto_policy=default_policy
+          - crypto_policy_not_legacy
 
     - id: 1.6.3
       title: Ensure system wide crypto policy macs are configured (Automated)
@@ -494,8 +492,7 @@ controls:
           - l1_workstation
       status: automated
       rules:
-          - configure_crypto_policy
-          - var_system_crypto_policy=default_policy
+          - crypto_policy_not_legacy
 
     - id: 1.6.4
       title: Ensure system wide crypto policy disables cbc for ssh (Automated)


### PR DESCRIPTION
This commit changes the expected crypto policy settings in the CIS profile for Hummingbird container images.
    
Hummingbird provides images in 2 basic variants:
1. normal (eg. `:latest`) - has the crypto policy set to `DEFAULT`
2. FIPS (eg. `:latest-fips`) - has the crypto policy set to `FIPS`.
    
CIS Benchmarks typically require that the crypto policy isn't set to `LEGACY`. Following these requirements, both variants of Hummingbird images are compliant with CIS. Both `DEFAULT` and `FIPS` crypto policy satisfy the requirement.
    
This commit make both variants of images passing the CIS profile by selecting new rule `crypto_policy_not_legacy` in the profile instead of the usual rule `configure_crypto_policy`. The new rule is created in this commit as well.




#### Review Hints:

1. `./build_product -d hummingbird`
2. `mkdir -p /tmp/ssg/`
3. `cp build/ssg-hummingbird-ds.xml /tmp/ssg`
4. `podman run --rm   --cap-add SYS_CHROOT   --mount type=image,source=quay.io/hummingbird/nginx:latest,destination=/target -e OSCAP_PROBE_ROOT=/target -v /tmp/ssg:/ssg:z,U quay.io/hummingbird/openscap:latest xccdf eval --profile cis --results-arf /ssg/results.xml --report /ssg/report.html /ssg/ssg-hummingbird-ds.xml`
5. `podman run --rm   --cap-add SYS_CHROOT   --mount type=image,source=quay.io/hummingbird/nginx:latest-fips,destination=/target -e OSCAP_PROBE_ROOT=/target -v /tmp/ssg:/ssg:z,U quay.io/hummingbird/openscap:latest xccdf eval --profile cis --results-arf /ssg/results-fips.xml --report /ssg/report-fips.html /ssg/ssg-hummingbird-ds.xml`