### PR TITLE
Fix pam_faillock_conf_path for sle16

### DIFF
--- a/tests/data/product_stability/sle16.yml
+++ b/tests/data/product_stability/sle16.yml
@@ -46,7 +46,7 @@ nobody_gid: 65534
 nobody_uid: 65534
 openssh_client_crypto_policy_config_file: /etc/crypto-policies/back-ends/openssh.config
 openssh_server_crypto_policy_config_file: /etc/crypto-policies/back-ends/opensshserver.config
-pam_faillock_conf_path: /usr/etc/security/faillock.conf
+pam_faillock_conf_path: /etc/security/faillock.conf
 pkg_manager: zypper
 pkg_manager_config_file: /etc/zypp/zypp.conf
 pkg_system: rpm


### PR DESCRIPTION
#### Description:

Fix pam_faillock_conf_path for sle16

#### Rationale:

Fix nightly build.
