### PR TITLE
package_rng-tools_installed: change applicability

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
@@ -27,7 +27,15 @@ fixtext: '{{{ fixtext_package_installed("rng-tools") }}}'
 
 srg_requirement: '{{{ srg_requirement_package_installed("rng-tools") }}}'
 
+{{% if product == "rhel8" %}}
+platform: (os_linux[rhel]<=8.3 or (os_linux[rhel]>=8.4 and not runtime_kernel_fips_enabled) and system_with_kernel)
+warnings:
+  - general: |-
+      For RHEL versions 8.4 and above running with kernel FIPS mode enabled this rule is not applicable.
+      The in-kernel deterministic random bit generator (DRBG) is used in FIPS mode instead.
+{{% else %}}
 platform: system_with_kernel and not runtime_kernel_fips_enabled
+{{% endif %}}
 
 template:
     name: package_installed


### PR DESCRIPTION
#### Description:

- change applicability of the rule
- in RHEL 8, match applicability of the service_rngd_enabled because that is what RHEL 8 STIG says
- in other STIGs, this package has no such limitations. But I decided to not install it on systems with FIPS enabled as the entropy is gathered not from this source anyway.

#### Rationale:

- RHEL 8 STIG: https://stigaview.com/products/rhel8/v2r7/RHEL-08-010472/
- RHEL 9 STIG: https://stigaview.com/products/rhel9/v2r8/RHEL-09-215090/

Fixes: #14729 

#### Review Hints:

See the linked issue for test cases.