### PR TITLE
Sle16 update sudoers related rules checks and remediations

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/etc_sudoers.missing.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/etc_sudoers.missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+if [ -e "/etc/sudoers" ] ; then
+    rm "/etc/sudoers"
+fi
+echo "Defaults noexec" >> /etc/sudoers.d/enable_noexec

--- a/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/noexec_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/noexec_absent.fail.sh
@@ -2,6 +2,9 @@
 # platform = multi_platform_all
 
 touch /etc/sudoers.d/empty
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Code taken from macro bash_sudo_remove_config()
 for f in /etc/sudoers /etc/sudoers.d/*; do
   if [ ! -e "$f" ]; then

--- a/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/noexec_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/noexec_enabled_dir.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_all
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 echo "Defaults noexec" >> /etc/sudoers.d/enable_noexec

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/etc_sudoers_missing.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/etc_sudoers_missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+if [ -e "/etc/sudoers" ] ; then
+    rm "/etc/sudoers"
+fi
+echo "Defaults use_pty" >> /etc/sudoers.d/enable_use_pty

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_absent.fail.sh
@@ -3,6 +3,9 @@
 # packages = sudo
 
 touch /etc/sudoers.d/empty
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Code taken from macro bash_sudo_remove_config()
 for f in /etc/sudoers /etc/sudoers.d/*; do
   [ -e "$f" ] || continue

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_disabled.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_disabled.fail.sh
@@ -2,5 +2,8 @@
 # platform = multi_platform_all
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 sed '/Defaults.*use_pty/ s/.*/#&/g' -i /etc/sudoers /etc/sudoers.d/*
 echo "Defaults !use_pty" >> /etc/sudoers.d/enable_use_pty

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled_dir.pass.sh
@@ -2,4 +2,7 @@
 # platform = multi_platform_all
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 echo "Defaults use_pty" >> /etc/sudoers.d/enable_use_pty

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/etc_sudoers_missing.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/etc_sudoers_missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+if [ -e "/etc/sudoers" ] ; then
+    rm "/etc/sudoers"
+fi
+echo "Defaults logfile=/var/log/sudo.log" >> /etc/sudoers.d/enable_logfile

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
@@ -3,6 +3,9 @@
 # packages = sudo
 
 touch /etc/sudoers.d/empty
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Code taken from macro bash_sudo_remove_config()
 for f in /etc/sudoers /etc/sudoers.d/*; do
   if [ ! -e "$f" ]; then

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_dir.pass.sh
@@ -2,4 +2,7 @@
 # platform = multi_platform_all
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 echo "Defaults logfile=/var/log/sudo.log" >> /etc/sudoers.d/enable_logfile

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/ansible/shared.yml
@@ -4,6 +4,19 @@
 # complexity = low
 # disruption = low
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ ansible_copy_distro_defaults('/usr/etc/sudoers', '/etc/sudoers', rule_title=rule_title) }}}
+{{{
+    ansible_lineinfile(
+        rule_title + " - Remove /usr/etc/sudoers.d include directive from /etc/sudoers",
+        path="/etc/sudoers",
+        regex='^\s*@includedir\s+/usr/etc/sudoers.d',
+        state="absent",
+        when="not ansible_check_mode"
+    )
+}}}
+{{% endif %}}
+
 {{{ ansible_sudo_remove_config("NOPASSWD", "NOPASSWD[\s]*\:") }}}
 
 {{{ ansible_sudo_remove_config("!authenticate", "\!authenticate") }}}

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/bash/shared.sh
@@ -4,6 +4,10 @@
 # complexity = low
 # disruption = low
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults("/usr/etc/sudoers", "/etc/sudoers") }}}
+{{{ lineinfile_absent("/etc/sudoers", "^\s*@includedir\s*/usr/etc/sudoers\.d", sed_path_separator="#", rule_id=rule_id) }}}
+{{% endif %}}
 {{{ bash_sudo_remove_config("NOPASSWD", "NOPASSWD[\s]*\:") }}}
 
 {{{ bash_sudo_remove_config("!authenticate", "\!authenticate") }}}

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
@@ -4,6 +4,15 @@
     <criteria operator="AND">
       <extend_definition definition_ref="sudo_remove_no_authenticate" />
       <extend_definition definition_ref="sudo_remove_nopasswd" />
+      {{% if product in [ 'sle16', 'slmicro6' ] %}}
+      <criterion
+          comment="test if configuration file /etc/sudoers exists for {{{ rule_id }}}"
+          test_ref="test_{{{ rule_id }}}_config_file_exists"/>
+      {{% endif %}}
     </criteria>
   </definition>
