### PR TITLE
Add var_system_crypto_policy to RHEL9 STIG profiles

### DIFF
--- a/products/rhel9/controls/stig_rhel9.yml
+++ b/products/rhel9/controls/stig_rhel9.yml
@@ -592,6 +592,7 @@ controls:
           - configure_crypto_policy
           - fips_crypto_subpolicy
           - fips_custom_stig_sub_policy
+          - var_system_crypto_policy=fips_stig
       status: automated
 
     - id: RHEL-09-231010

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -540,6 +540,7 @@ var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
 var_sudo_timestamp_timeout=always_prompt
+var_system_crypto_policy=fips_stig
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -538,6 +538,7 @@ var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
 var_sudo_timestamp_timeout=always_prompt
+var_system_crypto_policy=fips_stig
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces


### PR DESCRIPTION


#### Description:
Add `var_system_crypto_policy` in RHEL 9 STIG and set it to `FIPS:STIG`

#### Rationale:
Fixes #14669
#### Review Hints:
Review the issue above for reproducer.