### PR TITLE
rootfiles_configured: populate /usr/share/rootfiles/ in remediation

### DIFF
--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/ansible/shared.yml
@@ -6,10 +6,29 @@
 
 {{%- set files = ["bash_logout", "bash_profile", "bashrc", "cshrc", "tcshrc", ] %}}
 
+- name: "{{{ rule_title }}} - Ensure source directory exists"
+  ansible.builtin.file:
+    path: /usr/share/rootfiles
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+
 {{%- for file in files %}}
     {{% set dest_path = "/root/." ~  file -%}}
     {{% set source_path = "/usr/share/rootfiles/." ~ file -%}}
     {{% set new_line = "C " ~ dest_path ~ " 600 root root - "  ~ source_path  %}}
+- name: "{{{ rule_title }}} - Stat {{{ dest_path }}}"
+  ansible.builtin.stat:
+    path: "{{{ dest_path }}}"
+  register: {{{ rule_id }}}_{{{ file }}}_root_stat
+- name: "{{{ rule_title }}} - Copy {{{ dest_path }}} to {{{ source_path }}} if missing"
+  ansible.builtin.copy:
+    src: "{{{ dest_path }}}"
+    dest: "{{{ source_path }}}"
+    remote_src: true
+    force: false
+  when: {{{ rule_id }}}_{{{ file }}}_root_stat.stat.exists
 - name: "{{{ rule_title }}} - Find configuration files"
   ansible.builtin.find:
     paths: /etc/tmpfiles.d/

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/bash/shared.sh
@@ -7,6 +7,13 @@
 {{%- set files = ['bash_logout', 'bash_profile', 'bashrc', 'cshrc', 'tcshrc', ] %}}
 {{%- set ns = namespace(contents="") %}}
 
+mkdir -p /usr/share/rootfiles
+{{%- for file in files %}}
+    {{% set dest_path = '/root/.' ~ file -%}}
+    {{% set source_path = '/usr/share/rootfiles/.' ~ file -%}}
+    [ -f "{{{ dest_path }}}" ] && [ ! -f "{{{ source_path }}}" ] && cp "{{{ dest_path }}}" "{{{ source_path }}}"
+{{%- endfor %}}
+
 {{%- for file in files %}}
     {{% set dest_path = '/root/.' ~ file -%}}
     {{% set source_path = '/usr/share/rootfiles/.' ~ file -%}}


### PR DESCRIPTION
#### Description:

- On RHEL 9.0/9.1 the rootfiles package installs dotfiles directly into /root/ and does not create /usr/share/rootfiles/. The remediation was writing a tmpfiles.d conf with C copy entries sourcing from that directory. When the destination files were absent at boot, systemd-tmpfiles failed with "No such file or directory" because the source path did not exist.

- Fix the Bash and Ansible remediations to create /usr/share/rootfiles/ and copy each dotfile from /root/ to that directory if not already present, so the tmpfiles.d source is always valid. On RHEL 9.2+ where rootfiles already provides /usr/share/rootfiles/, these steps are no-ops.

#### Rationale:

- Fixes #14582

- This is a Claude suggestion to fix the issue, let's run the tests and see if the error is fixed.