+  {{% if product in [ 'sle16', 'slmicro6' ] %}}
+  {{{ oval_config_file_exists_test('/etc/sudoers', rule_id=rule_id) }}}
+  {{{ oval_config_file_exists_object('/etc/sudoers', rule_id=rule_id) }}}
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/authenticate_disabled_include_dir.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/authenticate_disabled_include_dir.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+touch /etc/sudoers
+echo "Defaults !authenticate" > /etc/sudoers.d/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/etc_sudoers_missing.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/etc_sudoers_missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+if [ -e "/etc/sudoers" ] ; then
+    rm "/etc/sudoers"
+fi
+echo "Defaults authenticate" > /etc/sudoers.d/authenticate

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/nopasswd_include_dir.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/nopasswd_include_dir.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+touch /etc/sudoers
+echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
@@ -6,6 +6,19 @@
 
 {{{ ansible_instantiate_variables("var_sudo_timestamp_timeout") }}}
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ ansible_copy_distro_defaults('/usr/etc/sudoers', '/etc/sudoers', rule_title=rule_title) }}}
+{{{
+    ansible_lineinfile(
+        rule_title + " - Remove /usr/etc/sudoers.d include directive from /etc/sudoers",
+        path="/etc/sudoers",
+        regex='^\s*@includedir\s+/usr/etc/sudoers.d',
+        state="absent",
+        when="not ansible_check_mode"
+    )
+}}}
+{{% endif %}}
+
 - name: "{{{ rule_title }}} - Find /etc/sudoers.d/* files containing 'Defaults timestamp_timeout'"
   ansible.builtin.find:
     path: "/etc/sudoers.d"
@@ -28,15 +41,24 @@
     validate: /usr/sbin/visudo -cf %s
     backrefs: yes
   register: edit_sudoers_timestamp_timeout_option
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+  when: not ansible_check_mode
+{{% endif %}}
 
 - name: "{{{ rule_title }}} - Enable timestamp_timeout option with correct value in /etc/sudoers"
   ansible.builtin.lineinfile: # noqa 503
     path: /etc/sudoers
     line: 'Defaults timestamp_timeout={{ var_sudo_timestamp_timeout }}'
     validate: /usr/sbin/visudo -cf %s
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+  when: >
+    not ansible_check_mode and edit_sudoers_timestamp_timeout_option is defined and
+    not edit_sudoers_timestamp_timeout_option.changed
+{{% else %}}
   when: >
     edit_sudoers_timestamp_timeout_option is defined and
     not edit_sudoers_timestamp_timeout_option.changed
+{{% endif %}}
 
 - name: "{{{ rule_title }}} - Remove timestamp_timeout wrong values in /etc/sudoers"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
@@ -7,6 +7,11 @@
 
 {{{ bash_instantiate_variables("var_sudo_timestamp_timeout") }}}
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults("/usr/etc/sudoers", "/etc/sudoers") }}}
+{{{ lineinfile_absent("/etc/sudoers", "^\s*@includedir\s*/usr/etc/sudoers\.d", sed_path_separator="#", rule_id=rule_id) }}}
+{{% endif %}}
+
 if grep -Px '^[\s]*Defaults.*timestamp_timeout[\s]*=.*' /etc/sudoers.d/*; then
     find /etc/sudoers.d/ -type f -exec sed -Ei "/^[[:blank:]]*Defaults.*timestamp_timeout[[:blank:]]*=.*/d" {} \;
 fi
@@ -22,7 +27,7 @@ if /usr/sbin/visudo -qcf /etc/sudoers; then
             sed -Ei "s/(^[[:blank:]]*Defaults.*timestamp_timeout[[:blank:]]*=)[[:blank:]]*[-]?\w+(.*$)/\1${var_sudo_timestamp_timeout}\2/" /etc/sudoers
         fi
     fi
-    
+
     # Check validity of sudoers and cleanup bak
     if /usr/sbin/visudo -qcf /etc/sudoers; then
         rm -f /etc/sudoers.bak

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
@@ -4,6 +4,11 @@
     <criteria comment="The timestamp_timeout should be configured" operator="AND">
       <criterion comment="check configuration in /etc/sudoers" test_ref="test_sudo_timestamp_timeout" />
       <criterion comment="check for - sign in configuration" test_ref="test_sudo_timestamp_timeout_no_signs" />
+      {{% if product in [ 'sle16', 'slmicro6' ] %}}
+      <criterion
+          comment="test if configuration file /etc/sudoers exists for {{{ rule_id }}}"
+          test_ref="test_{{{ rule_id }}}_config_file_exists"/>
+      {{% endif %}}
     </criteria>
   </definition>
 
