### PR TITLE
Optimize OVALs in multiple rules to avoid errors caused by non-UTF file names

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
@@ -31,7 +31,7 @@
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
                     recurse_file_system="local"/>
     <unix:path var_ref="var_accounts_users_home_files_groupownership_dirs" var_check="at least one"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
   </unix:file_object>
 
   <!-- #### creation of state #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/expected_groupowner_nonutf.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/expected_groupowner_nonutf.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "$USER" > /home/$USER/$USER.txt
+touch /home/$USER/$(printf "evil_filename_\334_non_utf8_character")
+GROUP=$(id $USER -g)
+chgrp -f $GROUP /home/$USER/*
+

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
@@ -28,7 +28,7 @@
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
                     recurse_file_system="local"/>
     <unix:path var_ref="var_accounts_users_home_files_ownership_dirs" var_check="at least one"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
   </unix:file_object>
 
   <!-- #### creation of state #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/expected_owner_nonutf.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/expected_owner_nonutf.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "$USER" > /home/$USER/$USER.txt
+touch /home/$USER/$(printf "evil_filename_\334_non_utf8_character")
+chown $USER /home/$USER/*

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
@@ -31,7 +31,7 @@
             recurse_file_system="defined"/>
             <unix:path operation="equals" var_check="at least one"
                 var_ref="{{{ var_local_mount_points }}}"/>
-        <unix:filename operation="pattern match">^.*$</unix:filename>
+        <unix:filename operation="not equal">/</unix:filename>
         <filter action="include">state_file_permissions_unauthorized_sgid_set</filter>
         <filter action="exclude">state_file_permissions_unauthorized_sgid_sysroot</filter>
     </unix:file_object>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/tests/no_unpackaged_sgid_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/tests/no_unpackaged_sgid_nonutf.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for x in $(find / -perm /g=s) ; do
+	if ! rpm -qf $x ; then
+		rm -rf $x
+	fi
+done
+touch /usr/bin/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
@@ -31,7 +31,7 @@
             recurse_file_system="defined"/>
             <unix:path operation="equals" var_check="at least one"
                 var_ref="{{{ var_local_mount_points }}}"/>
-        <unix:filename operation="pattern match">^.*$</unix:filename>
+        <unix:filename operation="not equal">/</unix:filename>
         <filter action="include">state_file_permissions_unauthorized_suid_set</filter>
         <filter action="exclude">state_file_permissions_unauthorized_suid_sysroot</filter>
     </unix:file_object>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/tests/no_unpackaged_suid_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/tests/no_unpackaged_suid_nonutf.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for x in $(find / -perm /u=s) ; do
+	if ! rpm -qf $x ; then
+		rm -rf $x
+	fi
+done
+touch /usr/bin/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -38,7 +38,7 @@
       recurse_file_system="defined"/>
       <unix:path operation="equals" var_check="at least one"
         var_ref="{{{ var_local_mount_points }}}"/>
-    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="include">state_file_permissions_unauthorized_world_write</filter>
     <filter action="exclude">state_file_permissions_unauthorized_world_write_special_selinux_files</filter>
     <filter action="exclude">state_file_permissions_unauthorized_world_write_sysroot</filter>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/tests/no_world_writable_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/tests/no_world_writable_nonutf.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+
+find / -xdev -type f -perm -002 -exec chmod o-w {} \;
+touch /etc/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -85,7 +85,7 @@
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
       var_ref="{{{ var_local_mount_points }}}"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="exclude">state_file_permissions_ungroupowned_local_group_owner</filter>
     <filter action="exclude">state_file_permissions_ungroupowned_sysroot</filter>
   </unix:file_object>
@@ -96,7 +96,7 @@
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
       var_ref="{{{ var_local_mount_points }}}"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="exclude">state_file_permissions_ungroupowned_local_group_owner_with_usrlib</filter>
     <filter action="exclude">state_file_permissions_ungroupowned_sysroot</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/all_owned_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/all_owned_nonutf.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done
+touch /etc/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/no_files_or_dirs_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_or_dirs_ungroupowned/oval/shared.xml
@@ -90,7 +90,7 @@
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
       var_ref="{{{ var_local_mount_points }}}"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="exclude">state_{{{ rule_id }}}_local_group_owner</filter>
     <filter action="exclude">state_{{{ rule_id }}}_sysroot</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/no_files_or_dirs_ungroupowned/tests/all_owned_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/no_files_or_dirs_ungroupowned/tests/all_owned_nonutf.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done
+touch /etc/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/no_files_or_dirs_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_or_dirs_unowned_by_user/oval/shared.xml
@@ -44,7 +44,7 @@
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
       var_ref="{{{ var_local_mount_points }}}"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="exclude">state_{{{ rule_id }}}_uids_list</filter>
   </unix:file_object>
   <unix:file_object id="object_{{{ rule_id }}}_directories" version="2"

--- a/linux_os/guide/system/permissions/files/no_files_or_dirs_unowned_by_user/tests/all_owned_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/no_files_or_dirs_unowned_by_user/tests/all_owned_nonutf.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done
+touch /etc/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -38,7 +38,7 @@
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
       var_ref="{{{ var_local_mount_points }}}"/>
-    <unix:filename operation="pattern match">.*</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="exclude">state_no_files_unowned_by_user_uids_list</filter>
   </unix:file_object>
 

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/all_owned_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/all_owned_nonutf.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done
+touch /etc/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/shared.xml
@@ -22,7 +22,7 @@
     {{% else %}}
     <unix:path operation="pattern match">^\/s?bin|^\/usr\/s?bin|^\/usr\/local\/s?bin</unix:path>
     {{% endif %}}
-    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
    <filter action="include">state_groupowner_system_commands_dirs_not_root_or_system_account</filter>
    <filter action="exclude">state_groupowner_system_commands_dirs_symlink</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_nonutf.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+{{% if 'ol9' in product %}}
+find -P /bin /sbin /usr/bin /usr/sbin /usr/libexec /usr/local/bin /usr/local/sbin \! -group root -type f -exec chgrp --no-dereference root '{}' \; || true
+{{% else %}}
+find -P /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin \! -group root -type f -exec chgrp --no-dereference root '{}' \; || true
+{{% endif %}}
+touch /usr/bin/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -42,7 +42,7 @@
          /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
 {{% endif %}}
-    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
 {{% if 'ubuntu' in product %}}
    <filter action="include">state_owner_binaries_not_system_accounts</filter>
 {{% else %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner_nonutf.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+{{% if 'ubuntu' in product %}}
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ \! -uid -{{{ uid_min }}} -execdir chown root {} \;
+{{% else %}}
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -user root -execdir chown root {} \;
+{{% endif %}}
+touch /usr/bin/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
@@ -17,7 +17,7 @@
     <!-- Check that binary files under /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
          /usr/local/sbin, and /usr/libexec directories have safe permissions (go-w) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
-    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="include">state_perms_binary_files_nogroupwrite_noworldwrite</filter>
     <filter action="exclude">state_perms_binary_files_symlink</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/tests/correct_permissions_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/tests/correct_permissions_nonutf.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIRS="/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec"
+for dirPath in $DIRS; do
+    find "$dirPath" -perm /022 -type f -exec chmod 0755 '{}' \;
+done
+touch /usr/bin/$(printf "evil_filename_\334_non_utf8_character")

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/oval/shared.xml
@@ -17,7 +17,7 @@
     <!-- Check that binary files under /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
          and /usr/local/sbin directories have safe permissions (go-w) -->
     <unix:path operation="pattern match">^\/(s|)bin|^\/usr\/(s|)bin|^\/usr\/local\/(s|)bin</unix:path>
-    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <unix:filename operation="not equal">/</unix:filename>
     <filter action="include">state_perms_system_commands_files_nogroupwrite_noworldwrite</filter>
     <filter action="exclude">state_perms_system_commands_files_symlink</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/tests/correct_permissions_nonutf.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/tests/correct_permissions_nonutf.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
+do
+  find -L  $SYSLIBDIRS  -perm /022 -type f -exec chmod go-w '{}' \;
+done
+
+touch /usr/bin/$(printf "evil_filename_\334_non_utf8_character")


### PR DESCRIPTION
#### Description:

This PR applies the change that we did in rule `audit_rules_privileged_commands` in https://github.com/ComplianceAsCode/content/pull/14706 to other rules that contain a similar check in OVAL. All contain a regular expression in the `filename` element that matches any file name.

Test scenarios simulating this situation has been added.

Related to: https://redhat.atlassian.net/browse/RHEL-171005

This PR doesn't solve the problem with non-UTF characters. But, it will avoid this problem in some situations. That will reduce the amount of errors that the user experiences.
