### PR TITLE
Optimize file search in ARPC

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -108,7 +108,7 @@
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
       var_ref="var_audit_rules_privileged_commands_exec_mountpoints"/>
-    <unix:filename operation="pattern match">^\w+</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="include">state_setuid_or_setgid_set</filter>
     <filter action="exclude">state_dracut_tmp_files</filter>
   </unix:file_object>
@@ -117,7 +117,7 @@
     <unix:behaviors recurse="directories" recurse_direction="down"
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals">/</unix:path>
-    <unix:filename operation="pattern match">^\w+</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="include">state_setuid_or_setgid_set</filter>
     <filter action="exclude">state_dracut_tmp_files</filter>
     <filter action="exclude">state_audit_rules_privileged_commands_sysroot</filter>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_nonutf8.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_nonutf8.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = audit
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
+
+# This creates a situation from https://redhat.atlassian.net/browse/RHEL-171005
+# OpenSCAP produced an error in previous version of OVAL
+touch /etc/$(printf "evil_filename_\334_non_utf8_character")
+
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules


### PR DESCRIPTION
This change should help avoid issues with PCRE when file names contain non-UTF characters.

A test scenario simulating this situation has been added.

Related to: https://redhat.atlassian.net/browse/RHEL-171005
