### PR TITLE
update contributors list for v0.1.81 release

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,5 +1,5 @@
 <!---This file is generated using the contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2026-02-16 16:01 UTC
+Last Modified: 2026-05-19 11:46 UTC
 --->
 
 The following people have contributed to the SCAP Security Guide project
@@ -46,6 +46,7 @@ The following people have contributed to the SCAP Security Guide project
 * Olivier Bonhomme <ptitoliv@ptitoliv.net>
 * bontreger <bontreger@users.noreply.github.com>
 * Lance Bragstad <lbragstad@gmail.com>
+* Vickey Brown <vibrown@redhat.com>
 * Ted Brunell <tbrunell@redhat.com>
 * Marcus Burghardt <maburgha@redhat.com>
 * Matthew Burket <mburket@redhat.com>
@@ -72,6 +73,7 @@ The following people have contributed to the SCAP Security Guide project
 * cueball23 <christoph.alms@westnetz.de>
 * cyarbrough76 <42849651+cyarbrough76@users.noreply.github.com>
 * Maura Dailey <maura@eclipse.ncsc.mil>
+* Harold Dean <hdean3@users.noreply.github.com>
 * Benjamin Deering <ben_deering@jeepingben.net>
 * Shane Dell <shanedell100@gmail.com>
 * Klaas Demter <demter@atix.de>
@@ -174,6 +176,7 @@ The following people have contributed to the SCAP Security Guide project
 * Milan Lysonek <mlysonek@redhat.com>
 * Fredrik Lysén <fredrik@pipemore.se>
 * Mackemania <8738793+Mackemania@users.noreply.github.com>
+* Peter Macko <pmacko@redhat.com>
 * Caitlin Macleod <caitelatte@gmail.com>
 * Dmitry Makovey <dmakovey@yahoo.com>
 * Nick Maludy <nmaludy@gmail.com>
@@ -197,6 +200,7 @@ The following people have contributed to the SCAP Security Guide project
 * Zbynek Moravec <zmoravec@redhat.com>
 * Kazuo Moriwaka <moriwaka@users.noreply.github.com>
 * Michael Moseley <michael@eclipse.ncsc.mil>
+* Samir MOUHOUNE <samir.mouhoune@nav-timing.safrangroup.com>
 * Nathan Moyer <nmoyer@spectric.com>
 * Ross Murphy <RossMurphy@ibm.com>
 * Renaud Métrich <rmetrich@redhat.com>
@@ -291,6 +295,7 @@ The following people have contributed to the SCAP Security Guide project
 * Nathan Strahs <135379779+nathanstrahs@users.noreply.github.com>
 * Jonathan Sturges <jsturges@redhat.com>
 * svet-se <svetlin.boychev@suse.com>
+* taimurhafeez <taimurhafeez93@gmail.com>
 * Kaushik Talathi <kaushik.talathi1@ibm.com>
 * teacup-on-rockingchair <315160+teacup-on-rockingchair@users.noreply.github.com>
 * Ian Tewksbury <itewk@redhat.com>

--- a/Contributors.xml
+++ b/Contributors.xml
@@ -1,5 +1,5 @@
 <!--This file is generated using the contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2026-02-16 16:01 UTC
+Last Modified: 2026-05-19 11:46 UTC
 -->
 
 <text>
@@ -44,6 +44,7 @@ Last Modified: 2026-02-16 16:01 UTC
 <contributor>Olivier Bonhomme &lt;ptitoliv@ptitoliv.net&gt;</contributor>
 <contributor>bontreger &lt;bontreger@users.noreply.github.com&gt;</contributor>
 <contributor>Lance Bragstad &lt;lbragstad@gmail.com&gt;</contributor>
+<contributor>Vickey Brown &lt;vibrown@redhat.com&gt;</contributor>
 <contributor>Ted Brunell &lt;tbrunell@redhat.com&gt;</contributor>
 <contributor>Marcus Burghardt &lt;maburgha@redhat.com&gt;</contributor>
 <contributor>Matthew Burket &lt;mburket@redhat.com&gt;</contributor>
@@ -70,6 +71,7 @@ Last Modified: 2026-02-16 16:01 UTC
 <contributor>cueball23 &lt;christoph.alms@westnetz.de&gt;</contributor>
 <contributor>cyarbrough76 &lt;42849651+cyarbrough76@users.noreply.github.com&gt;</contributor>
 <contributor>Maura Dailey &lt;maura@eclipse.ncsc.mil&gt;</contributor>
+<contributor>Harold Dean &lt;hdean3@users.noreply.github.com&gt;</contributor>
 <contributor>Benjamin Deering &lt;ben_deering@jeepingben.net&gt;</contributor>
 <contributor>Shane Dell &lt;shanedell100@gmail.com&gt;</contributor>
 <contributor>Klaas Demter &lt;demter@atix.de&gt;</contributor>
@@ -172,6 +174,7 @@ Last Modified: 2026-02-16 16:01 UTC
 <contributor>Milan Lysonek &lt;mlysonek@redhat.com&gt;</contributor>
 <contributor>Fredrik Lysén &lt;fredrik@pipemore.se&gt;</contributor>
 <contributor>Mackemania &lt;8738793+Mackemania@users.noreply.github.com&gt;</contributor>
+<contributor>Peter Macko &lt;pmacko@redhat.com&gt;</contributor>
 <contributor>Caitlin Macleod &lt;caitelatte@gmail.com&gt;</contributor>
 <contributor>Dmitry Makovey &lt;dmakovey@yahoo.com&gt;</contributor>
 <contributor>Nick Maludy &lt;nmaludy@gmail.com&gt;</contributor>
@@ -195,6 +198,7 @@ Last Modified: 2026-02-16 16:01 UTC
 <contributor>Zbynek Moravec &lt;zmoravec@redhat.com&gt;</contributor>
 <contributor>Kazuo Moriwaka &lt;moriwaka@users.noreply.github.com&gt;</contributor>
 <contributor>Michael Moseley &lt;michael@eclipse.ncsc.mil&gt;</contributor>
+<contributor>Samir MOUHOUNE &lt;samir.mouhoune@nav-timing.safrangroup.com&gt;</contributor>
 <contributor>Nathan Moyer &lt;nmoyer@spectric.com&gt;</contributor>
 <contributor>Ross Murphy &lt;RossMurphy@ibm.com&gt;</contributor>
 <contributor>Renaud Métrich &lt;rmetrich@redhat.com&gt;</contributor>
@@ -289,6 +293,7 @@ Last Modified: 2026-02-16 16:01 UTC
 <contributor>Nathan Strahs &lt;135379779+nathanstrahs@users.noreply.github.com&gt;</contributor>
 <contributor>Jonathan Sturges &lt;jsturges@redhat.com&gt;</contributor>
 <contributor>svet-se &lt;svetlin.boychev@suse.com&gt;</contributor>
+<contributor>taimurhafeez &lt;taimurhafeez93@gmail.com&gt;</contributor>
 <contributor>Kaushik Talathi &lt;kaushik.talathi1@ibm.com&gt;</contributor>
 <contributor>teacup-on-rockingchair &lt;315160+teacup-on-rockingchair@users.noreply.github.com&gt;</contributor>
 <contributor>Ian Tewksbury &lt;itewk@redhat.com&gt;</contributor>


### PR DESCRIPTION
#### Description

- Updating contributors list. See new contributors in changes

#### Rationale:

- Fixes [OPENSCAP-6814](https://issues.redhat.com/browse/OPENSCAP-6814)


[OPENSCAP-6814]: https://redhat.atlassian.net/browse/OPENSCAP-6814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