### PR TITLE
CMP-4284: Fix api_server_bind_address for IPv6 and dual-stack clusters

### DIFF
--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -11,13 +11,17 @@ title: Ensure that the bindAddress is set to a relevant secure port
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 
-description: "The bindAddress is set by default to <tt>0.0.0.0:6443</tt>, and listening with TLS enabled."
+description: |-
+  The bindAddress is set by default to <tt>0.0.0.0:6443</tt> on IPv4 clusters
+  or <tt>[::]:6443</tt> on IPv6 and dual-stack clusters, and listening with
+  TLS enabled.
 
 rationale: |-
   The OpenShift API server is served over HTTPS with authentication and authorization;
-  the secure API endpoint is bound to <tt>0.0.0.0:6443</tt> by default. In OpenShift, the only
+  the secure API endpoint is bound to <tt>0.0.0.0:6443</tt> (IPv4) or
+  <tt>[::]:6443</tt> (IPv6/dual-stack) by default. In OpenShift, the only
   supported way to access the API server pod is through the load balancer and then through
-  the internal service.  The value is set by the bindAddress argument under the servingInfo
+  the internal service. The value is set by the bindAddress argument under the servingInfo
   parameter.
 
 identifiers:
@@ -38,7 +42,8 @@ ocil_clause: '<tt>bindAddress</tt> allows unsecure connections'
 ocil: |-
     Run the following command:
     <pre>oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq -r '.servingInfo["bindAddress"]'</pre>
-    The output should return <pre>0.0.0.0:6443</pre>.
+    The output should return <pre>0.0.0.0:6443</pre> on IPv4 single-stack clusters
+    or <pre>[::]:6443</pre> on IPv6 and dual-stack clusters.
 
 warnings:
 - general: |-
@@ -52,8 +57,4 @@ template:
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.servingInfo["bindAddress"]'
     xccdf_variable: var_apiserver_bind_address
-    embedded_data: "true"
-    values:
-    - value: '(.+)'
-      operation: "pattern match"
-      type: "string"
+    regex_data: "true"

--- a/applications/openshift/api-server/var_apiserver_bind_address.var
+++ b/applications/openshift/api-server/var_apiserver_bind_address.var
@@ -2,13 +2,17 @@ documentation_complete: true
 
 title: 'Bind Address of secure API endpoint'
 
-description: 'Bind Address of secure API endpoint'
+description: |-
+    Regular expression matching the expected bind address
+    of the secure API endpoint. Accepts both IPv4 (0.0.0.0:6443)
+    and IPv6 ([::]:6443) wildcard addresses to support
+    single-stack and dual-stack clusters.
 
 type: string
 
-operator: equals
+operator: pattern match
 
 interactive: false
 
 options:
-    default: "0.0.0.0:6443"
+    default: "^(0\\.0\\.0\\.0:6443|\\[::\\]:6443)$"


### PR DESCRIPTION
#### Description:

- Fix rule `api_server_bind_address` to accept both `0.0.0.0:6443` (IPv4) and `[::]:6443` (IPv6/dual-stack) as valid bind addresses. Previously the rule hardcoded `0.0.0.0:6443` via an exact-match variable, causing failures on IPv6 single-stack and dual-stack clusters.
- Switch from `embedded_data` with equals comparison to `regex_data` with a pattern-match variable, following the same approach used by `configure_network_policies`.

#### Rationale:

- On IPv6 single-stack and dual-stack OCP clusters, the kube-apiserver operator sets `servingInfo.bindAddress` to `[::]:6443` instead of `0.0.0.0:6443` (see [CORS-4363](https://github.com/openshift/cluster-kube-apiserver-operator/pull/2079)). Both values mean "listen on all interfaces on the TLS port" and are security-equivalent. The rule should pass for either.

#### Review Hints:

- Only two files changed: `rule.yml` and `var_apiserver_bind_address.var`. Review them together.
- The template code path follows the same pattern as `configure_network_policies` (`xccdf_variable` + `regex_data`), which is well-tested.
- Build with: `./build_product --datastream-only ocp4`
- Affected profiles: any profile including `api_server_bind_address` (STIG, CIS, PCI-DSS, moderate, high).

[CORS-4363]: https://redhat.atlassian.net/browse/CORS-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