### PR TITLE
Fix yamllint violations in automatus CI workflows

### DIFF
--- a/.github/workflows/automatus-debian12.yaml
+++ b/.github/workflows/automatus-debian12.yaml
@@ -1,9 +1,11 @@
 name: Automatus Debian 12
 on:
   pull_request:
-    branches: [ master, 'stabilization*' ]
+    branches: [master, 'stabilization*']
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{
+    github.event.number || github.run_id }}
   cancel-in-progress: true
 env:
   DATASTREAM: ssg-debian12-ds.xml
@@ -13,32 +15,65 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build python3-yaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip libxml2-utils xsltproc ansible-lint wget libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python3 swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev g++ libyaml-dev libxmlsec1-dev libxmlsec1-openssl
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            cmake ninja-build python3-yaml \
+            python3-jinja2 git python3-deepdiff \
+            python3-requests jq python3-pip \
+            libxml2-utils xsltproc ansible-lint wget \
+            libdbus-1-dev libdbus-glib-1-dev \
+            libcurl4-openssl-dev libgcrypt20-dev \
+            libselinux1-dev libxslt1-dev \
+            libgconf2-dev libacl1-dev libblkid-dev \
+            libcap-dev libxml2-dev libldap2-dev \
+            libpcre3-dev python3 swig \
+            libxml-parser-perl libxml-xpath-perl \
+            libperl-dev libbz2-dev librpm-dev g++ \
+            libyaml-dev libxmlsec1-dev \
+            libxmlsec1-openssl
       - name: Install deps python
         run: pip3 install gitpython xmldiff lxml lxml-stubs requests
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        # actions/checkout v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Checkout (CTF)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        # actions/checkout v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ComplianceAsCode/content-test-filtering
           path: ctf
       # https://github.com/actions/checkout/issues/766
       - name: Set git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: >-
+          git config --global --add safe.directory
+          "$GITHUB_WORKSPACE"
       - name: Find forking point
         env:
           BASE_BRANCH: ${{ github.base_ref }}
-        run: echo "FORK_POINT=$(git merge-base origin/$BASE_BRANCH ${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
+        run: |
+          FORK_POINT=$(git merge-base \
+            origin/$BASE_BRANCH \
+            ${{ github.event.pull_request.head.sha }})
+          echo "FORK_POINT=$FORK_POINT" >> $GITHUB_OUTPUT
         id: fork_point
       - name: Detect content changes in the PR
-        run: python3 ./ctf/content_test_filtering.py pr --base ${{ steps.fork_point.outputs.FORK_POINT }} --remote_repo ${{ github.server_url }}/${{ github.repository }}  --verbose --rule --output json ${{ github.event.pull_request.number }} > output.json
+        run: |
+          python3 ./ctf/content_test_filtering.py pr \
+            --base ${{ steps.fork_point.outputs.FORK_POINT }} \
+            --remote_repo \
+            ${{ github.server_url }}/${{ github.repository }} \
+            --verbose --rule --output json \
+            ${{ github.event.pull_request.number }} \
+            > output.json
       - name: Test if there are no content changes
-        run: echo "CTF_OUTPUT_SIZE=$(stat --printf="%s" output.json)" >> $GITHUB_OUTPUT
+        run: >-
+          echo "CTF_OUTPUT_SIZE=$(stat --printf="%s"
+          output.json)" >> $GITHUB_OUTPUT
         id: ctf
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      # actions/upload-artifact v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: output.json
@@ -49,12 +84,15 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Download OpenSCAP
-        run: wget https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
+        run: |
+          wget \
+            https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
       - name: Extract OpenSCAP
         run: tar xf openscap-1.3.10.tar.gz
       - name: Build OpenSCAP
