### PR TITLE
CMP-4323: Fix file_permissions/owner/groupowner_cni_conf for /etc/kubernetes/cni/net.d and runtime lock files

### DIFF
--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -5,7 +5,12 @@ platform: ocp4-node
 
 title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+description: |-
+    {{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -31,6 +36,6 @@ ocil: |-
 template:
     name: file_groupowner
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -5,7 +5,12 @@ platform: ocp4-node
 
 title: 'Verify User Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+description: |-
+    {{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -31,6 +36,6 @@ ocil: |-
 template:
     name: file_owner
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         uid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -7,6 +7,10 @@ title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -32,6 +36,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*\.(conf|conflist|json)$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -32,6 +32,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf_not_s390x/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf_not_s390x/rule.yml
@@ -7,6 +7,10 @@ title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
     This rule is for architectures other than s390x.
 
 rationale: |-
@@ -33,6 +37,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*\.(conf|conflist|json)$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf_not_s390x/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf_not_s390x/rule.yml
@@ -33,6 +33,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf_s390x/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf_s390x/rule.yml
@@ -7,6 +7,10 @@ title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
     This rule is for architectures on s390x.
 
 rationale: |-
@@ -33,6 +37,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*\.(conf|conflist|json)$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf_s390x/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf_s390x/rule.yml
@@ -33,6 +33,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"


### PR DESCRIPTION
#### Description:

The `file_permissions_cni_conf` rules (and the `_not_s390x` / `_s390x` variants), plus the sibling `file_owner_cni_conf` / `file_groupowner_cni_conf` rules, only matched CNI config files under `/etc/cni/net.d/`. This caused two problems, both reported against the rule:

1. **Runtime lock file false FAIL.** `/etc/cni/net.d/` can contain `cni.lock` — a zero-byte `flock` sentinel created by CRI-O/podman with mode `0644`. The original permissions regex `^/etc/cni/net.d/.*$` matched it and reported FAIL on otherwise-compliant clusters.

2. **Wrong / missing directory (CMP-4323).** `/etc/cni/net.d/` is populated by the **cri-o RPM** (the `100-crio-bridge.conflist` / `200-loopback.conflist` bootstrap configs). It is *not* the directory CRI-O actually reads — OpenShift sets CRI-O's `network_dir` to **`/etc/kubernetes/cni/net.d/`** (via the machine-config-operator crio drop-in), where the active Multus configuration (`00-multus.conf`) lives. On **OpenShift 4.22** the cri-o RPM no longer ships the `/etc/cni/net.d/` bootstrap configs and the directory is **absent**, so the rules matched nothing and silently provided no coverage while the real configuration in `/etc/kubernetes/cni/net.d/` went unchecked.

This narrows the regex to real CNI config-file extensions (fixing #1) **and** broadens it to cover both directories (fixing #2), applied consistently across the permissions, owner, and groupowner rules:

```
filepath: ^/etc/cni/net.d/.*$
       -> ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
```

#### Rationale:

`cni.lock` is a runtime lock file, not a network configuration file, and its `0644` mode is set by the container runtime — not something an admin can or should remediate. Restricting the check to actual CNI config-file extensions (`.conf`, `.conflist`, `.json`) excludes both `cni.lock` and the `0644` `whereabouts.d/nodename` file, while the `(kubernetes/)?` group keeps the rules meaningful across OpenShift versions: they verify whatever CNI config files exist, in whichever directory is present, and fail if any are more permissive than `0600` (permissions) or not owned by `root:root` (owner/groupowner).

The directory layout by version (verified on live clusters):

| OCP | cri-o | `/etc/cni/net.d/` | `/etc/kubernetes/cni/net.d/` |
|-----|-------|-------------------|------------------------------|
| 4.19 | 1.32 | present (`*.conflist`, `0600`) | present (`00-multus.conf`, `0600`) |
| 4.20 | 1.33 | present (`*.conflist`, `0600`) | present |
| 4.22 | 1.35 | **absent** | present (only location) |

#### Validation:

Built the `ocp4` datastream and ran it through the compliance-operator with `debug: true` on **three live clusters (4.19, 4.20, 4.22)**:

- Clean clusters → **PASS / COMPLIANT** on master and worker pools.
- Negative test: seeding a `0644` `.conf` into the matching directory (old path on 4.19, new path on 4.20/4.22) flips that node to **FAIL** — confirming the rule actively collects and evaluates files in **both** locations, i.e. the PASS is real coverage and not a vacuous `none_exist` pass.

The owner/groupowner siblings use the same `filepath_is_regex` template family and the same broadened regex; the CNI config files in both directories are `root:root`, so they PASS on clean clusters.

#### Review Hints:

- The `EXCLUDED_FILES` mechanism in the `file_permissions` template only applies to the `is_directory` branch, not the `filepath_is_regex` branch these rules use, so narrowing/broadening the regex is the appropriate fix.
- Grouping/alternation in `filepath` regexes is already used elsewhere with the same template family (e.g. `file_permissions_var_log_kube_audit` uses `^/var/log/kube-apiserver($|/.*$)`).

Reported via Red Hat Jira CMP-4323 (and the earlier OCPBUGS-22995, which first noted the rule checks `/etc/cni/net.d/` instead of `/etc/kubernetes/cni/net.d/`).
