### PR TITLE
Fix rsyslog rainerscript oval

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/oval/shared.xml
@@ -27,7 +27,7 @@
   {{% macro object_remote_method(method, test_ref) %}}
   <ind:textfilecontent54_object id="obj_{{{ test_ref }}}" version="1">
     <ind:filepath operation="pattern match">^/etc/rsyslog\.(conf|d/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[ \t]*(?:(?:\w+,)*{{{ method }}}(?:,\w+)*\.\*|\S+;{{{ method }}}\.\*|{{{ method }}}\.\*;\S+|\S+;{{{ method }}}\.\*;\S+)[ \t]+(?:(?!action\()\S+|action\([^)]*file\s*=\s*["'][^"']+["'][^)]*\))\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[ \t]*(?:(?:\w+,)*{{{ method }}}(?:,\w+)*\.\*|\S+;{{{ method }}}\.\*|{{{ method }}}\.\*;\S+|\S+;{{{ method }}}\.\*;\S+)[ \t]+(?:(?!(?i)action(?-i)\()\S+|(?i)action(?-i)\([^)]*(?i)file(?-i)\s*=\s*["'][^"']+["'][^)]*\))\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endmacro %}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/rainerscript_action.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/rainerscript_action.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+rm -rf /etc/rsyslog.d/*
+true > /etc/rsyslog.conf
+
+# Use RainerScript action() syntax with capitalized File property
+echo '*.info;daemon.*;kern.*;auth.*;mail,authpriv,cron.none   action(name="local-messages" type="omfile" File="/var/log/messages")' >> /etc/rsyslog.conf
+echo 'authpriv.*   action(name="local-authpriv" type="omfile" File="/var/log/secure")' >> /etc/rsyslog.conf


### PR DESCRIPTION
#### Description:

- Fix the OVAL check for rule `rsyslog_remote_access_monitoring` to handle case-insensitive RainerScript keywords. The regex previously used literal lowercase `action` and `file`, but RainerScript keywords and parameter names are case-insensitive (e.g. `Action()`, `File="..."`). Use `(?i)/(?-i)` OVAL regex flags to match any casing.
- Add a test scenario (`rainerscript_action.pass.sh`) that verifies the rule passes when rsyslog uses RainerScript `action()` syntax with capitalized `File` property names.

#### Rationale:

- RainerScript is a valid and commonly used rsyslog configuration syntax. The `action()` keyword and its parameter names (like `File`) are case-insensitive per the rsyslog documentation. The OVAL check must account for this to avoid false negatives on systems with valid RainerScript configurations.
- reference: https://www.rsyslog.com/doc/rainerscript/configuration_objects.html

#### Review Hints:

- Affected products: rhel8, rhel9, rhel10, ol8. Build with: `./build_product --datastream-only rhel9`
- Test with Automatus:
  ```
  python3 tests/automatus.py rule --libvirt qemu:///system <vm_name> --datastream build/ssg-rhel9-ds.xml rsyslog_remote_access_monitoring
  ```
- The OVAL regex change is on a single line — review both the negative lookahead (`(?!(?i)action(?-i)\()`) and the positive match (`(?i)action(?-i)\(`) to confirm they are consistent.
- Related to PR #14317 which originally added RainerScript `action()` support to this OVAL check.

Fixes: https://redhat.atlassian.net/browse/RHEL-171951
