### PR TITLE
Remove draft status from RHEL 10 OSPP profile

### DIFF
--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -9,11 +9,10 @@ metadata:
 
 reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=469&id=469
 
-title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
+title: 'Protection Profile for General Purpose Operating Systems'
 
 description: |-
-    This draft profile is based on the Red Hat Enterprise Linux 9 Common Criteria Guidance as
-    guidance for Red Hat Enterprise Linux 10 was not available at the time of release.
+    This profile is based on the Red Hat Enterprise Linux 10 Common Criteria Guidance.
 
     Where appropriate, CNSSI 1253 or DoD-specific values are used for
     configuration, based on Configuration Annex to the OSPP.


### PR DESCRIPTION
#### Description:

- Remove draft status from the RHEL 10 OSPP profile. Update the title from "DRAFT - Protection Profile for General Purpose Operating Systems" to "Protection Profile for General Purpose Operating Systems" and update the description to reference RHEL 10 Common Criteria Guidance directly instead of noting it was based on RHEL 9 guidance.

#### Rationale:

- RHEL 10 Common Criteria Guidance is now available, so the profile no longer needs the draft designation.

#### Review Hints:

- Single file changed: `products/rhel10/profiles/ospp.profile`
- Build with: `./build_product --datastream-only rhel10`
- Review is straightforward — title and description text changes only, no rule selection changes.
