### PR TITLE
Fix aarch64 audit rules for unsupported syscalls

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
@@ -13,7 +13,9 @@
 # '/etc/audit/audit.rules' (for 'auditctl') so the remediation works
 # regardless of which tool the system uses to load audit rules.
 
-# Retrieve hardware architecture of the underlying system
+# Audit rules filter by program type: 32-bit programs use a different
+# syscall table than 64-bit programs. On 64-bit systems with a 32-bit
+# compatibility layer, both can run, so rules are written for each.
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
@@ -1,6 +1,18 @@
 # platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_almalinux
 
-# Perform the remediation for the syscall rule
+# Remediation: write audit rules that log all file deletion events
+# ('rmdir', 'unlink', 'unlinkat', 'rename', 'renameat', 'renameat2'),
+# successful or not. Example output:
+#   -a always,exit -F arch=b64 -S unlinkat -F auid>=1000 -F auid!=unset -k delete
+#
+# On aarch64, 'rmdir', 'unlink', and 'rename' do not exist in the b64
+# syscall table and are skipped. The b32 table (for 32-bit programs)
+# still has them.
+#
+# Writes to both '/etc/audit/rules.d/*.rules' (for 'augenrules') and
+# '/etc/audit/audit.rules' (for 'auditctl') so the remediation works
+# regardless of which tool the system uses to load audit rules.
+
 # Retrieve hardware architecture of the underlying system
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
@@ -9,10 +21,21 @@ do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
-	SYSCALL="rmdir unlink unlinkat rename renameat renameat2"
 	KEY="delete"
