### PR TITLE
Fix NIST 800-53 CIS control references sync indentation and update NIST-800-53 control files

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -673,18 +673,17 @@ macro(ssg_generate_nist_viewer)
     # This generates for all RHEL products at once
     set(NIST_PRODUCTS rhel8 rhel9 rhel10)
     add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/nist-controls-viewer/nist-controls-viewer.html"
+        OUTPUT "${CMAKE_BINARY_DIR}/nist-controls-viewer/index.html"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/nist-controls-viewer"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/nist_sync/generate_nist_viewer.py"
             --products ${NIST_PRODUCTS}
             --output-dir "${CMAKE_BINARY_DIR}/nist-controls-viewer"
             --repo-root "${CMAKE_SOURCE_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_BINARY_DIR}/nist-controls-viewer/nist-controls-viewer.html"
         COMMENT "[nist-viewer] generating NIST 800-53 control viewer with gap analysis"
     )
 
     add_custom_target(nist-viewer
-        DEPENDS "${CMAKE_BINARY_DIR}/nist-controls-viewer/nist-controls-viewer.html"
+        DEPENDS "${CMAKE_BINARY_DIR}/nist-controls-viewer/index.html"
     )
 endmacro()
 

--- a/products/rhel10/controls/nist_800_53/au.yml
+++ b/products/rhel10/controls/nist_800_53/au.yml
@@ -19,6 +19,7 @@ controls:
           - audit_rules_privileged_commands_usermod
           - auditd_data_disk_error_action
           - auditd_data_disk_full_action
+          - auditd_data_retention_action_mail_acct
           - auditd_data_retention_admin_space_left_action
           - auditd_data_retention_space_left_action
           - grub2_audit_backlog_limit_argument

--- a/products/rhel10/controls/nist_800_53/other.yml
+++ b/products/rhel10/controls/nist_800_53/other.yml
@@ -13,7 +13,7 @@ controls:
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - accounts_passwords_pam_faillock_deny
-          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time_with_zero
           - accounts_set_post_pw_existing
           - accounts_tmout
@@ -35,6 +35,8 @@ controls:
           - file_permissions_var_log_audit
           - inactivity_timeout_value=15_minutes
           - package_gdm_removed
+          - package_postfix_installed
+          - package_sequoia-sq_installed
           - service_firewalld_enabled
           - sshd_idle_timeout_value=5_minutes
           - sshd_max_auth_tries_value=4
@@ -67,10 +69,12 @@ controls:
           - var_accounts_password_warn_age_login_defs=7
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_dir=run
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_tmout=15_min
           - var_accounts_user_umask=027
           - var_audit_backlog_limit=8192
+          - var_auditd_action_mail_acct=root
           - var_auditd_admin_space_left_action=cis_rhel10
           - var_auditd_disk_error_action=cis_rhel10
           - var_auditd_disk_full_action=cis_rhel10

--- a/products/rhel8/controls/nist_800_53/other.yml
+++ b/products/rhel8/controls/nist_800_53/other.yml
@@ -13,7 +13,7 @@ controls:
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - accounts_passwords_pam_faillock_deny
-          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time_with_zero
           - accounts_set_post_pw_existing
           - accounts_tmout
@@ -69,6 +69,7 @@ controls:
           - var_accounts_password_warn_age_login_defs=7
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_dir=run
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_tmout=15_min
           - var_accounts_user_umask=027

--- a/products/rhel9/controls/nist_800_53/other.yml
+++ b/products/rhel9/controls/nist_800_53/other.yml
@@ -13,7 +13,7 @@ controls:
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - accounts_passwords_pam_faillock_deny
-          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time
           - accounts_set_post_pw_existing
           - accounts_tmout
@@ -34,6 +34,7 @@ controls:
           - gnome_gdm_disable_xdmcp
           - inactivity_timeout_value=15_minutes
           - package_gdm_removed
+          - package_postfix_installed
           - service_firewalld_enabled
           - service_nftables_disabled
           - sshd_idle_timeout_value=5_minutes
@@ -64,6 +65,7 @@ controls:
           - var_accounts_password_warn_age_login_defs=7
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_dir=run
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_tmout=15_min
           - var_accounts_user_umask=027

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/au.yml
@@ -19,6 +19,7 @@ controls:
           - audit_rules_privileged_commands_usermod
           - auditd_data_disk_error_action
           - auditd_data_disk_full_action
+          - auditd_data_retention_action_mail_acct
           - auditd_data_retention_admin_space_left_action
           - auditd_data_retention_space_left_action
           - grub2_audit_backlog_limit_argument

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/other.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/other.yml
@@ -13,7 +13,7 @@ controls:
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - accounts_passwords_pam_faillock_deny
-          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time_with_zero
           - accounts_set_post_pw_existing
           - accounts_tmout
