### PR TITLE
Fix no_invalid_shell_accounts_unlocked for unlocked user in last line of /etc/passwd

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
@@ -44,7 +44,7 @@
     <concat>
       <literal_component>^(?:</literal_component>
       <object_component item_field="subexpression" object_ref="obj_{{{ rule_id }}}_local_interactive_users" />
-      <literal_component>):(?:[^:]*:){5}([^:]+)$</literal_component>
+      <literal_component>):(?:[^:]*:){5}([^\n\r:]+)$</literal_component>
     </concat>
   </local_variable>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/unlocked_valid_shell.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/unlocked_valid_shell.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "testuser:x:1001:1001::/home/testuser:/bin/bash" >> /etc/passwd
+echo 'testuser:$6$exIFis0tobKRcGBk$b.UR.Z8h96FdxJ1bgA/vhdnp0Lsm488swdILNguQX/5qH5hdmClyYb5xk3TpELXWzr4JOiTlHfRkPsXSjMPjv0:20111:0:99999:7:::' >> /etc/shadow
+echo "/bin/bash" >> /etc/shells


### PR DESCRIPTION
When the last line in /etc/passwd is an unlocked user with a valid shell, the shell path was parsed as '/path/to/shell\n' instead of just '/path/to/shell' and the comparison to valid shells list failed.

Fixes: https://github.com/ComplianceAsCode/content/issues/13657
