### PR TITLE
SLE16 related fixes to  accounts password template

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -13,6 +13,10 @@
 
 {{{ ansible_instantiate_variables("var_password_pam_retry") }}}
 
+{{% if product == 'sle16' %}}
+{{{ ansible_copy_distro_defaults('/usr/lib/security/pwquality.conf', pwquality_path, rule_title=rule_title) }}}
+{{% endif %}}
+
 {{% if product in ['rhel8', 'rhel9', 'almalinux', 'sle15', 'sle16'] -%}}
 - name: Ensure PAM variable retry is set accordingly
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -11,6 +11,10 @@
 
 {{{ bash_instantiate_variables("var_password_pam_retry") }}}
 
+{{% if product == 'sle16' %}}
+{{{ bash_copy_distro_defaults('/usr/lib/security/pwquality.conf', pwquality_path) }}}
+{{% endif %}}
+
 {{% if 'rhel' in product or product in ['sle15', 'sle16'] -%}}
 	{{{ bash_replace_or_append(pwquality_path,
 							   '^retry',

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct.pass.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# packages = authselect
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_sle
 # variables = var_password_pam_retry=3
+{{% if product in ['sle15', 'sle16'] %}}
+# packages = libpwquality1
+{{% else %}}
+# packages = authselect
+{{% endif %}}
 
 source common.sh
 
@@ -13,10 +17,11 @@ if grep -q "^.*retry\s*=" "$CONF_FILE"; then
 else
 	echo "retry = $retry_cnt" >> "$CONF_FILE"
 fi
-
+{{% if product not in ['sle15', 'sle16'] %}}
 for file in ${configuration_files[@]}; do
 	echo "password required pam_pwquality.so" >> \
 		"/etc/authselect/custom/testingProfile/$file"
 done
 
 authselect apply-changes
+{{% endif %}}

--- a/product_properties/10-pwquality-conf.yml
+++ b/product_properties/10-pwquality-conf.yml
@@ -1,7 +1,2 @@
 default:
   pwquality_path: "/etc/security/pwquality.conf"
-
-overrides:
-{{% if product == 'sle16' %}}
-  pwquality_path: "/usr/lib/security/pwquality.conf"
-{{% endif %}}

--- a/shared/templates/accounts_password/ansible.template
+++ b/shared/templates/accounts_password/ansible.template
@@ -43,6 +43,10 @@
 {{{ ansible_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'requisite', 'pam_pwquality.so', '', '', 'BOF', rule_id=rule_id, rule_title=rule_title) }}}
 {{% endif %}}
 
+{{% if product == 'sle16' %}}
+{{{ ansible_copy_distro_defaults('/usr/lib/security/pwquality.conf', pwquality_path, rule_title=rule_title) }}}
+{{% endif %}}
+
 - name: {{{ rule_title }}} - Ensure PAM variable {{{ VARIABLE }}} is set accordingly
   ansible.builtin.lineinfile:
     create: yes

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -35,4 +35,8 @@ fi
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'requisite', 'pam_pwquality.so', '', '', 'BOF') }}}
 {{% endif %}}
 
+{{% if product == 'sle16' %}}
+{{{ bash_copy_distro_defaults('/usr/lib/security/pwquality.conf', pwquality_path) }}}
+{{% endif %}}
+
 {{{ bash_replace_or_append(pwquality_path, '^' ~ VARIABLE , '$var_password_pam_' ~ VARIABLE , '%s = %s', cce_identifiers=cce_identifiers) }}}


### PR DESCRIPTION
#### Description:

- Distro defaults from /usr/lib/security/pwquality.conf is used only as bootstrap for pwquality configuration to be hardened. Cannot rely on anything in /usr/etc to remain same after distro or package upgrade so hardening should be based only on configuration in /etc

#### Rationale:

- bash/ansible remediations now copy distro defaults from /usr/lib/security/pwquality.conf to /etc/security/pwquality.conf. This affects rules accounts_password_pam_dcredit, accounts_password_pam_lcredit, accounts_password_pam_minlen and non-template using rule like accounts_password_pam_retry should have same behaviour