### PR TITLE
sysctl template: add AlmaLinux to /lib/sysctl.d exclusion list to fix false positive sysctl failures

### DIFF
--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -180,7 +180,7 @@
   <ind:textfilecontent54_object id="object_static_etc_lib_sysctls_{{{ rule_id }}}" version="1">
     <set>
       <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2204", "ubuntu2404"] %}}
+{{% if product not in [ "almalinux8", "almalinux9", "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2204", "ubuntu2404"] %}}
       <object_reference>object_static_lib_sysctld_{{{ rule_id }}}</object_reference>
 {{% endif %}}
     </set>
@@ -231,7 +231,7 @@
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "ubuntu2204", "ubuntu2404"] or 'rhel' in product or 'almalinux' in product %}}
   <ind:textfilecontent54_object id="object_static_lib_sysctld_{{{ rule_id }}}" version="1">
     <ind:path>/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>


### PR DESCRIPTION
… sysctl OVAL template

https://github.com/ComplianceAsCode/content/issues/14722

#### Description:

AlmaLinux is missing from the /lib/sysctl.d exclusion list in the sysctl OVAL template, causing false positive failures on sysctl rules where a package-owned file in /lib/sysctl.d/ contains a conflicting value that is correctly overridden by a user drop-in in /etc/sysctl.d/.
Two changes are made: AlmaLinux 8 and 9 are added to the exclusion list in object_static_etc_lib_sysctls so /lib/sysctl.d is not included in the user-managed object scan, and 'almalinux' in product is added to the condition that controls whether object_static_lib_sysctld is defined, keeping the two conditions consistent. Note that almalinux has been chosen instead of scoping to specific releases to align with how 'rhel' is used in this same condition.

#### Rationale:

AlmaLinux is a 1:1 binary-compatible RHEL clone and inherits the same systemd-managed /lib/sysctl.d/50-default.conf which sets net.ipv4.conf.default.rp_filter = 2.
RHEL 8, RHEL 9, OL8, and OL9 are already excluded from the /lib/sysctl.d user object inclusion for exactly this reason. AlmaLinux was simply omitted from the list.
The correct remediation on these systems is a drop-in in /etc/sysctl.d/, which is what systemd documents and recommends (see systemd/systemd#32563).
With a compliant drop-in in place, the rule still fails because /lib/sysctl.d/50-default.conf is included in the user object scan and evaluated with check="all".

Fixes #14722

#### Review Hints:

To reproduce the false positive before this fix: install AlmaLinux 9, set net.ipv4.conf.default.rp_filter = 1 in /etc/sysctl.d/, verify sysctl net.ipv4.conf.default.rp_filter returns 1, then run OpenSCAP against the CIS Level 1 Server profile- the rule fails because it finds a value of '2' in /lib/sysctl.d/50-default.conf. After this fix it should pass.
The change is deliberately consistent with the existing pattern for RHEL and OL products - version-specific entries in the first condition, substring match in the second. See also the related discussion in #10203 and prior AlmaLinux work in #13409 (which did not address this issue).
