### PR TITLE
[stabilization] Fix pwquality_path for SLE16

### DIFF
--- a/tests/data/product_stability/sle16.yml
+++ b/tests/data/product_stability/sle16.yml
@@ -69,7 +69,7 @@ platform_package_overrides:
 product: sle16
 profiles_root: ./profiles
 pwhistory_path: /usr/etc/security/pwhistory.conf
-pwquality_path: /usr/lib/security/pwquality.conf
+pwquality_path: /etc/security/pwquality.conf
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers


### PR DESCRIPTION
This is a backport of https://github.com/ComplianceAsCode/content/pull/14741 to the stabilization branch

Addressing:
```
Following properties got different values in the sle16 product:
 - pwquality_path from '/usr/lib/security/pwquality.conf' -> '/etc/security/pwquality.conf'
If changes to mentioned products are intentional, execute this script with PYTHONPATH set to the project root to regenerate reference products: 
/__w/content/content/tests/test_product_stability.py --update-reference-data /__w/content/content/products /__w/content/content/tests/data/product_stability
If those changes are unwanted, take a look at product properties that likely cause these changes.

```