### PR TITLE
Fix RHEL 10 profile descriptions

### DIFF
--- a/products/rhel10/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel10/profiles/anssi_bp28_enhanced.profile
@@ -9,8 +9,7 @@ metadata:
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -9,8 +9,7 @@ metadata:
 title: 'ANSSI-BP-028 (high)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel10/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel10/profiles/anssi_bp28_intermediary.profile
@@ -9,8 +9,7 @@ metadata:
 title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel10/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel10/profiles/anssi_bp28_minimal.profile
@@ -9,8 +9,7 @@ metadata:
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel10/profiles/e8.profile
+++ b/products/rhel10/profiles/e8.profile
@@ -11,9 +11,7 @@ reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
-    This draft profile contains configuration checks for Red Hat Enterprise Linux 10
+    This profile contains configuration checks for Red Hat Enterprise Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Essential Eight.
 
     A copy of the Essential Eight in Linux Environments guide can be found at the

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -10,8 +10,6 @@ reference: https://www.hhs.gov/hipaa/for-professionals/index.html
 title: 'Health Insurance Portability and Accountability Act (HIPAA)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
     The HIPAA Security Rule establishes U.S. national standards to protect individuals's
     electronic personal health information that is created, received, used, or
     maintained by a covered entity. The Security Rule requires appropriate
@@ -19,7 +17,7 @@ description: |-
     confidentiality, integrity, and security of electronic protected health
     information.
 
-    This draft profile configures Red Hat Enterprise Linux 10 to the HIPAA Security
+    This profile configures Red Hat Enterprise Linux 10 to the HIPAA Security
     Rule identified for securing of electronic protected health information.
     Use of this profile in no way guarantees or makes claims against legal compliance against the HIPAA Security Rule(s).
 

--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -14,7 +14,7 @@ reference: https://www.cyber.gov.au/ism
 title: 'Australian Cyber Security Centre (ACSC) ISM Official - Base'
 
 description: |-
-    This draft profile contains configuration checks for Red Hat Enterprise Linux 10
+    This profile contains configuration checks for Red Hat Enterprise Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
 
     The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -14,9 +14,7 @@ reference: https://www.cyber.gov.au/ism
 title: 'Australian Cyber Security Centre (ACSC) ISM Official - Secret'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
-    This draft profile contains configuration checks for Red Hat Enterprise Linux 10
+    This profile contains configuration checks for Red Hat Enterprise Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
 
     The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -14,7 +14,7 @@ reference: https://www.cyber.gov.au/ism
 title: 'Australian Cyber Security Centre (ACSC) ISM Official - Top Secret'
 
 description: |-
-    This draft profile contains configuration checks for Red Hat Enterprise Linux 10
+    This profile contains configuration checks for Red Hat Enterprise Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
 
     The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning

--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -12,7 +12,7 @@ reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=469&id=469
 title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
 
 description: |-
-    This is draft profile is based on the Red Hat Enterprise Linux 9 Common Criteria Guidance as
+    This draft profile is based on the Red Hat Enterprise Linux 9 Common Criteria Guidance as
     guidance for Red Hat Enterprise Linux 10 was not available at the time of release.
 
     Where appropriate, CNSSI 1253 or DoD-specific values are used for

--- a/products/rhel10/profiles/pci-dss.profile
+++ b/products/rhel10/profiles/pci-dss.profile
@@ -13,14 +13,12 @@ reference: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-
 title: 'PCI-DSS v4.0.1 Control Baseline for Red Hat Enterprise Linux 10'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
     Payment Card Industry - Data Security Standard (PCI-DSS) is a set of
     security standards designed to ensure the secure handling of payment card
     data, with the goal of preventing data breaches and protecting sensitive
     financial information.
 
-    This draft profile ensures Red Hat Enterprise Linux 10 is configured in alignment
+    This profile ensures Red Hat Enterprise Linux 10 is configured in alignment
     with PCI-DSS v4.0.1 requirements.
 
 selections:


### PR DESCRIPTION
Remove outdated information about draft status from profile descriptions in RHEL 10 profiles.