@@ -65,7 +103,8 @@ jobs:
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ./build_product debian12
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      # actions/upload-artifact v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ${{ env.DATASTREAM }}
@@ -76,19 +115,38 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt update && sudo apt install -y cmake ninja-build libxml2-utils xsltproc python3-jinja2 python3-yaml ansible-lint podman wget libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python3 swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev g++ libyaml-dev libxmlsec1-dev libxmlsec1-openssl
+        run: |
+          sudo apt update && sudo apt install -y \
+            cmake ninja-build libxml2-utils xsltproc \
+            python3-jinja2 python3-yaml ansible-lint \
+            podman wget \
+            libdbus-1-dev libdbus-glib-1-dev \
+            libcurl4-openssl-dev libgcrypt20-dev \
+            libselinux1-dev libxslt1-dev \
+            libgconf2-dev libacl1-dev libblkid-dev \
+            libcap-dev libxml2-dev libldap2-dev \
+            libpcre3-dev python3 swig \
+            libxml-parser-perl libxml-xpath-perl \
+            libperl-dev libbz2-dev librpm-dev g++ \
+            libyaml-dev libxmlsec1-dev \
+            libxmlsec1-openssl
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        # actions/checkout v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Get cached CTF output
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        # actions/download-artifact v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         id: get_ctf_output
         with:
           name: output.json
-        # continue even if the file is unavailable that
-        # means there are no changes detected by CTF in the previous job
+        # continue even if the file is unavailable;
+        # that means there are no changes detected
+        # by CTF in the previous job
         continue-on-error: true
       - name: Download OpenSCAP
-        run: wget https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
+        run: |
+          wget \
+            https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
       - name: Extract OpenSCAP
         run: tar xf openscap-1.3.10.tar.gz
       - name: Build OpenSCAP
@@ -97,21 +155,33 @@ jobs:
           cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr .
           sudo cmake --build build --target install
       - name: Test if there are no content changes
-        if: ${{ steps.get_ctf_output.outcome == 'success' }}
-        run: echo "CTF_OUTPUT_SIZE=$(stat --printf="%s" output.json)" >> $GITHUB_OUTPUT
+        if: >-
+          ${{ steps.get_ctf_output.outcome == 'success' }}
+        run: >-
+          echo "CTF_OUTPUT_SIZE=$(stat --printf="%s"
+          output.json)" >> $GITHUB_OUTPUT
         id: ctf
       - name: Print changes to content detected if any
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: cat output.json
       - name: Generate id_rsa key
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ssh-keygen -N '' -t rsa -f ~/.ssh/id_rsa
       - name: Build test suite container
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-debian12
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: |
+          podman build \
+            --build-arg \
+            "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" \
+            -t ssg_test_suite \
+            -f test_suite-debian12
         working-directory: ./Dockerfiles
       - name: Get oscap-ssh
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |
           wget https://raw.githubusercontent.com/OpenSCAP/openscap/maint-1.3/utils/oscap-ssh
           sudo chmod 755 oscap-ssh
