### PR TITLE
Fix overlayfs kernel mod name

### DIFF
--- a/linux_os/guide/system/permissions/mounting/kernel_module_overlayfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_overlayfs_disabled/rule.yml
@@ -3,13 +3,13 @@ documentation_complete: true
 title: 'Ensure overlayfs kernel module is not available'
 
 description: |-
-    {{{ describe_module_disable(module="overlayfs") }}}
+    {{{ describe_module_disable(module="overlay") }}}
     overlayfs is a Linux filesystem that layers multiple filesystems to create a single
     unified view which allows a user to "merge" several mount points into a unified
     filesystem.
 
 rationale: |-
-    The overlayfs has known CVE's. Disabling the overlayfs reduces the local attack 
+    The overlayfs has known CVE's. Disabling the overlayfs reduces the local attack
     surface by removing support for unnecessary filesystem types and mitigates potential
     risks associated with unauthorized execution of setuid files, enhancing the overall
     system security.
@@ -26,4 +26,4 @@ platform: system_with_kernel
 template:
     name: kernel_module_disabled
     vars:
-        kernmodule: overlayfs
+        kernmodule: overlay


### PR DESCRIPTION


#### Description:

Fix overlayfs kernel mod name
#### Rationale:

Fixes #14761
#### Review Hints:

```
$ modinfo overlayfs                  
modinfo: ERROR: Module overlayfs not found.
$ modinfo overlay  
filename:       /lib/modules/..
``` 
