### PR TITLE
Add default domain to SSSD related remediations and fix Fedora test failures

### DIFF
--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
@@ -1,36 +1,16 @@
 # sssd.service needs /etc/sssd/sssd.conf to start
-if [ ! -f /etc/sssd/sssd.conf ]; then
-	cat << EOF > /etc/sssd/sssd.conf
-[sssd]
-config_file_version = 2
-services = nss, pam
-domains = example.com
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
 
-[domain/example.com]
-{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
-id_provider = proxy
-proxy_lib_name = files
-local_auth_policy = only
+{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']%}}
+{{{ bash_ensure_ini_config("$SSSD_CONF $SSSD_CONF_DIR/*.conf", "pam", "pam_cert_auth", "True") }}}
+{{%- endif %}}
+
+{{%- if product in ["fedora"] or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+{{{ bash_package_install("sssd-proxy") }}}
+authselect select sssd with-smartcard
+chmod 0640 $SSSD_CONF
 {{%- else %}}
-id_provider = files
-access_provider = simple
-simple_allow_users = user1, user2
+chmod 0600 $SSSD_CONF
 {{%- endif %}}
-
-[nss]
-filter_groups = root
-filter_users = root
-
-[pam]
-{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
-pam_cert_auth = True
-{{%- endif %}}
-EOF
-	{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
-	dnf install sssd-proxy -y
-	authselect select sssd with-smartcard
-	chmod 0640 /etc/sssd/sssd.conf
-	{{%- else %}}
-	chmod 0600 /etc/sssd/sssd.conf
-	{{%- endif %}}
-fi

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
@@ -5,17 +5,23 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("var_sssd_certificate_verification_digest_function") }}}
 
-- name: Ensure that "certificate_verification" is not set in /etc/sssd/sssd.conf
+{{% set sssd_conf = "/etc/sssd/sssd.conf" -%}}
+{{% set sssd_conf_dir = "/etc/sssd/conf.d" -%}}
+{{{ ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) }}}
+
+{{{ ansible_install_sssd_proxy(rule_title) }}}
+
+- name: Ensure that "certificate_verification" is not set in {{{ sssd_conf }}}
   community.general.ini_file:
-      path: /etc/sssd/sssd.conf
+      path: {{{ sssd_conf }}}
       section: sssd
       option: certificate_verification
       state: absent
       mode: 0600
 
-- name: 'Ensure that "certificate_verification" is not set in  /etc/sssd/conf.d/*.conf'
+- name: 'Ensure that "certificate_verification" is not set in {{{ sssd_conf_dir }}}/*.conf'
   community.general.ini_file:
-      path: /etc/sssd/conf.d/*.conf
+      path: {{{ sssd_conf_dir }}}/*.conf
       section: sssd
       option: certificate_verification
       state: absent
@@ -23,7 +29,7 @@
 
 - name: Ensure that "certificate_verification" is set
   community.general.ini_file:
-      path: /etc/sssd/conf.d/certificate_verification.conf
+      path: {{{ sssd_conf_dir }}}/certificate_verification.conf
       section: sssd
       option: certificate_verification
       value: "ocsp_dgst={{ var_sssd_certificate_verification_digest_function }}"

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
@@ -11,8 +11,13 @@
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
-MAIN_CONF="/etc/sssd/conf.d/certificate_verification.conf"
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
 
-{{{ bash_ensure_ini_config("$MAIN_CONF /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "sssd", "certificate_verification", "ocsp_dgst=$var_sssd_certificate_verification_digest_function") }}}
+MAIN_CONF="$SSSD_CONF_DIR/certificate_verification.conf"
+
+{{{ bash_ensure_ini_config("$MAIN_CONF $SSSD_CONF $SSSD_CONF_DIR/*.conf", "sssd", "certificate_verification", "ocsp_dgst=$var_sssd_certificate_verification_digest_function") }}}
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -4,14 +4,20 @@
 # complexity = low
 # disruption = medium
 
-- name: {{{ rule_title }}} - Find all the conf files inside the /etc/sssd/conf.d/ directory
+{{% set sssd_conf = "/etc/sssd/sssd.conf" -%}}
+{{% set sssd_conf_dir = "/etc/sssd/conf.d" -%}}
+{{{ ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) }}}
+
+{{{ ansible_install_sssd_proxy(rule_title) }}}
+
+- name: {{{ rule_title }}} - Find all the conf files inside the {{{ sssd_conf_dir }}} directory
   ansible.builtin.find:
     paths:
-    - "/etc/sssd/conf.d/"
+    - "{{{ sssd_conf_dir }}}"
     patterns: "*.conf"
   register: sssd_conf_d_files
 
-- name: {{{ rule_title }}} - Modify lines in files in the /etc/sssd/conf.d/ directory
+- name: {{{ rule_title }}} - Modify lines in files in the {{{ sssd_conf_dir }}} directory
   ansible.builtin.replace:
     path: "{{ item }}"
     regexp: '^(\s*\[sssd\].*(?:\n\s*[^[\s].*)*\n\s*services\s*=(?!.*\bpam\b).*)$'
@@ -20,22 +26,22 @@
   register: modify_lines_sssd_conf_d_files
   when: sssd_conf_d_files.matched is defined and sssd_conf_d_files.matched >= 1
 
-- name: {{{ rule_title }}} - Find /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Find {{{ sssd_conf }}}
   ansible.builtin.stat:
-    path: /etc/sssd/sssd.conf
+    path: {{{ sssd_conf }}}
   register: sssd_conf_file
 
-- name: {{{ rule_title }}} - Modify lines in /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Modify lines in {{{ sssd_conf }}}
   ansible.builtin.replace:
-    path: "/etc/sssd/sssd.conf"
+    path: "{{{ sssd_conf }}}"
     regexp: '^(\s*\[sssd\].*(?:\n\s*[^[\s].*)*\n\s*services\s*=(?!.*\bpam\b).*)$'
     replace: '\1,pam'
   register: modify_lines_sssd_conf_file
   when: sssd_conf_file.stat.exists
 
-- name: {{{ rule_title }}} - Find services key in /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Find services key in {{{ sssd_conf }}}
   ansible.builtin.replace:
-    path: "/etc/sssd/sssd.conf"
+    path: "{{{ sssd_conf }}}"
     regexp: '^\s*\[sssd\][^\[\]]*?(?:\n(?!\[)[^\n]*?services\s*=)+'
     replace: ''
   changed_when: false
@@ -43,9 +49,9 @@
   register: sssd_conf_file_services
   when: sssd_conf_file.stat.exists
 
-- name: {{{ rule_title }}} - Insert entry to /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Insert entry to {{{ sssd_conf }}}
   community.general.ini_file:
-    path: /etc/sssd/sssd.conf
+    path: {{{ sssd_conf }}}
     section: sssd
     option: services
     value: pam

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -1,23 +1,19 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_almalinux,multi_platform_ubuntu
 
 
-
 # sssd configuration files must be created with 600 permissions if they don't exist
 # otherwise the sssd module fails to start
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
 SSSD_CONF="/etc/sssd/sssd.conf"
-SSSD_CONF_DIR="/etc/sssd/conf.d/*.conf"
-
-if [ ! -f "$SSSD_CONF" ] && [ ! -f "$SSSD_CONF_DIR" ]; then
-    mkdir -p /etc/sssd
-    touch "$SSSD_CONF"
-fi
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
 
 # Flag to check if there is already services with pam
 service_already_exist=false
-for f in $SSSD_CONF $SSSD_CONF_DIR; do
+for f in $SSSD_CONF $SSSD_CONF_DIR/*.conf; do
 	if [ ! -e "$f" ]; then
 		continue
 	fi
@@ -39,13 +35,7 @@ done
 
 # If there was no service in [sssd], add it to first config
 if [ "$service_already_exist" = false ]; then
-    for f in $SSSD_CONF $SSSD_CONF_DIR; do
-        cat << EOF >> "$f"
-[sssd]
-services = pam
-EOF
-        break
-    done
+{{{ bash_ensure_ini_config("$SSSD_CONF $SSSD_CONF_DIR/*.conf", "sssd", "services", "pam") }}}
 fi
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -3,44 +3,28 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
-- name: "Test for domain group"
-  ansible.builtin.command: grep '^\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
-  register: test_grep_domain
-  failed_when: false
-  changed_when: False
-  check_mode: no
+{{% set sssd_conf = "/etc/sssd/sssd.conf" -%}}
+{{% set sssd_conf_dir = "/etc/sssd/conf.d" -%}}
+{{{ ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) }}}
 
-- name: "Add default domain group (if no domain there)"
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    section: "{{ item.section }}"
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    create: yes
-    mode: 0600
-  with_items:
-    - { section: sssd, option: domains, value: default}
-    - { section: domain/default, option: id_provider, value: files }
-  when:
-    - test_grep_domain.stdout is defined
-    - test_grep_domain.stdout | length < 1
+{{{ ansible_install_sssd_proxy(rule_title) }}}
 
 - name: "Enable Smartcards in SSSD"
   community.general.ini_file:
-    dest: /etc/sssd/sssd.conf
+    path: {{{ sssd_conf }}}
     section: pam
     option: pam_cert_auth
     value: 'True'
     create: yes
     mode: 0600
 
-- name: Find all the conf files inside /etc/sssd/conf.d/
+- name: Find all the conf files inside {{{ sssd_conf_dir }}}
   ansible.builtin.find:
-    paths: "/etc/sssd/conf.d/"
+    paths: "{{{ sssd_conf_dir }}}"
     patterns: "*.conf"
   register: sssd_conf_d_files
 
-- name: Fix pam_cert_auth configuration in /etc/sssd/conf.d/
+- name: Fix pam_cert_auth configuration in {{{ sssd_conf_dir }}}
   ansible.builtin.replace:
     path: "{{ item.path }}"
     regexp: '[^#]*pam_cert_auth.*'

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -9,7 +9,12 @@
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
-{{{ bash_ensure_ini_config("/etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "pam", "pam_cert_auth", "True") }}}
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
+
+{{{ bash_ensure_ini_config("$SSSD_CONF $SSSD_CONF_DIR/*.conf", "pam", "pam_cert_auth", "True") }}}
 
 umask $OLD_UMASK
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_false.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_false.fail.sh
@@ -2,6 +2,10 @@
 # packages = sssd
 # platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
-SSSD_FILE="/etc/sssd/sssd.conf"
-echo "[pam]" > $SSSD_FILE
-echo "pam_cert_auth = False" >> $SSSD_FILE
+{{% if product in ["fedora", "ol8", "ol9"] or 'rhel' in product %}}
+authselect select sssd --force
+{{% endif %}}
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_ensure_ini_config("$SSSD_CONF $SSSD_CONF_DIR/*.conf", "pam", "pam_cert_auth", "False") }}}

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing.fail.sh
@@ -2,5 +2,9 @@
 # packages = sssd
 # platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
+{{% if product in ["fedora", "ol8", "ol9"] or 'rhel' in product %}}
+authselect select sssd --force
+{{% endif %}}
+
 SSSD_FILE="/etc/sssd/sssd.conf"
 echo "[pam]" > $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing_file.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing_file.fail.sh
@@ -2,5 +2,9 @@
 # packages = sssd
 # platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
+{{% if product in ["fedora", "ol8", "ol9"] or 'rhel' in product %}}
+authselect select sssd --force
+{{% endif %}}
+
 SSSD_FILE="/etc/sssd/sssd.conf"
 rm -f $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_true.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_true.pass.sh
@@ -3,5 +3,10 @@
 # platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
 SSSD_FILE="/etc/sssd/sssd.conf"
-echo "[pam]" > $SSSD_FILE
-echo "pam_cert_auth = True" >> $SSSD_FILE
+{{{ bash_ensure_ini_config("$SSSD_FILE", "pam", "pam_cert_auth", "True") }}}
+
+{{% if product in ["fedora", "ol8", "ol9"] or 'rhel' in product %}}
+authselect select sssd --force
+authselect enable-feature with-smartcard
+authselect apply-changes
+{{% endif %}}

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -5,31 +5,15 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("var_sssd_memcache_timeout") }}}
 
-- name: "Test for domain group"
-  ansible.builtin.command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
-  register: test_grep_domain
-  failed_when: false
-  changed_when: False
-  check_mode: no
+{{% set sssd_conf = "/etc/sssd/sssd.conf" -%}}
+{{% set sssd_conf_dir = "/etc/sssd/conf.d" -%}}
+{{{ ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) }}}
 
-- name: "Add default domain group (if no domain there)"
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    section: "{{ item.section }}"
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    create: yes
-    mode: 0600
-  with_items:
-    - { section: sssd, option: domains, value: default}
-    - { section: domain/default, option: id_provider, value: files }
-  when:
-    - test_grep_domain.stdout is defined
-    - test_grep_domain.stdout | length < 1
+{{{ ansible_install_sssd_proxy(rule_title) }}}
 
 - name: "Configure SSSD's Memory Cache to Expire"
   community.general.ini_file:
-    dest: /etc/sssd/sssd.conf
+    path: {{{ sssd_conf }}}
     section: nss
     option: memcache_timeout
     value: "{{ var_sssd_memcache_timeout }}"

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
@@ -7,6 +7,11 @@
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
-{{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "nss", "memcache_timeout", "$var_sssd_memcache_timeout") }}}
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
+
+{{{ bash_ensure_ini_config("$SSSD_CONF", "nss", "memcache_timeout", "$var_sssd_memcache_timeout") }}}
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -3,44 +3,28 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
-- name: "Test for domain group"
-  ansible.builtin.command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
-  register: test_grep_domain
-  failed_when: false
-  changed_when: False
-  check_mode: no
+{{% set sssd_conf = "/etc/sssd/sssd.conf" -%}}
+{{% set sssd_conf_dir = "/etc/sssd/conf.d" -%}}
+{{{ ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) }}}
 
-- name: "Add default domain group (if no domain there)"
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    section: "{{ item.section }}"
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    create: yes
-    mode: 0600
-  with_items:
-    - { section: sssd, option: domains, value: default}
-    - { section: domain/default, option: id_provider, value: files }
-  when:
-    - test_grep_domain.stdout is defined
-    - test_grep_domain.stdout | length < 1
+{{{ ansible_install_sssd_proxy(rule_title) }}}
 
 - name: "Configure SSD to Expire Offline Credentials"
   community.general.ini_file:
-    dest: /etc/sssd/sssd.conf
+    path: {{{ sssd_conf }}}
     section: pam
     option: offline_credentials_expiration
     value: 1
     create: yes
     mode: 0600
 
-- name: Find all the conf files inside /etc/sssd/conf.d/
+- name: Find all the conf files inside {{{ sssd_conf_dir }}}
   ansible.builtin.find:
-    paths: "/etc/sssd/conf.d/"
+    paths: "{{{ sssd_conf_dir }}}"
     patterns: "*.conf"
   register: sssd_conf_d_files
 
-- name: Fix offline_credentials_expiration configuration in /etc/sssd/conf.d/
+- name: Fix offline_credentials_expiration configuration in {{{ sssd_conf_dir }}}
   ansible.builtin.replace:
     path: "{{ item.path }}"
     regexp: '[^#]*offline_credentials_expiration.*'

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
@@ -9,6 +9,11 @@
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
-{{{ bash_ensure_ini_config("/etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "pam", "offline_credentials_expiration", "1") }}}
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
+
+{{{ bash_ensure_ini_config("$SSSD_CONF $SSSD_CONF_DIR/*.conf", "pam", "offline_credentials_expiration", "1") }}}
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
@@ -1,12 +1,17 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_almalinux
 
-MAIN_CONF="/etc/sssd/conf.d/ospp.conf"
-
 # sssd configuration files must be created with 600 permissions if they don't exist
 # otherwise the sssd module fails to start
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
-{{{ bash_ensure_ini_config("$MAIN_CONF /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "sssd", "user", "sssd") }}}
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
+
+MAIN_CONF="$SSSD_CONF_DIR/ospp.conf"
+
+{{{ bash_ensure_ini_config("$MAIN_CONF $SSSD_CONF $SSSD_CONF_DIR/*.conf", "sssd", "user", "sssd", remove_wrong_entries=true) }}}
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_section_sssd.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_section_sssd.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
+
+systemctl enable sssd
+mkdir -p /etc/sssd/conf.d
+echo -e "[sssd-wrong]\nuser = sssd" >> /etc/sssd/conf.d/ospp.conf
+chmod 600 /etc/sssd/conf.d/ospp.conf

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_value_sssd.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_value_sssd.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
+
+systemctl enable sssd
+mkdir -p /etc/sssd/conf.d
+echo -e "[sssd]\nuser = sssd\nuser = sssd-wrong" >> /etc/sssd/conf.d/ospp.conf
+chmod 600 /etc/sssd/conf.d/ospp.conf

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -5,31 +5,15 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("var_sssd_ssh_known_hosts_timeout") }}}
 
-- name: "Test for domain group"
-  ansible.builtin.command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
-  register: test_grep_domain
-  failed_when: false
-  changed_when: False
-  check_mode: no
+{{% set sssd_conf = "/etc/sssd/sssd.conf" -%}}
+{{% set sssd_conf_dir = "/etc/sssd/conf.d" -%}}
+{{{ ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) }}}
 
-- name: "Add default domain group (if no domain there)"
-  community.general.ini_file:
-    path: /etc/sssd/sssd.conf
-    section: "{{ item.section }}"
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    create: yes
-    mode: 0600
-  with_items:
-    - { section: sssd, option: domains, value: default}
-    - { section: domain/default, option: id_provider, value: files }
-  when:
-    - test_grep_domain.stdout is defined
-    - test_grep_domain.stdout | length < 1
+{{{ ansible_install_sssd_proxy(rule_title) }}}
 
 - name: "Configure SSSD to Expire SSH Known Hosts"
   community.general.ini_file:
-    dest: /etc/sssd/sssd.conf
+    path: {{{ sssd_conf }}}
     section: ssh
     option: ssh_known_hosts_timeout
     value: "{{ var_sssd_ssh_known_hosts_timeout }}"

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
@@ -7,6 +7,11 @@
 OLD_UMASK=$(umask)
 umask u=rw,go=
 
-{{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "ssh", "ssh_known_hosts_timeout", "$var_sssd_ssh_known_hosts_timeout") }}}
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR="/etc/sssd/conf.d"
+{{{ bash_sssd_ensure_default_config("$SSSD_CONF", "$SSSD_CONF_DIR") }}}
+{{{ bash_install_sssd_proxy() }}}
+
+{{{ bash_ensure_ini_config("$SSSD_CONF", "ssh", "ssh_known_hosts_timeout", "$var_sssd_ssh_known_hosts_timeout") }}}
 
 umask $OLD_UMASK

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -806,6 +806,78 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- endmacro %}}
 
 
+{{#
+    Ensure a default domain is configured in sssd.conf so that sssd can start
+
+:param sssd_conf: Path to the main sssd configuration file
+:type sssd_conf: str
+:param sssd_conf_dir: Path to the sssd conf.d drop-in directory
+:type sssd_conf_dir: str
+:param rule_title: Rule title used as prefix in Ansible task names
+:type rule_title: str
+#}}
+{{% macro ansible_sssd_ensure_default_config(sssd_conf, sssd_conf_dir, rule_title) -%}}
+- name: "{{{ rule_title }}} - Ensure sssd config directory exists"
+  ansible.builtin.file:
+    path: "{{{ sssd_conf_dir }}}"
+    state: directory
+    mode: '0711'
+
+- name: "{{{ rule_title }}} - Test for domain group in main config"
+  ansible.builtin.command: grep '^\s*\[domain\/[^]]*]' {{{ sssd_conf }}}
+  register: test_grep_domain
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
+- name: "{{{ rule_title }}} - Test for domain group in conf.d"
+  ansible.builtin.shell: grep -rs '^\s*\[domain\/[^]]*]' {{{ sssd_conf_dir }}}/*.conf 2>/dev/null
+  register: test_grep_domain_conf_d
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
+- name: "{{{ rule_title }}} - Add default domain group (if no domain there)"
+  community.general.ini_file:
+    path: {{{ sssd_conf }}}
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: true
+    mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+{{% if product in ["fedora"] or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+    - { section: domain/default, option: id_provider, value: proxy }
+    - { section: domain/default, option: proxy_lib_name, value: files }
+    - { section: domain/default, option: local_auth_policy, value: only }
+{{% else %}}
+    - { section: domain/default, option: id_provider, value: files }
+{{% endif %}}
+  when:
+    - test_grep_domain.stdout is defined
+    - test_grep_domain.stdout | length < 1
+    - test_grep_domain_conf_d.stdout is defined
+    - test_grep_domain_conf_d.stdout | length < 1
+{{%- endmacro %}}
+
+
+{{#
+    Install sssd-proxy package on products that use proxy id_provider for default domain
+
+:param rule_title: Rule title used as prefix in Ansible task names
+:type rule_title: str
+#}}
+{{% macro ansible_install_sssd_proxy(rule_title) -%}}
+{{% if product in ["fedora"] or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+- name: "{{{ rule_title }}} - Install sssd-proxy for default domain"
+  ansible.builtin.package:
+    name: sssd-proxy
+    state: present
+{{% endif %}}
+{{%- endmacro %}}
+
+
 {{% macro ansible_ini_file_set(filename, section, key, value, description="", no_extra_spaces=False) -%}}
 - name: "{{{ description if description else ("Set '" + key + "' to '" + value + "' in the [" + section + "] section of '" + filename + "'") }}}"
   community.general.ini_file:

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1522,6 +1522,46 @@ done
 
 
 {{#
+    Ensure a default domain is configured in sssd.conf so that sssd can start
+
+:param sssd_conf: main sssd configuration file
+:type sssd_conf: str
+:param sssd_conf_dir: sssd conf.d drop-in directory
+:type sssd_conf_dir: str
+#}}
+{{% macro bash_sssd_ensure_default_config(sssd_conf, sssd_conf_dir) -%}}
+mkdir -p "$(dirname "{{{ sssd_conf }}}")"
+if [ ! -f "{{{ sssd_conf }}}" ]; then
+    touch "{{{ sssd_conf }}}"
+fi
+if ! grep -qsrP '^\s*\[domain\/[^]]*]' "{{{ sssd_conf }}}" "{{{ sssd_conf_dir }}}"/*.conf 2>/dev/null; then
+    {{{ bash_ensure_ini_config(sssd_conf, "sssd", "domains", "default") }}}
+    cat >> "{{{ sssd_conf }}}" << EOF
+
+[domain/default]
+{{% if product in ["fedora"] or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) -%}}
+id_provider = proxy
+proxy_lib_name = files
+local_auth_policy = only
+{{% else -%}}
+id_provider = files
+{{% endif -%}}
+EOF
+fi
+{{%- endmacro %}}
+
+
+{{#
+    Install sssd-proxy package on products that use proxy id_provider for default domain
+#}}
+{{% macro bash_install_sssd_proxy() -%}}
+{{% if product in ["fedora"] or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+{{{ bash_package_install("sssd-proxy") }}}
+{{% endif %}}
+{{%- endmacro %}}
+
+
+{{#
     Check whether or not a package is installed.
 #}}
 {{%- macro bash_package_installed(pkgname) -%}}
@@ -2272,9 +2312,11 @@ Example macro invocation(s)::
 :type key: str
 :param value:   value
 :type value: str
+:param remove_wrong_entries: if true, remove entries in [section] where key has a different value
+:type remove_wrong_entries: bool
 
 #}}
-{{% macro bash_ensure_ini_config(files, section, key, value, no_quotes=true) -%}}
+{{% macro bash_ensure_ini_config(files, section, key, value, no_quotes=true, remove_wrong_entries=false) -%}}
 found=false
 
 # set value in all files if they contain section or key
@@ -2285,7 +2327,7 @@ for f in $(echo -n "{{{ files }}}"); do
 
     # find key in section and change value
     if grep -qzosP "(?m)^[[:space:]]*\[{{{ section }}}\]([^\n\[]*\n+)+?[[:space:]]*{{{ key }}}" "$f"; then
-        if ! grep -qzosP "(?m)^[[:space:]]*{{{ key }}}[[:space:]]*=[[:space:]]*{{{ value }}}" "$f"; then
+        if ! grep -qzosP "(?m)^[[:space:]]*{{{ key }}}[[:space:]]*=[[:space:]]*{{{ value }}}"'[[:space:]]*$' "$f"; then
 {{% if no_quotes %}}
             sed -i "/^[[:space:]]*{{{ key }}}/s/\([[:blank:]]*=[[:blank:]]*\).*/\1{{{ value | replace("/", "\/") }}}/" "$f"
 {{% else %}}
@@ -2304,6 +2346,15 @@ for f in $(echo -n "{{{ files }}}"); do
 {{% endif %}}
             found=true
     fi
+
+{{% if remove_wrong_entries %}}
+    # within [{{{ section }}}], remove entries where {{{ key }}} has wrong value
+{{% if no_quotes %}}
+    sed -i "/^[[:space:]]*\[{{{ section }}}\]/,/^[[:space:]]*\[/{/^[[:space:]]*{{{ key }}}[[:blank:]]*=/{ /=[[:blank:]]*{{{ value | replace("/", "\/") }}}"'[[:space:]]*$/!d }}' "$f"
+{{% else %}}
+    sed -i '/^[[:space:]]*\[{{{ section }}}\]/,/^[[:space:]]*\[/{/^[[:space:]]*{{{ key }}}[[:blank:]]*=/{ /=[[:blank:]]*"{{{ value | replace("/", "\/") }}}"[[:space:]]*$/!d }}' "$f"
+{{% endif %}}
+{{% endif %}}
 done
 
 # if section not in any file, append section with key = value to FIRST file in files parameter


### PR DESCRIPTION
#### Description:

- updating ansible and bash remediations for some sssd related rules to use default domain
- adding new macros `ansible_sssd_ensure_default_domain` and `bash_sssd_ensure_default_domain`

#### Rationale:

- add default domain configuration to some SSSD related remediations, because when remediation configure SSSD settings (e.g., `pam_cert_auth`, `certificate_verification`, `user`), SSSD won't start if no domain is defined
- for `sssd_enable_smartcards` tests, `authselect` package has to be installed and configured to use `sssd`, because default profile is `local`, which has no `with-smartcard` feature
- `sssd_run_as_sssd_user` remediation fails on `wrong_value.fail.sh` test
  - the `wrong_value.fail.sh` test creates `user=sssd` + `user=bob` in the same section, then `bash_ensure_ini_config` finds `user=sssd` already matching, skips the `sed` and leaves `user=bob` untouched
  - add option to `bash_ensure_ini_config` macro to remove duplicated keys during remediation
- Fixes #14559