@@ -119,77 +189,138 @@ jobs:
           sudo chown root:root /usr/local/bin/oscap-ssh
           rm -f oscap-ssh
       - name: Get rule ids to be tested
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'rules'
       - name: Get product attribute
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Get bash attribute
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'bash'
       - name: Get ansible attribute
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'ansible'
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+      # actions/download-artifact v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
-        if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        if: >-
+          ${{steps.bash.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: |
+          tests/test_rule_in_container.sh \
+            --no-make-applicable-in-containers \
+            --dontclean \
+            --logdir logs_bash \
+            --remediate-using bash \
+            --name ssg_test_suite \
+            --datastream $DATASTREAM \
+            ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
+          ADDITIONAL_TEST_OPTIONS: >-
+            --duplicate-templates
+            --remove-fips-certified
       - name: Check for ERROR in logs
-        if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{steps.bash.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
         id: check_results_bash
-        # when grep returns 1 means it didn't find the ^ERROR string in the test_suite.log file
-        # and this means tests finished successfully without errors. So the job needs to keep going.
-        # By using continue-on-error: true the "conclusion" parameter is set to true so it's not possible to use
-        # it to determine whether the task has failed or succeed. The "outcome" parameter has to be used instead.
+        # when grep returns 1 means it didn't find the
+        # ^ERROR string in the test_suite.log file and
+        # this means tests finished successfully without
+        # errors. So the job needs to keep going.
+        # By using continue-on-error: true the
+        # "conclusion" parameter is set to true so it's
+        # not possible to use it to determine whether
+        # the task has failed or succeed. The "outcome"
+        # parameter has to be used instead.
         # See the step below
         continue-on-error: true
       - name: Upload logs in case of failure
-        if: ${{steps.bash.outputs.prop == 'True' && steps.check_results_bash.outcome == 'success' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        if: >-
+          ${{steps.bash.outputs.prop == 'True'
+          && steps.check_results_bash.outcome == 'success'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: logs_bash
           path: logs_bash/
       - name: Run tests in a container - Ansible
-        if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        if: >-
+          ${{ steps.ansible.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: |
+          tests/test_rule_in_container.sh \
+            --no-make-applicable-in-containers \
+            --dontclean \
+            --logdir logs_ansible \
+            --remediate-using ansible \
+            --name ssg_test_suite \
+            --datastream $DATASTREAM \
+            ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product debian12"
+          ADDITIONAL_TEST_OPTIONS: >-
+            --duplicate-templates
+            --remove-fips-certified
+            --product debian12
       - name: Check for ERROR in logs
-        if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{steps.ansible.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log
         id: check_results_ansible
         continue-on-error: true
       - name: Upload logs in case of failure
-        if: ${{ steps.ansible.outputs.prop == 'True' && steps.check_results_ansible.outcome == 'success' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        if: >-
+          ${{ steps.ansible.outputs.prop == 'True'
+          && steps.check_results_ansible.outcome == 'success'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: logs_ansible
           path: logs_ansible/
-      - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
-        if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+      - name: Fail if ERROR in test logs
+        if: >-
+          ${{ (steps.check_results_bash.outcome == 'success'
+          || steps.check_results_ansible.outcome == 'success')
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |
-          [[ -f logs_bash/test_suite.log ]] && echo "---------Bash Remediation Logs---------" && cat logs_bash/test_suite.log | grep -v "DEBUG - "
-          [[ -f logs_ansible/test_suite.log ]] && echo "---------Ansible Remediation Logs---------" && cat logs_ansible/test_suite.log | grep -v "DEBUG - "
+          [[ -f logs_bash/test_suite.log ]] \
+            && echo "---Bash Remediation Logs---" \
+            && cat logs_bash/test_suite.log \
+            | grep -v "DEBUG - "
+          [[ -f logs_ansible/test_suite.log ]] \
+            && echo "---Ansible Remediation Logs---" \
+            && cat logs_ansible/test_suite.log \
+            | grep -v "DEBUG - "
           exit 1

--- a/.github/workflows/automatus-debian12.yaml
+++ b/.github/workflows/automatus-debian12.yaml
@@ -34,13 +34,11 @@ jobs:
       - name: Install deps python
         run: pip3 install gitpython xmldiff lxml lxml-stubs requests
       - name: Checkout
-        # actions/checkout v4
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 0
       - name: Checkout (CTF)
-        # actions/checkout v4
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           repository: ComplianceAsCode/content-test-filtering
           path: ctf
@@ -72,8 +70,7 @@ jobs:
           echo "CTF_OUTPUT_SIZE=$(stat --printf="%s"
           output.json)" >> $GITHUB_OUTPUT
         id: ctf
-      # actions/upload-artifact v4
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: output.json
@@ -84,8 +81,8 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -103,8 +100,7 @@ jobs:
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ./build_product debian12
-      # actions/upload-artifact v4
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ${{ env.DATASTREAM }}
@@ -131,11 +127,9 @@ jobs:
             libyaml-dev libxmlsec1-dev \
             libxmlsec1-openssl
       - name: Checkout
-        # actions/checkout v4
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Get cached CTF output
-        # actions/download-artifact v4
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         id: get_ctf_output
         with:
           name: output.json
@@ -192,8 +186,8 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'rules'
@@ -201,8 +195,8 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -210,8 +204,8 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'bash'
@@ -219,13 +213,12 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'ansible'
-      # actions/download-artifact v4
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
@@ -269,8 +262,7 @@ jobs:
           ${{steps.bash.outputs.prop == 'True'
           && steps.check_results_bash.outcome == 'success'
           && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: logs_bash
           path: logs_bash/
@@ -304,8 +296,7 @@ jobs:
           ${{ steps.ansible.outputs.prop == 'True'
           && steps.check_results_ansible.outcome == 'success'
           && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: logs_ansible
           path: logs_ansible/

--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -34,13 +34,11 @@ jobs:
       - name: Install deps python
         run: pip3 install gitpython xmldiff lxml lxml-stubs requests
       - name: Checkout
-        # actions/checkout v4
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           fetch-depth: 0
       - name: Checkout (CTF)
-        # actions/checkout v4
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
           repository: ComplianceAsCode/content-test-filtering
           path: ctf
@@ -72,8 +70,7 @@ jobs:
           echo "CTF_OUTPUT_SIZE=$(stat --printf="%s"
           output.json)" >> $GITHUB_OUTPUT
         id: ctf
-      # actions/upload-artifact v4
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: output.json
@@ -84,8 +81,8 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -103,8 +100,7 @@ jobs:
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ./build_product ubuntu2204
-      # actions/upload-artifact v4
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ${{ env.DATASTREAM }}
@@ -131,11 +127,9 @@ jobs:
             libyaml-dev libxmlsec1-dev \
             libxmlsec1-openssl
       - name: Checkout
-        # actions/checkout v4
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Get cached CTF output
-        # actions/download-artifact v4
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         id: get_ctf_output
         with:
           name: output.json
@@ -192,8 +186,8 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'rules'
@@ -201,8 +195,8 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -210,8 +204,8 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'bash'
@@ -219,13 +213,12 @@ jobs:
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        # notiz-dev/github-action-json-property v0.2.0
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
+        # yamllint disable-line rule:line-length
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
         with:
           path: 'output.json'
           prop_path: 'ansible'
-      # actions/download-artifact v4
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         if: >-
           ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
@@ -269,8 +262,7 @@ jobs:
           ${{steps.bash.outputs.prop == 'True'
           && steps.check_results_bash.outcome == 'success'
           && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: logs_bash
           path: logs_bash/
@@ -304,8 +296,7 @@ jobs:
           ${{ steps.ansible.outputs.prop == 'True'
           && steps.check_results_ansible.outcome == 'success'
           && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: logs_ansible
           path: logs_ansible/

--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -1,9 +1,11 @@
 name: Automatus Ubuntu 22.04
 on:
   pull_request:
-    branches: [ master, 'stabilization*' ]
+    branches: [master, 'stabilization*']
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{
+    github.event.number || github.run_id }}
   cancel-in-progress: true
 env:
   DATASTREAM: ssg-ubuntu2204-ds.xml
@@ -13,32 +15,65 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build python3-yaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip libxml2-utils xsltproc ansible-lint wget libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python3 swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev g++ libyaml-dev libxmlsec1-dev libxmlsec1-openssl
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            cmake ninja-build python3-yaml \
+            python3-jinja2 git python3-deepdiff \
+            python3-requests jq python3-pip \
+            libxml2-utils xsltproc ansible-lint wget \
+            libdbus-1-dev libdbus-glib-1-dev \
+            libcurl4-openssl-dev libgcrypt20-dev \
+            libselinux1-dev libxslt1-dev \
+            libgconf2-dev libacl1-dev libblkid-dev \
+            libcap-dev libxml2-dev libldap2-dev \
+            libpcre3-dev python3 swig \
+            libxml-parser-perl libxml-xpath-perl \
+            libperl-dev libbz2-dev librpm-dev g++ \
+            libyaml-dev libxmlsec1-dev \
+            libxmlsec1-openssl
       - name: Install deps python
         run: pip3 install gitpython xmldiff lxml lxml-stubs requests
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        # actions/checkout v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Checkout (CTF)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        # actions/checkout v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ComplianceAsCode/content-test-filtering
           path: ctf
       # https://github.com/actions/checkout/issues/766
       - name: Set git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: >-
+          git config --global --add safe.directory
+          "$GITHUB_WORKSPACE"
       - name: Find forking point
         env:
           BASE_BRANCH: ${{ github.base_ref }}
-        run: echo "FORK_POINT=$(git merge-base origin/$BASE_BRANCH ${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
+        run: |
+          FORK_POINT=$(git merge-base \
+            origin/$BASE_BRANCH \
+            ${{ github.event.pull_request.head.sha }})
+          echo "FORK_POINT=$FORK_POINT" >> $GITHUB_OUTPUT
         id: fork_point
       - name: Detect content changes in the PR
-        run: python3 ./ctf/content_test_filtering.py pr --base ${{ steps.fork_point.outputs.FORK_POINT }} --remote_repo ${{ github.server_url }}/${{ github.repository }}  --verbose --rule --output json ${{ github.event.pull_request.number }} > output.json
+        run: |
+          python3 ./ctf/content_test_filtering.py pr \
+            --base ${{ steps.fork_point.outputs.FORK_POINT }} \
+            --remote_repo \
+            ${{ github.server_url }}/${{ github.repository }} \
+            --verbose --rule --output json \
+            ${{ github.event.pull_request.number }} \
+            > output.json
       - name: Test if there are no content changes
-        run: echo "CTF_OUTPUT_SIZE=$(stat --printf="%s" output.json)" >> $GITHUB_OUTPUT
+        run: >-
+          echo "CTF_OUTPUT_SIZE=$(stat --printf="%s"
+          output.json)" >> $GITHUB_OUTPUT
         id: ctf
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      # actions/upload-artifact v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: output.json
@@ -49,12 +84,15 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Download OpenSCAP
-        run: wget https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
+        run: |
+          wget \
+            https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
       - name: Extract OpenSCAP
         run: tar xf openscap-1.3.10.tar.gz
       - name: Build OpenSCAP
@@ -65,7 +103,8 @@ jobs:
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ./build_product ubuntu2204
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      # actions/upload-artifact v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ${{ env.DATASTREAM }}
@@ -76,19 +115,38 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt update && sudo apt install -y cmake ninja-build libxml2-utils xsltproc python3-jinja2 python3-yaml ansible-lint podman wget libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev python3 swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev librpm-dev g++ libyaml-dev libxmlsec1-dev libxmlsec1-openssl
+        run: |
+          sudo apt update && sudo apt install -y \
+            cmake ninja-build libxml2-utils xsltproc \
+            python3-jinja2 python3-yaml ansible-lint \
+            podman wget \
+            libdbus-1-dev libdbus-glib-1-dev \
+            libcurl4-openssl-dev libgcrypt20-dev \
+            libselinux1-dev libxslt1-dev \
+            libgconf2-dev libacl1-dev libblkid-dev \
+            libcap-dev libxml2-dev libldap2-dev \
+            libpcre3-dev python3 swig \
+            libxml-parser-perl libxml-xpath-perl \
+            libperl-dev libbz2-dev librpm-dev g++ \
+            libyaml-dev libxmlsec1-dev \
+            libxmlsec1-openssl
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        # actions/checkout v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Get cached CTF output
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        # actions/download-artifact v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         id: get_ctf_output
         with:
           name: output.json
-        # continue even if the file is unavailable that
-        # means there are no changes detected by CTF in the previous job
+        # continue even if the file is unavailable;
+        # that means there are no changes detected
+        # by CTF in the previous job
         continue-on-error: true
       - name: Download OpenSCAP
-        run: wget https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
+        run: |
+          wget \
+            https://github.com/OpenSCAP/openscap/releases/download/1.3.10/openscap-1.3.10.tar.gz
       - name: Extract OpenSCAP
         run: tar xf openscap-1.3.10.tar.gz
       - name: Build OpenSCAP
@@ -97,21 +155,33 @@ jobs:
           cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr .
           sudo cmake --build build --target install
       - name: Test if there are no content changes
-        if: ${{ steps.get_ctf_output.outcome == 'success' }}
-        run: echo "CTF_OUTPUT_SIZE=$(stat --printf="%s" output.json)" >> $GITHUB_OUTPUT
+        if: >-
+          ${{ steps.get_ctf_output.outcome == 'success' }}
+        run: >-
+          echo "CTF_OUTPUT_SIZE=$(stat --printf="%s"
+          output.json)" >> $GITHUB_OUTPUT
         id: ctf
       - name: Print changes to content detected if any
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: cat output.json
       - name: Generate id_rsa key
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ssh-keygen -N '' -t rsa -f ~/.ssh/id_rsa
       - name: Build test suite container
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-ubuntu2204
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: |
+          podman build \
+            --build-arg \
+            "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" \
+            -t ssg_test_suite \
+            -f test_suite-ubuntu2204
         working-directory: ./Dockerfiles
       - name: Get oscap-ssh
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |
           wget https://raw.githubusercontent.com/OpenSCAP/openscap/maint-1.3/utils/oscap-ssh
           sudo chmod 755 oscap-ssh
@@ -119,77 +189,138 @@ jobs:
           sudo chown root:root /usr/local/bin/oscap-ssh
           rm -f oscap-ssh
       - name: Get rule ids to be tested
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'rules'
       - name: Get product attribute
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Get bash attribute
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'bash'
       - name: Get ansible attribute
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8 # v0.2.0
+        # notiz-dev/github-action-json-property v0.2.0
+        uses: notiz-dev/github-action-json-property@a5a9c668b16513c737c3e1f8956772c99c73f6e8
         with:
           path: 'output.json'
           prop_path: 'ansible'
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+      # actions/download-artifact v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        if: >-
+          ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
-        if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        if: >-
+          ${{steps.bash.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: |
+          tests/test_rule_in_container.sh \
+            --no-make-applicable-in-containers \
+            --dontclean \
+            --logdir logs_bash \
+            --remediate-using bash \
+            --name ssg_test_suite \
+            --datastream $DATASTREAM \
+            ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
+          ADDITIONAL_TEST_OPTIONS: >-
+            --duplicate-templates
+            --remove-fips-certified
       - name: Check for ERROR in logs
-        if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{steps.bash.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
         id: check_results_bash
-        # when grep returns 1 means it didn't find the ^ERROR string in the test_suite.log file
-        # and this means tests finished successfully without errors. So the job needs to keep going.
-        # By using continue-on-error: true the "conclusion" parameter is set to true so it's not possible to use
-        # it to determine whether the task has failed or succeed. The "outcome" parameter has to be used instead.
+        # when grep returns 1 means it didn't find the
+        # ^ERROR string in the test_suite.log file and
+        # this means tests finished successfully without
+        # errors. So the job needs to keep going.
+        # By using continue-on-error: true the
+        # "conclusion" parameter is set to true so it's
+        # not possible to use it to determine whether
+        # the task has failed or succeed. The "outcome"
+        # parameter has to be used instead.
         # See the step below
         continue-on-error: true
       - name: Upload logs in case of failure
-        if: ${{steps.bash.outputs.prop == 'True' && steps.check_results_bash.outcome == 'success' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        if: >-
+          ${{steps.bash.outputs.prop == 'True'
+          && steps.check_results_bash.outcome == 'success'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: logs_bash
           path: logs_bash/
       - name: Run tests in a container - Ansible
-        if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        if: >-
+          ${{ steps.ansible.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: |
+          tests/test_rule_in_container.sh \
+            --no-make-applicable-in-containers \
+            --dontclean \
+            --logdir logs_ansible \
+            --remediate-using ansible \
+            --name ssg_test_suite \
+            --datastream $DATASTREAM \
+            ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product ubuntu2204"
+          ADDITIONAL_TEST_OPTIONS: >-
+            --duplicate-templates
+            --remove-fips-certified
+            --product ubuntu2204
       - name: Check for ERROR in logs
-        if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        if: >-
+          ${{steps.ansible.outputs.prop == 'True'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log
         id: check_results_ansible
         continue-on-error: true
       - name: Upload logs in case of failure
-        if: ${{ steps.ansible.outputs.prop == 'True' && steps.check_results_ansible.outcome == 'success' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        if: >-
+          ${{ steps.ansible.outputs.prop == 'True'
+          && steps.check_results_ansible.outcome == 'success'
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: logs_ansible
           path: logs_ansible/
-      - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
-        if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+      - name: Fail if ERROR in test logs
+        if: >-
+          ${{ (steps.check_results_bash.outcome == 'success'
+          || steps.check_results_ansible.outcome == 'success')
+          && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |
-          [[ -f logs_bash/test_suite.log ]] && echo "---------Bash Remediation Logs---------" && cat logs_bash/test_suite.log | grep -v "DEBUG - "
-          [[ -f logs_ansible/test_suite.log ]] && echo "---------Ansible Remediation Logs---------" && cat logs_ansible/test_suite.log | grep -v "DEBUG - "
+          [[ -f logs_bash/test_suite.log ]] \
+            && echo "---Bash Remediation Logs---" \
+            && cat logs_bash/test_suite.log \
+            | grep -v "DEBUG - "
+          [[ -f logs_ansible/test_suite.log ]] \
+            && echo "---Ansible Remediation Logs---" \
+            && cat logs_ansible/test_suite.log \
+            | grep -v "DEBUG - "
           exit 1


### PR DESCRIPTION
#### Description:

- Fix all pre-existing yamllint violations (26 per file) in the `automatus-debian12.yaml` and `automatus-ubuntu2204.yaml` GitHub Actions workflow files.
- Changes are purely formatting -- no functional changes to CI behavior.
- Techniques used:
  - Fix bracket spacing on branch filters (`[ master, ...]` to `[master, ...]`)
  - Break long `apt-get`/`apt` install commands using `run: |` with `\` line continuations
  - Break long shell commands (`git`, `python3`, `podman`, `wget`, test scripts) into multiline blocks
  - Move inline version comments from `uses:` lines to comment lines above (e.g., `# notiz-dev/github-action-json-property v0.2.0`)
  - Fold long `if:` expressions using `>-` YAML scalars
  - Fold long `env:` values using `>-` YAML scalars
  - Rewrap long comments and shorten long step names

#### Rationale:

- These yamllint violations were pre-existing but never caught because the CI lint job (`ci_lint.yml`) only validates files modified by a PR. Any PR that touches either of these workflow files would trigger yamllint failures unrelated to the PR's changes.
- This was observed in PR #14743 where a one-line change to remove a pip dependency caused 10 yamllint annotation errors.

#### Review Hints:

- Verify locally with: `yamllint -s -c .yamllint .github/workflows/automatus-debian12.yaml .github/workflows/automatus-ubuntu2204.yaml`
- Both files are structurally identical except for product-specific values (`debian12` vs `ubuntu2204`). Reviewing one file thoroughly and then spot-checking the other for product name differences is sufficient.
- Related PR: #14743 (Remove compliance-trestle dependency), which is blocked by these lint failures.
