### PR TITLE
Disable scheduled run of update-oscal workflow

### DIFF
--- a/.github/workflows/update-oscal.yml
+++ b/.github/workflows/update-oscal.yml
@@ -2,9 +2,6 @@ name: Update vendored OSCAL content
 
 on:
     workflow_dispatch:
-    schedule:
-        # Run weekly at 05:00 on Sunday
-        - cron: "0 5 * * 0"
 
 jobs:
     update-oscal:


### PR DESCRIPTION
#### Description:

- Remove the weekly cron schedule from the `update-oscal.yml` workflow, keeping only the `workflow_dispatch` trigger so it can still be run manually when needed.

#### Rationale:

- The workflow has been [failing for almost two months](https://github.com/ComplianceAsCode/content/actions/workflows/update-oscal.yml) and the catalog sources are pinned to a fixed commit hash (`690f517d`), so the weekly schedule is effectively a no-op for catalogs. Its sole consumer (`utils/oscal/build_cd_from_policy.py`) is an optional developer tool not integrated into the build system or CI pipelines. Disabling the schedule avoids unnecessary failing workflow runs while preserving the ability to trigger it manually when the underlying issues are fixed.

#### Review Hints:

- This is a 3-line deletion removing the `schedule` block from `.github/workflows/update-oscal.yml`. The `workflow_dispatch` trigger is preserved so the workflow remains available for manual execution.