@@ -18,14 +23,18 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_sudo_timestamp_timeout" version="1">
-    <ind:filepath operation="pattern match">^\/etc\/(sudoers|sudoers\.d\/.*)$</ind:filepath>  
+    <ind:filepath operation="pattern match">^\/etc\/(sudoers|sudoers\.d\/.*)$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*Defaults[\s]+timestamp_timeout[\s]*=\s*[+]?(\d*\.\d+|\d+\.\d*|\d+)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
    <ind:textfilecontent54_object id="obj_sudo_timestamp_timeout_no_signs" version="1">
-    <ind:filepath operation="pattern match">^\/etc\/(sudoers|sudoers\.d\/.*)$</ind:filepath>  
+    <ind:filepath operation="pattern match">^\/etc\/(sudoers|sudoers\.d\/.*)$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*Defaults[\s]+timestamp_timeout[\s]*=\s*[\-](\d*\.\d+|\d+\.\d*|\d+)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object> 
+  </ind:textfilecontent54_object>
+  {{% if product in [ 'sle16', 'slmicro6' ] %}}
+  {{{ oval_config_file_exists_test('/etc/sudoers', rule_id=rule_id) }}}
+  {{{ oval_config_file_exists_object('/etc/sudoers', rule_id=rule_id) }}}
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_1.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_1.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_4.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_4.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_7.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_7.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_8.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_8.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_with_spaces_2.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_with_spaces_2.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/etc_sudoers_missing.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/etc_sudoers_missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+
+if [ -e "/etc/sudoers" ] ; then
+    rm "/etc/sudoers"
+fi
+echo "Defaults timestamp_timeout=3" >> /etc/sudoers.d/00-complianceascode-test.conf

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/missing_value.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers
 fi

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/missing_value_1.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/missing_value_1.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from /etc/sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/wrong_value_1.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/wrong_value_1.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = sudo
 
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+touch /etc/sudoers
+{{% endif %}}
 # Remove Defaults timestamp_timeout from sudoers
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
@@ -3,6 +3,11 @@
      {{{ oval_metadata("Check that sudoers doesn't contain command negations", rule_title=rule_title) }}}
      <criteria operator="AND">
 	     <criterion comment="Make sure that no command in user spec contains negation" test_ref="test_{{{ rule_id }}}" />
+      {{% if product in [ 'sle16', 'slmicro6' ] %}}
+      <criterion
+          comment="test if configuration file /etc/sudoers exists for {{{ rule_id }}}"
+          test_ref="test_{{{ rule_id }}}_config_file_exists"/>
+      {{% endif %}}
      </criteria>
   </definition>
 
@@ -23,4 +28,8 @@
     <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,!\n][^,\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()(!\S+).*</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% if product in [ 'sle16', 'slmicro6' ] %}}
+  {{{ oval_config_file_exists_test('/etc/sudoers', rule_id=rule_id) }}}
+  {{{ oval_config_file_exists_object('/etc/sudoers', rule_id=rule_id) }}}
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/etc_sudoers_missing.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/etc_sudoers_missing.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = sudo
+# remediation = none
+
+if [ -e "/etc/sudoers" ] ; then
+    rm "/etc/sudoers"
+fi
+echo 'nobody ALL=/bin/ls, (bob !alice) /bin/dog, /bin/cat !arg' > /etc/sudoers.d/foo

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -847,6 +847,9 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   with_items:
     - { path: /etc/sudoers }
     - "{{ sudoers.files }}"
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+  when: not ansible_check_mode
+{{% endif %}}
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1325,7 +1325,13 @@ fi
     {{% if sed_path_separator in regex %}}
     {{{ raise("regex (" + regex + ") uses sed path separator (" + sed_path_separator + ") in " + rule_id) }}}
     {{% endif %}}
-LC_ALL=C sed -i "{{{ sed_path_separator }}}{{{ regex }}}{{{ sed_path_separator }}}{{{ modifier }}}" "{{{ path }}}"
+    {{%- if sed_path_separator != "/" -%}}
+    # non default delimiter with delete operation needs to be escaped
+    LC_ALL=C sed -i "\{{{ sed_path_separator }}}{{{ regex }}}{{{ sed_path_separator }}}{{{ modifier }}}" "{{{ path }}}"
+    {{%- else -%}}
+    LC_ALL=C sed -i "{{{ sed_path_separator }}}{{{ regex }}}{{{ sed_path_separator }}}{{{ modifier }}}" "{{{ path }}}"
+    {{%- endif -%}}
+
 {{%- endmacro -%}}
 
 

