### PR TITLE
Remove unreliable test scenarios

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/tests/world_writable_tmp.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/tests/world_writable_tmp.fail.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ubuntu
-
-find / -xdev -type f -perm -002 -exec chmod o-w {} \;
-
-mount tmpfs /tmp -t tmpfs
-
-touch /tmp/test
-chmod o+w /tmp/test

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_file_tmp.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_file_tmp.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ubuntu
-# remediation = none
-
-mount tmpfs /tmp -t tmpfs
-
-touch /tmp/test
-chown 9999:9999 /tmp/test

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/unowned_file_tmp.fail.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/unowned_file_tmp.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ubuntu
-# remediation = none
-
-mount tmpfs /tmp -t tmpfs
-
-touch /tmp/test
-chown 9999:9999 /tmp/test


### PR DESCRIPTION
This commit removes 3 test scenarios.  These scenarios create a violating file in `/tmp`.  However, these rules should skip remote and special file system.  That creates a problem that the evaluation result depends on whether `/tmp` on the target system is a partition on the disk or a `tmpfs` file system.

If the `/tmp` is a partition on the disk, OpenSCAP examines the files in the `/tmp` directory, the violating file in `/tmp` is detected and the rule fails as expected by the test scenarios.

If the `/tmp` is a `tmpfs` file system, OpenSCAP considers it a special file system, it skips it, doesn't examine the `/tmp` directory, therefore it doesn't detect the violating file in `/tmp` and rule result is pass, which isn't expected by test scenarios.

In general, we don't want test scenarios with variable behavior.  Also, we don't have a way to control the expected test scenario result based on the target system properties. Therefore, we will remove the test scenarios.

Fixes: https://github.com/ComplianceAsCode/content/issues/13778

#### Review Hints:

Run `/per-rule/oscap/from-env` from Contest, add to `test_vars` this item: `"RULE=file_permissions_ungroupowned no_files_unowned_by_user file_permissions_unauthorized_world_writable"`
