### PR TITLE
Add service disable rules for Kea DHCP server (CIS 2.1.3)

### DIFF
--- a/components/dhcp.yml
+++ b/components/dhcp.yml
@@ -20,5 +20,8 @@ rules:
 - package_dhcp_removed
 - service_dhcpd_disabled
 - service_dhcpd6_disabled
+- service_kea_dhcp4_server_disabled
+- service_kea_dhcp6_server_disabled
+- service_kea_dhcp_ddns_server_disabled
 - sysconfig_networking_bootproto_ifcfg
 - package_kea_removed

--- a/components/kea.yml
+++ b/components/kea.yml
@@ -3,3 +3,6 @@ packages:
 - kea
 rules:
 - package_kea_removed
+- service_kea_dhcp4_server_disabled
+- service_kea_dhcp6_server_disabled
+- service_kea_dhcp_ddns_server_disabled

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_kea_dhcp4_server_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_kea_dhcp4_server_disabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Disable kea-dhcp4-server Service'
+
+description: |-
+    The <tt>kea-dhcp4-server</tt> service should be disabled on
+    any system that does not need to act as a DHCPv4 server.
+    {{{ describe_service_disable(service="kea-dhcp4-server") }}}
+
+rationale: |-
+    Unmanaged or unintentionally activated DHCP servers may provide faulty information
+    to clients, interfering with the operation of a legitimate site
+    DHCP server if there is one.
+
+severity: medium
+
+ocil_clause: |-
+    {{{ ocil_clause_service_disabled(service="kea-dhcp4-server") }}}
+
+ocil: |-
+    {{{ ocil_service_disabled(service="kea-dhcp4-server") }}}
+
+platform: system_with_kernel
+
+template:
+    name: service_disabled
+    vars:
+        servicename: kea-dhcp4-server
+        packagename: kea

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_kea_dhcp6_server_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_kea_dhcp6_server_disabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Disable kea-dhcp6-server Service'
+
+description: |-
+    The <tt>kea-dhcp6-server</tt> service should be disabled on
+    any system that does not need to act as a DHCPv6 server.
+    {{{ describe_service_disable(service="kea-dhcp6-server") }}}
+
+rationale: |-
+    Unmanaged or unintentionally activated DHCP servers may provide faulty information
+    to clients, interfering with the operation of a legitimate site
+    DHCP server if there is one.
+
+severity: medium
+
+ocil_clause: |-
+    {{{ ocil_clause_service_disabled(service="kea-dhcp6-server") }}}
+
+ocil: |-
+    {{{ ocil_service_disabled(service="kea-dhcp6-server") }}}
+
+platform: system_with_kernel
+
+template:
+    name: service_disabled
+    vars:
+        servicename: kea-dhcp6-server
+        packagename: kea

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_kea_dhcp_ddns_server_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_kea_dhcp_ddns_server_disabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Disable kea-dhcp-ddns-server Service'
+
+description: |-
+    The <tt>kea-dhcp-ddns-server</tt> service should be disabled on
+    any system that does not need to act as a DHCP Dynamic DNS update server.
+    {{{ describe_service_disable(service="kea-dhcp-ddns-server") }}}
+
+rationale: |-
+    Unmanaged or unintentionally activated DHCP servers may provide faulty information
+    to clients, interfering with the operation of a legitimate site
+    DHCP server if there is one.
+
+severity: medium
+
+ocil_clause: |-
+    {{{ ocil_clause_service_disabled(service="kea-dhcp-ddns-server") }}}
+
+ocil: |-
+    {{{ ocil_service_disabled(service="kea-dhcp-ddns-server") }}}
+
+platform: system_with_kernel
+
+template:
+    name: service_disabled
+    vars:
+        servicename: kea-dhcp-ddns-server
+        packagename: kea


### PR DESCRIPTION
Add three new rules to disable the Kea DHCP server services:
- service_kea_dhcp4_server_disabled
- service_kea_dhcp6_server_disabled
- service_kea_dhcp_ddns_server_disabled

Kea is the ISC successor to ISC DHCP and ships as the default DHCP server on Debian 13. CIS Debian Linux 13 Benchmark v1.0.0 section 2.1.3 requires these services to be disabled on systems that do not act as DHCP servers. All three rules use the service_disabled template. Map the new rules to the existing kea component.

#### Description:

  - Add three new rules to disable the Kea DHCP server services:
    `service_kea_dhcp4_server_disabled`, `service_kea_dhcp6_server_disabled`,
    and `service_kea_dhcp_ddns_server_disabled`.
  - Map the new rules to the existing `kea` component.

#### Rationale:

  - Kea is the ISC successor to ISC DHCP and ships as the default DHCP server
    on Debian 13. Systems that do not act as DHCP servers should have these
    services disabled to reduce the attack surface.
  - Unmanaged or unintentionally activated DHCP servers may provide faulty
    information to clients, interfering with the operation of a legitimate
    site DHCP server.
  - All three rules use the `service_disabled` template, consistent with the
    existing `service_dhcpd_disabled` and `service_dhcpd6_disabled` rules.

#### Review Hints:

  - Three new rule directories under
    `linux_os/guide/services/dhcp/disabling_dhcp_server/`, each with a
    single `rule.yml` using the `service_disabled` template.
  - Build to verify: `./build_product debian13 --datastream-only`
