### PR TITLE
Improve pam_options SLE16 -related behaviour

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_authok_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_authok_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = pam
+# variables = var_password_pam_remember=4
+
+echo "password requisite pam_pwhistory.so remember=4" > /etc/pam.d/common-password

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_correct_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = pam
+# variables = var_password_pam_remember=4
+
+echo "password requisite pam_pwhistory.so remember=4 use_authtok" > /etc/pam.d/common-password

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_greater_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_greater_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = pam
+# variables = var_password_pam_remember=4
+
+echo "password requisite pam_pwhistory.so remember=10 use_authtok" > /etc/pam.d/common-password

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_less_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_less_value.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = pam
+# variables = var_password_pam_remember=4
+
+echo "password requisite pam_pwhistory.so remember=1 use_authtok" > /etc/pam.d/common-password

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_missing.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+# packages = pam
+
+if [ -e "/etc/pam.d/common-password" ] ; then
+    rm "/etc/pam.d/common-password"
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_remember_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/common_password_remember_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = pam
+# variables = var_password_pam_remember=4
+
+echo "password requisite pam_pwhistory.so use_authtok" > /etc/pam.d/common-password

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth-missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth-missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = SUSE Linux Enterprise 16
+
+if [ -e "/etc/pam.d/common-auth" ] ; then
+    rm "/etc/pam.d/common-auth"
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth.pam_unix_not_sha512.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth.pam_unix_not_sha512.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = SUSE Linux Enterprise 15
+# platform = SUSE Linux Enterprise 15, SUSE Linux Enterprise 16
 
-echo "auth	required 	pam_unix.so	try_first_pass" > /etc/pam.d/common-auth
+echo "auth	sufficient 	pam_unix.so	try_first_pass" > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth.pam_unix_not_sufficient.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth.pam_unix_not_sufficient.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = SUSE Linux Enterprise 15
+# platform = SUSE Linux Enterprise 15, SUSE Linux Enterprise 16
 
 echo "auth	optional 	pam_unix.so	try_first_pass sha512" > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/tests/common-auth.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = SUSE Linux Enterprise 15
+# platform = SUSE Linux Enterprise 15, SUSE Linux Enterprise 16
 
-echo "auth	required 	pam_unix.so	try_first_pass sha512" > /etc/pam.d/common-auth
+echo "auth	sufficient 	pam_unix.so	try_first_pass sha512" > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/line_not_there.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # variables = var_pam_wheel_group_for_su=sugroup
 
+{{% if product in ["sle16", "slmicro6"] %}}
+touch /etc/pam.d/su
+{{% endif %}}
+
 #clean possible lines
 sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' /etc/pam.d/su

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -2555,7 +2555,7 @@ copied onto /etc/ssh/sshd_config, if /etc/ssh/sshd_config does not exist
     src: {{{ source }}}
     dest: {{{ destination }}}
     force: no