-	SYSCALL_GROUPING="rmdir unlink unlinkat rename renameat renameat2"
+
+	# aarch64 b64 syscall table does not have rmdir, unlink, rename;
+	# the b32 table (for 32-bit programs, aarch64 can run 32-bit code) still has them
+	if [ "$(uname -m)" = "aarch64" ] && [ "$ARCH" = "b64" ]; then
+		SYSCALL="unlinkat renameat renameat2"
+	else
+		SYSCALL="rmdir unlink unlinkat rename renameat renameat2"
+	fi
+	# SYSCALL_GROUPING tells the macro which syscalls belong together
+	# so it merges them into existing rules instead of creating duplicates
+	SYSCALL_GROUPING="$SYSCALL"
+
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+
 	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 	{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 done

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
@@ -1,13 +1,24 @@
 <def-group>
   <definition class="compliance" id="audit_rules_file_deletion_events" version="1">
     {{{ oval_metadata("Audit files deletion events.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_rmdir" />
-      <extend_definition comment="audit unlink" definition_ref="audit_rules_file_deletion_events_unlink" />
-      <extend_definition comment="audit unlinkat" definition_ref="audit_rules_file_deletion_events_unlinkat" />
-      <extend_definition comment="audit rename" definition_ref="audit_rules_file_deletion_events_rename" />
-      <extend_definition comment="audit renameat" definition_ref="audit_rules_file_deletion_events_renameat" />
-      <extend_definition comment="audit renameat2" definition_ref="audit_rules_file_deletion_events_renameat2" />
+    <criteria operator="OR">
+      <!-- aarch64: only unlinkat, renameat, renameat2 syscalls exist -->
+      <criteria operator="AND">
+        <extend_definition comment="aarch64 architecture" definition_ref="system_info_architecture_aarch_64" />
+        <extend_definition comment="audit unlinkat" definition_ref="audit_rules_file_deletion_events_unlinkat" />
+        <extend_definition comment="audit renameat" definition_ref="audit_rules_file_deletion_events_renameat" />
+        <extend_definition comment="audit renameat2" definition_ref="audit_rules_file_deletion_events_renameat2" />
+      </criteria>
+      <!-- other architectures: all syscalls including rmdir, unlink, rename, unlinkat, renameat, renameat2 -->
+      <criteria operator="AND">
+        <extend_definition comment="aarch64 architecture" definition_ref="system_info_architecture_aarch_64" negate="true" />
+        <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_rmdir" />
+        <extend_definition comment="audit unlink" definition_ref="audit_rules_file_deletion_events_unlink" />
+        <extend_definition comment="audit unlinkat" definition_ref="audit_rules_file_deletion_events_unlinkat" />
+        <extend_definition comment="audit rename" definition_ref="audit_rules_file_deletion_events_rename" />
+        <extend_definition comment="audit renameat" definition_ref="audit_rules_file_deletion_events_renameat" />
+        <extend_definition comment="audit renameat2" definition_ref="audit_rules_file_deletion_events_renameat2" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -17,6 +17,10 @@ description: |-
     system, or having two lines for both b32 and b64 in case your system is 64-bit:
     <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat2 -S renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
 
+    If the system is aarch64, the 64-bit syscall table does not include
+    <tt>rmdir</tt>, <tt>unlink</tt>, and <tt>rename</tt> syscalls. They are replaced by
+    <tt>unlinkat</tt>, <tt>renameat</tt>, and <tt>renameat2</tt>, respectively.
+
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed
     from the system. The audit trail could aid in system troubleshooting, as well as, detecting

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -18,7 +18,9 @@
 # '/etc/audit/audit.rules' (for 'auditctl') so the remediation works
 # regardless of which tool the system uses to load audit rules.
 
-# Retrieve hardware architecture of the underlying system
+# Audit rules filter by program type: 32-bit programs use a different
+# syscall table than 64-bit programs. On 64-bit systems with a 32-bit
+# compatibility layer, both can run, so rules are written for each.
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -1,33 +1,52 @@
 # platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_almalinux
 
-# Perform the remediation of the syscall rule
+# Remediation: write audit rules that log only failed file 'open', 'create',
+# and 'truncate' attempts -- not successful ones.
+# "Failed" means the syscall returned EACCES (permission denied) or
+# EPERM (operation not permitted).
+#
+# For each architecture (b32, b64) and each syscall, two audit rules are
+# written -- one for EACCES and one for EPERM -- because auditd cannot
+# match multiple exit codes in a single rule. Example output:
+#   -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k access
+#   -a always,exit -F arch=b64 -S openat -F exit=-EPERM  -F auid>=1000 -F auid!=unset -k access
+#
+# On aarch64, 'creat' and 'open' do not exist in the b64 syscall table
+# and are skipped. The b32 table (for 32-bit programs) still has them.
+#
+# Writes to both '/etc/audit/rules.d/*.rules' (for 'augenrules') and
+# '/etc/audit/audit.rules' (for 'auditctl') so the remediation works
+# regardless of which tool the system uses to load audit rules.
+
 # Retrieve hardware architecture of the underlying system
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-
-	# First fix the -EACCES requirement
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	KEY="access"
+
+	# aarch64 b64 syscall table does not have creat or open;
+	# the b32 table (for 32-bit programs, aarch64 can run 32-bit code) still has them
+	if [ "$(uname -m)" = "aarch64" ] && [ "$ARCH" = "b64" ]; then
+		SYSCALL="openat open_by_handle_at truncate ftruncate"
+	else
+		SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
+	fi
+	# SYSCALL_GROUPING tells the macro which syscalls belong together
+	# so it merges them into existing rules instead of creating duplicates
+	SYSCALL_GROUPING="$SYSCALL"
+
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+
+	# First pass: EACCES (permission denied by file mode bits)
 	OTHER_FILTERS="-F exit=-EACCES"
-	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
-	SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
-	KEY="access"
-	SYSCALL_GROUPING="creat open openat open_by_handle_at truncate ftruncate"
-	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 	{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 
-	# Then fix the -EPERM requirement
-	# No need to change content of $GROUP variable - it's the same as for -EACCES case above
-	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	# Second pass: EPERM (operation needs a privilege the process lacks)
 	OTHER_FILTERS="-F exit=-EPERM"
-	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
-	SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
-	KEY="access"
-	SYSCALL_GROUPING="creat open openat open_by_handle_at truncate ftruncate"
-	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 	{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
-
 done

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/oval/shared.xml
@@ -2,13 +2,25 @@
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification" version="1">
     {{{ oval_metadata("Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.", rule_title=rule_title) }}}
 
-    <criteria operator="AND">
-      <extend_definition comment="audit creat" definition_ref="audit_rules_unsuccessful_file_modification_creat" />
-      <extend_definition comment="audit ftruncate" definition_ref="audit_rules_unsuccessful_file_modification_ftruncate" />
-      <extend_definition comment="audit openat" definition_ref="audit_rules_unsuccessful_file_modification_openat" />
-      <extend_definition comment="audit open_by_handle_at" definition_ref="audit_rules_unsuccessful_file_modification_open_by_handle_at" />
-      <extend_definition comment="audit open" definition_ref="audit_rules_unsuccessful_file_modification_open" />
-      <extend_definition comment="audit truncate" definition_ref="audit_rules_unsuccessful_file_modification_truncate" />
+    <criteria operator="OR">
+      <!-- aarch64: only openat, open_by_handle_at, truncate, ftruncate exist -->
+      <criteria operator="AND">
+        <extend_definition comment="aarch64 architecture" definition_ref="system_info_architecture_aarch_64" />
+        <extend_definition comment="audit ftruncate" definition_ref="audit_rules_unsuccessful_file_modification_ftruncate" />
+        <extend_definition comment="audit openat" definition_ref="audit_rules_unsuccessful_file_modification_openat" />
+        <extend_definition comment="audit open_by_handle_at" definition_ref="audit_rules_unsuccessful_file_modification_open_by_handle_at" />
+        <extend_definition comment="audit truncate" definition_ref="audit_rules_unsuccessful_file_modification_truncate" />
+      </criteria>
+      <!-- other architectures: all syscalls including creat, open -->
+      <criteria operator="AND">
+        <extend_definition comment="aarch64 architecture" definition_ref="system_info_architecture_aarch_64" negate="true" />
+        <extend_definition comment="audit creat" definition_ref="audit_rules_unsuccessful_file_modification_creat" />
+        <extend_definition comment="audit ftruncate" definition_ref="audit_rules_unsuccessful_file_modification_ftruncate" />
+        <extend_definition comment="audit openat" definition_ref="audit_rules_unsuccessful_file_modification_openat" />
+        <extend_definition comment="audit open_by_handle_at" definition_ref="audit_rules_unsuccessful_file_modification_open_by_handle_at" />
+        <extend_definition comment="audit open" definition_ref="audit_rules_unsuccessful_file_modification_open" />
+        <extend_definition comment="audit truncate" definition_ref="audit_rules_unsuccessful_file_modification_truncate" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -25,6 +25,9 @@ description: |-
     -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
     -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
 
+    If the system is aarch64, the 64-bit syscall table does not include
+    <tt>creat</tt> and <tt>open</tt> syscalls. They are replaced by <tt>openat</tt>.
+
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
     these events could serve as evidence of potential system compromise.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -31,9 +31,6 @@ rationale: |-
 
 severity: medium
 
-platforms:
-    - not aarch64_arch
-
 identifiers:
     cce@rhel8: CCE-80750-3
     cce@rhel9: CCE-83793-0


### PR DESCRIPTION
### Description:

Fix `audit_rules_file_deletion_events` and `audit_rules_unsuccessful_file_modification`
for aarch64.

Some syscalls do not exist on aarch64 for 64-bit programs. 32-bit programs (via the
compatibility layer) still have them.

Missing syscalls and their replacements:
- `rmdir`, `unlink`, `rename` -> `unlinkat`, `renameat`, `renameat2`
- `creat`, `open` -> `openat`

Both rules had two problems on aarch64:
- The bash remediation wrote audit rules for nonexistent syscalls. `auditctl` rejects
  unknown syscalls with "Syscall name unknown" and stops loading all subsequent rules,
  causing `audit-rules.service` to fail.
- The OVAL check expected all syscalls to be present in the audit config, including the
  ones that don't exist on aarch64. A correctly configured aarch64 system would fail the
  scan.

### Changes:

Bash remediations (`bash/shared.sh`):
- Detect aarch64 at runtime via `uname -m`
- On aarch64 b64: write only supported syscalls to the audit config
- On b32 and non-aarch64: write all syscalls as before

OVAL checks (`oval/shared.xml`):
- Detect aarch64 at scan time
- On aarch64: expect only supported syscalls in the audit config
- On other architectures: expect all syscalls

`audit_rules_unsuccessful_file_modification/rule.yml`:
- Remove `platform: not aarch64_arch`; the rule was completely excluded from aarch64
  because the OVAL and remediation didn't handle it. Now that they do, the exclusion is no
  longer needed.

### Rationale:

Per-syscall rules (e.g. `audit_rules_file_deletion_events_rename`) already handle aarch64
via `platform: not aarch64_arch`.

`audit_rules_file_deletion_events` and `audit_rules_unsuccessful_file_modification` bundle
all syscalls into one rule and had no aarch64 handling:
- Some profiles select them directly
- Excluding them would mean no audit coverage on aarch64
- This PR makes them work by writing only supported syscalls

- Fixes #14196
- Fixes #14372

### Review hints:

1. Build:
```bash
./build_product rhel9 --datastream
```

2. Run Automatus on an aarch64 VM:
```bash
python3 automatus.py rule \
    --libvirt qemu:///session rhel9-aarch64 \
    --datastream build/ssg-rhel9-ds.xml \
    audit_rules_file_deletion_events \
    audit_rules_unsuccessful_file_modification
```

3. Manual check -- SSH into the aarch64 VM and verify:
- `auditd` loads the rules without errors
- `auditctl -l` shows only supported syscalls for b64 rules
```bash
auditctl -R /etc/audit/rules.d/*.rules
auditctl -l
```

Note: I recommend using an `aarch64` VM for this, or testing natively on `aarch64`.