--- a/shared/templates/sudo_defaults_option/ansible.template
+++ b/shared/templates/sudo_defaults_option/ansible.template
@@ -3,6 +3,20 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ ansible_copy_distro_defaults('/usr/etc/sudoers', '/etc/sudoers', rule_title=rule_title) }}}
+{{{
+    ansible_lineinfile(
+        rule_title + " - Remove /usr/etc/sudoers.d include directive from /etc/sudoers",
+        path="/etc/sudoers",
+        regex='^\s*@includedir\s+/usr/etc/sudoers.d',
+        state="absent",
+        when="not ansible_check_mode"
+    )
+}}}
+{{% endif %}}
+
 {{% if VARIABLE_NAME %}}
 {{{ ansible_instantiate_variables(VARIABLE_NAME) }}}
 - name: Ensure {{{ OPTION }}} is enabled with the appropriate value in /etc/sudoers
@@ -13,13 +27,19 @@
     validate: /usr/sbin/visudo -cf %s
     backrefs: yes
   register: edit_sudoers_{{{ OPTION }}}_option
-
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+  when: not ansible_check_mode
+{{% endif %}}
 - name: Enable {{{ OPTION }}} option with appropriate value in /etc/sudoers
   ansible.builtin.lineinfile: # noqa 503
     path: /etc/sudoers
     line: 'Defaults {{{ OPTION }}}={{ {{{ VARIABLE_NAME }}} }}'
     validate: /usr/sbin/visudo -cf %s
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+  when: not ansible_check_mode and edit_sudoers_{{{ OPTION }}}_option is defined and not edit_sudoers_{{{ OPTION }}}_option.changed
+{{% else %}}
   when: edit_sudoers_{{{ OPTION }}}_option is defined and not edit_sudoers_{{{ OPTION }}}_option.changed
+{{% endif %}}
 {{% else %}}
 - name: Ensure {{{ OPTION }}} is enabled in /etc/sudoers
   ansible.builtin.lineinfile:
@@ -27,4 +47,7 @@
     regexp: '^[\s]*Defaults.*\b{{{ OPTION }}}\b.*$'
     line: 'Defaults {{{ OPTION }}}'
     validate: /usr/sbin/visudo -cf %s
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+  when: not ansible_check_mode
+{{% endif %}}
 {{% endif %}}

--- a/shared/templates/sudo_defaults_option/bash.template
+++ b/shared/templates/sudo_defaults_option/bash.template
@@ -7,6 +7,11 @@
 
 {{{ bash_instantiate_variables(VARIABLE_NAME) }}}
 {{% endif %}}
+
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+{{{ bash_copy_distro_defaults("/usr/etc/sudoers", "/etc/sudoers") }}}
+{{{ lineinfile_absent("/etc/sudoers", "^\s*@includedir\s*/usr/etc/sudoers\.d", sed_path_separator="#", rule_id=rule_id) }}}
+{{% endif %}}
 if /usr/sbin/visudo -qcf /etc/sudoers; then
     cp /etc/sudoers /etc/sudoers.bak
     if ! grep -P '^[\s]*Defaults\b[^!\n]*\b{{{ OPTION_REGEX }}}.*$' /etc/sudoers; then

--- a/shared/templates/sudo_defaults_option/oval.template
+++ b/shared/templates/sudo_defaults_option/oval.template
@@ -1,7 +1,12 @@
 <def-group>
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Checks sudoers Defaults " + OPTION + " configuration", rule_title=rule_title) }}}
-    <criteria >
+    <criteria operator="AND">
+        {{% if product in [ 'sle16', 'slmicro6' ] %}}
+        <criterion
+            comment="test if configuration file /etc/sudoers exists for {{{ rule_id }}}"
+            test_ref="test_{{{ rule_id }}}_config_file_exists"/>
+        {{% endif %}}
         <criterion comment="{{{ OPTION }}} is configured in /etc/sudoers or /etc/sudoers.d/" test_ref="test_{{{ OPTION }}}_sudoers" />
     </criteria>
   </definition>
@@ -24,4 +29,8 @@
 
   <external_variable comment="Variable value for sudo {{{ OPTION }}} " datatype="string" id="{{{ VARIABLE_NAME }}}" version="1" />
 {{% endif %}}
+   {{% if product in [ 'sle16', 'slmicro6' ] %}}
+   {{{ oval_config_file_exists_test('/etc/sudoers', rule_id=rule_id) }}}
+   {{{ oval_config_file_exists_object('/etc/sudoers', rule_id=rule_id) }}}
+   {{% endif %}}
 </def-group>


### PR DESCRIPTION
#### Description:

- Update sudoers related rules checks and remediations for SLE16

#### Rationale:

- Check if non-default sed_path_separator is used and add escape to it
- Add condition for sle16/slmicro6, file is missing by default
- Update the template for sle16 so
    - if /etc/sudoers is missing always fail the OVAL
    in bash,ansible remediations:
    - copy distro defaults and remove @includedir /usr/etc/sudoers.d before applying real fix
- Make sure we use sudo_defaults_option implementation and add relevant tests
- Added same fixes as sudo_defaults_option template and modified/added tests