-    mode: '0600'
+    mode: 'preserve'
     remote_src: yes
 {{%- endmacro %}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2595,6 +2595,7 @@ if [ -e "{{{ pam_file }}}" ] ; then
 else
     echo "{{{ pam_file }}} was not found" >&2
 fi
+
 {{%- endmacro -%}}
 
 
@@ -2837,9 +2838,9 @@ chmod 0600 {{{ sshd_config_dir }}}/{{{ hardening_config_basename }}}
 #}}
 {{% macro bash_copy_distro_defaults(source, destination) -%}}
 
-{{% if  product in ["sle16", "slmicro6"] %}}
+{{% if product in ["sle16", "slmicro6"] %}}
 if ! [ -e "{{{ destination }}}" ] ; then
-    cp "{{{ source }}}" "{{{ destination }}}"
+    cp -p "{{{ source }}}" "{{{ destination }}}"
 fi
 {{% endif %}}
 {{%- endmacro %}}

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -11,12 +11,8 @@
 # for now.
 
 {{% if product == 'sle16' %}}
-- name: Copy default /usr/lib/pam.d/{{ '{{{ PATH }}}' | basename }} to {{{ PATH }}}
-  ansible.builtin.copy:
-    src: /usr/lib/pam.d/{{ '{{{ PATH }}}' | basename }}
-    dest: {{{ PATH }}}
-    force: no
-    mode: '0644'
+{{% set PAM_VENDOR_FILE = "/usr/lib/pam.d/" + PATH.split('/') | last %}}
+{{{ ansible_copy_distro_defaults(PAM_VENDOR_FILE, PATH, rule_title=rule_title) }}}
 {{% endif %}}
 
 - name: Set control_flag fact

--- a/shared/templates/pam_options/bash.template
+++ b/shared/templates/pam_options/bash.template
@@ -10,11 +10,9 @@ declare -a ARGS=()
 declare -a NEW_ARGS=()
 declare -a DEL_ARGS=()
 
-{{% if product == 'sle16' %}}
+{{% if product in ["sle16", "slmicro6"] %}}
 PAM_DEFAULTS_FILE_NAME="/usr/lib/pam.d/$(basename "{{{ PATH }}}")"
-if ! [ -e "{{{ PATH }}}" ] ; then
-    cp "${PAM_DEFAULTS_FILE_NAME}" "{{{ PATH }}}"
-fi
+{{{ bash_copy_distro_defaults("${PAM_DEFAULTS_FILE_NAME}", PATH) }}}
 {{% endif %}}
 
 {{% for arg in ARGUMENTS -%}}

--- a/shared/templates/pam_options/oval.template
+++ b/shared/templates/pam_options/oval.template
@@ -4,37 +4,9 @@
    {{% set MATCH_CONTROL_FLAG = '\S+' %}}
 {{% endif %}}
 
-{{% if product == 'sle16' %}}
-{{% set PAM_VENDOR_FILE = "/usr/lib/pam.d/" + PATH.split('/') | last %}}
-{{% endif %}}
-
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="3">
     {{{ oval_metadata("Configure PAM module", rule_title=rule_title) }}}
-{{% if product == 'sle16' %}}
-    <criteria comment="PAM options properly configured" operator="OR">
-      <criteria operator="AND" comment="Make sure arguments are properly configured in {{{ PAM_VENDOR_FILE }}}">
-            <criterion comment="test if configuration file {{{ PATH }}} exists for {{{ rule_id }}}" test_ref="test_{{{ rule_id }}}_config_file_exists" negate="true"/>
-        {{% for arg in ARGUMENTS %}}
-        {{% if arg['variable']|length %}}
-            <criterion test_ref="test_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['variable']|lower }}}" comment="Verify {{{ arg['variable'] }}} is set to the desired state" />
-        {{% else %}}
-            <criterion test_ref="test_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['argument']|lower }}}" comment="Verify {{{ arg['argument'] }}} is set to the desired state" />
-        {{% endif %}}
-        {{% endfor %}}
-      </criteria>
-        <criteria operator="AND" comment="Make sure arguments are properly configured in {{{ PATH }}}">
-            {{{ oval_config_file_exists_criterion(PATH, rule_id=rule_id) }}}
-        {{% for arg in ARGUMENTS %}}
-        {{% if arg['variable']|length %}}
-            <criterion test_ref="test_pam_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['variable']|lower }}}" comment="Verify {{{ arg['variable'] }}} is set to the desired state" />
-        {{% else %}}
-            <criterion test_ref="test_pam_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['argument']|lower }}}" comment="Verify {{{ arg['argument'] }}} is set to the desired state" />
-        {{% endif %}}
-        {{% endfor %}}
-      </criteria>
-    </criteria>
-{{% else %}}
     <criteria operator="AND" comment="Make sure arguments are properly configured in {{{ PATH }}}">
     {{% for arg in ARGUMENTS %}}
     {{% if arg['variable']|length %}}
@@ -44,13 +16,7 @@
     {{% endif %}}
     {{% endfor %}}
     </criteria>
-{{% endif %}}
   </definition>
-
-{{% if product == 'sle16' %}}
-{{{ oval_config_file_exists_test(PATH, rule_id=rule_id) }}}
-{{{ oval_config_file_exists_object(PATH, rule_id=rule_id) }}}
-{{% endif %}}
 
 {{% for arg in ARGUMENTS %}}
 {{% if arg['variable']|length %}}
@@ -81,22 +47,6 @@
 
   <external_variable comment="PAM external variable {{{ pam_variable_name }}}" datatype="int" id="{{{ pam_variable_name }}}" version="1" />
 
-{{% if product == 'sle16' %}}
-  <ind:textfilecontent54_test id="test_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['variable']|lower }}}"
-  check="all"
-  comment="Verify {{{ arg['variable'] }}} configuation of {{{ MODULE }}}" version="1">
-    <ind:object object_ref="object_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['variable']|lower }}}" />
-    <ind:state state_ref="state_pam_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['variable']|lower }}}" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="object_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['variable']|lower }}}" comment="Check {{{ arg['variable'] }}} configuration of PAM {{{ MODULE }}} module" version="1">
-    <ind:filepath>{{{ PAM_VENDOR_FILE }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*{{{ TYPE }}}\s+{{{ MATCH_CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s{{{ arg['variable'] }}}=(-?[a-zA-Z0-9]+)(?:\s+.*)?</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% endif %}}
-
-
 {{% else %}}
   <ind:textfilecontent54_test id="test_pam_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['argument']|lower }}}"
   check="all" check_existence={{% if arg['remove_argument']|length %}}"none_exist"{{% else %}}"all_exist"{{% endif %}}
@@ -113,24 +63,6 @@
 {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-
-{{% if product == 'sle16' %}}
-  <ind:textfilecontent54_test id="test_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['argument']|lower }}}"
-  check="all" check_existence={{% if arg['remove_argument']|length %}}"none_exist"{{% else %}}"all_exist"{{% endif %}}
-  comment="Verify {{{ arg['argument'] }}} configuation of {{{ MODULE }}}" version="1">
-    <ind:object object_ref="object_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['argument']|lower }}}" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="object_pam_vendor_{{{ TYPE|lower }}}_{{{ MODULE|lower|replace('.so', '') }}}_{{{ arg['argument']|lower }}}" comment="Check {{{ arg['argument'] }}} configuration of PAM {{{ MODULE }}} module" version="1">
-    <ind:filepath>{{{ PAM_VENDOR_FILE }}}</ind:filepath>
-{{% if arg['argument_match']|length %}}
-    <ind:pattern operation="pattern match">^\s*{{{ TYPE }}}(?:(?!\n)\s)+{{{ MATCH_CONTROL_FLAG }}}(?:(?!\n)\s)+{{{ MODULE }}}((?!\n)\s[^\n]+)?(?!\n)\s+{{{ arg['argument'] }}}={{{ arg['argument_match'] }}}((\s+\S+)*\s*\\*\s*)$</ind:pattern>
-{{% else %}}
-    <ind:pattern operation="pattern match">^\s*{{{ TYPE }}}(?:(?!\n)\s)+{{{ MATCH_CONTROL_FLAG }}}(?:(?!\n)\s)+{{{ MODULE }}}((?!\n)\s[^\n]+)?(?!\n)\s+{{{ arg['argument'] }}}((\s+\S+)*\s*\\*\s*)$</ind:pattern>
-{{% endif %}}
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% endif %}}
 {{% endif %}}
 {{% endfor %}}
 </def-group>


### PR DESCRIPTION
#### Description:

- Improve pam_options related rules behaviour for SLE16. Make sure distro default configuration files from /usr/etc are not used in hardening for anything else but for source of generating default configuration in /etc from remediation scripts. Anything in /usr/etc will be changed or wiped out on upgrade so we should not rely on it for hardening

#### Rationale:

- Remove the special case for sle16 in OVAL, if file is missing test will FAIL
- Add preserve option when copy distro defaults to /etc for bash and ansible
- Fix tests for use_pam_wheel_group_for_su and set_password_hashing_algorithm_commonauth
- Add test for accounts_password_pam_pwhistory_remember
