### PR TITLE
Bump version to 0.1.82

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(SSGCommon)
 # Define Version values
 set(SSG_MAJOR_VERSION 0)
 set(SSG_MINOR_VERSION 1)
-set(SSG_PATCH_VERSION 81)
+set(SSG_PATCH_VERSION 82)
 set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}")
 
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")


### PR DESCRIPTION
#### Description:

- Bumping ssg version to 0.1.82

#### Rationale:

- Fixes [OPENSCAP-6816](https://redhat.atlassian.net/browse/OPENSCAP-6816)


[OPENSCAP-6816]: https://redhat.atlassian.net/browse/OPENSCAP-6816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