@@ -35,6 +35,8 @@ controls:
           - file_permissions_var_log_audit
           - inactivity_timeout_value=15_minutes
           - package_gdm_removed
+          - package_postfix_installed
+          - package_sequoia-sq_installed
           - service_firewalld_enabled
           - sshd_idle_timeout_value=5_minutes
           - sshd_max_auth_tries_value=4
@@ -67,10 +69,12 @@ controls:
           - var_accounts_password_warn_age_login_defs=7
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_dir=run
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_tmout=15_min
           - var_accounts_user_umask=027
           - var_audit_backlog_limit=8192
+          - var_auditd_action_mail_acct=root
           - var_auditd_admin_space_left_action=cis_rhel10
           - var_auditd_disk_error_action=cis_rhel10
           - var_auditd_disk_full_action=cis_rhel10

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/other.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/other.yml
@@ -13,7 +13,7 @@ controls:
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - accounts_passwords_pam_faillock_deny
-          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time_with_zero
           - accounts_set_post_pw_existing
           - accounts_tmout
@@ -69,6 +69,7 @@ controls:
           - var_accounts_password_warn_age_login_defs=7
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_dir=run
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_tmout=15_min
           - var_accounts_user_umask=027

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/other.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/other.yml
@@ -13,7 +13,7 @@ controls:
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - accounts_passwords_pam_faillock_deny
-          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time
           - accounts_set_post_pw_existing
           - accounts_tmout
@@ -34,6 +34,7 @@ controls:
           - gnome_gdm_disable_xdmcp
           - inactivity_timeout_value=15_minutes
           - package_gdm_removed
+          - package_postfix_installed
           - service_firewalld_enabled
           - service_nftables_disabled
           - sshd_idle_timeout_value=5_minutes
@@ -64,6 +65,7 @@ controls:
           - var_accounts_password_warn_age_login_defs=7
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_dir=run
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_tmout=15_min
           - var_accounts_user_umask=027

--- a/utils/generate_html_pages.sh
+++ b/utils/generate_html_pages.sh
@@ -142,7 +142,7 @@ echo "<li><a href=\"guides/index.html\">Guides</a></li>" >> index.html
 echo "<li><a href=\"tables/index.html\">Mapping Tables</a></li>" >> index.html
 echo "<li><a href=\"srg_mapping/index.html\">SRG Mapping Tables</a></li>" >> index.html
 echo "<li><a href=\"rendered-policies/index.html\">Rendered Policies</a></li>" >> index.html
-echo "<li><a href=\"nist-viewer/nist-controls-viewer.html\">NIST 800-53 Control Viewer & Gap Analysis</a></li>" >> index.html
+echo "<li><a href=\"nist-viewer/index.html\">NIST 800-53 Control Viewer & Gap Analysis</a></li>" >> index.html
 echo "<li><a href=\"components/index.html\">Components</a></li>" >> index.html
 echo "<li><a href=\"prometheus_stats/policies_metrics\">Prometheus Policies Metrics</a></li>" >> index.html
 echo "</ul>" >> index.html

--- a/utils/nist_sync/sync_nist_split.py
+++ b/utils/nist_sync/sync_nist_split.py
@@ -123,7 +123,7 @@ class NISTSplitSync:
         self.yaml.preserve_quotes = False
         self.yaml.default_flow_style = False
         self.yaml.width = 99
-        self.yaml.indent(mapping=4, sequence=4, offset=2)
+        self.yaml.indent(mapping=4, sequence=6, offset=4)
 
     def extract_family(self, control_id: str) -> str:
         """Extract family prefix from control ID."""


### PR DESCRIPTION
#### Description:

- Fix `utils/nist_sync/sync_nist_split.py` to use correct ruamel.yaml indent settings so that generated YAML uses 4-space indented sequence items, matching the project's style. This applies to the reference CIS -> NIST 800-53 mapping files
- Sync `products/{rhel8,rhel9,rhel10}/controls/nist_800_53/` product control files to pick up CIS updates that had accumulated since the last sync.

#### Rationale:

- The wrong indent settings caused the weekly automated sync workflow to produce PRs (https://github.com/ComplianceAsCode/content/pull/14701) with ~18 000 spurious line changes.
- The content updates reflect CIS control file changes merged in recent weeks.

#### Review Hints:

- The script fix is a one-line change in `utils/nist_sync/sync_nist_split.py`. You can verify it by running `python3 utils/nist_sync/sync_nist_split.py --product rhel9` and confirming no diff appears in `shared/references/controls/nist_800_53_cis_reference_rhel9/`.
- The reference files (`shared/references/controls/`) and product control files (`products/*/controls/nist_800_53/`) carry the same content changes — review one set and the other mirrors it.