### PR TITLE
Add UFW default policy rules with OVAL checks (CIS 3.3.x)

### DIFF
--- a/components/ufw.yml
+++ b/components/ufw.yml
@@ -10,6 +10,9 @@ rules:
 - service_ufw_enabled
 - set_ufw_default_rule
 - set_ufw_loopback_traffic
+- ufw_default_incoming_rule
+- ufw_default_outgoing_rule
+- ufw_disabled_routed
 - ufw_only_required_services
 - ufw_rate_limit
 - ufw_rules_for_open_ports

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ubuntu,multi_platform_debian
+
+ufw default deny incoming

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/oval/shared.xml
@@ -1,0 +1,21 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure ufw default incoming policy is deny or reject", rule_title=rule_title) }}}
+    <criteria>
+      <criterion comment="DEFAULT_INPUT_POLICY is DROP or REJECT in /etc/default/ufw"
+        test_ref="{{{ rule_id }}}_test_default_input_policy" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+    id="{{{ rule_id }}}_test_default_input_policy" version="1"
+    comment="Check DEFAULT_INPUT_POLICY is DROP or REJECT in /etc/default/ufw">
+    <ind:object object_ref="{{{ rule_id }}}_obj_default_input_policy"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_default_input_policy" version="1">
+    <ind:filepath>/etc/default/ufw</ind:filepath>
+    <ind:pattern operation="pattern match">^DEFAULT_INPUT_POLICY="(DROP|REJECT)"$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+title: 'Ensure ufw Default Deny Policy for Incoming Connections'
+
+description: |-
+    A default deny policy on incoming connections ensures that any unconfigured
+    inbound network traffic will be rejected.
+
+    Note: Any port or protocol without an explicit allow before the default
+    deny will be blocked.
+
+rationale: |-
+    With a default accept policy the firewall will accept any incoming packet
+    that is not configured to be denied. It is easier to allow acceptable
+    usage than to block unacceptable usage.
+
+severity: medium
+
+platform: package[ufw]
+
+ocil_clause: 'the default policy for incoming connections is not set to deny or reject'
+
+ocil: |-
+    Run the following command and verify that the default policy for incoming
+    connections is deny or reject:
+    <pre># ufw status verbose | grep Default:</pre>
+    Example output:
+    <pre>Default: deny (incoming), ...</pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/rule.yml
@@ -5,6 +5,8 @@ title: 'Ensure ufw Default Deny Policy for Incoming Connections'
 description: |-
     A default deny policy on incoming connections ensures that any unconfigured
     inbound network traffic will be rejected.
+    Set <tt>DEFAULT_INPUT_POLICY</tt> to <tt>DROP</tt> or <tt>REJECT</tt>
+    in <tt>/etc/default/ufw</tt>.
 
     Note: Any port or protocol without an explicit allow before the default
     deny will be blocked.

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/tests/allow.fail.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/tests/allow.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ufw
+
+ufw allow ssh
+ufw default allow incoming
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/tests/deny.pass.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/tests/deny.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ufw
+
+ufw allow ssh
+ufw default deny incoming
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/tests/reject.pass.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_incoming_rule/tests/reject.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ufw
+
+ufw allow ssh
+ufw default reject incoming
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ubuntu,multi_platform_debian
+
+ufw default deny outgoing

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/oval/shared.xml
@@ -1,0 +1,21 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure ufw default outgoing policy is deny or reject", rule_title=rule_title) }}}
+    <criteria>
+      <criterion comment="DEFAULT_OUTPUT_POLICY is DROP or REJECT in /etc/default/ufw"
+        test_ref="{{{ rule_id }}}_test_default_output_policy" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+    id="{{{ rule_id }}}_test_default_output_policy" version="1"
+    comment="Check DEFAULT_OUTPUT_POLICY is DROP or REJECT in /etc/default/ufw">
+    <ind:object object_ref="{{{ rule_id }}}_obj_default_output_policy"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_default_output_policy" version="1">
+    <ind:filepath>/etc/default/ufw</ind:filepath>
+    <ind:pattern operation="pattern match">^DEFAULT_OUTPUT_POLICY="(DROP|REJECT)"$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/rule.yml
@@ -5,6 +5,8 @@ title: 'Ensure ufw Default Deny Policy for Outgoing Connections'
 description: |-
     A default deny policy on outgoing connections ensures that only explicitly
     allowed outbound network traffic will be permitted.
+    Set <tt>DEFAULT_OUTPUT_POLICY</tt> to <tt>DROP</tt> or <tt>REJECT</tt>
+    in <tt>/etc/default/ufw</tt>.
 
     Note: Any port or protocol without an explicit allow before the default
     deny will be blocked.

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+title: 'Ensure ufw Default Deny Policy for Outgoing Connections'
+
+description: |-
+    A default deny policy on outgoing connections ensures that only explicitly
+    allowed outbound network traffic will be permitted.
+
+    Note: Any port or protocol without an explicit allow before the default
+    deny will be blocked.
+
+rationale: |-
+    With a default accept policy the firewall will allow any outgoing packet
+    that is not configured to be denied. Restricting outgoing traffic reduces
+    the risk of data exfiltration and limits the impact of a compromised host.
+
+severity: medium
+
+platform: package[ufw]
+
+ocil_clause: 'the default policy for outgoing connections is not set to deny or reject'
+
+ocil: |-
+    Run the following command and verify that the default policy for outgoing
+    connections is deny or reject:
+    <pre># ufw status verbose | grep Default:</pre>
+    Example output:
+    <pre>Default: ..., deny (outgoing), ...</pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/tests/allow.fail.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/tests/allow.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ufw
+
+ufw allow ssh
+ufw default allow outgoing
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/tests/deny.pass.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/tests/deny.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ufw
+
+ufw allow ssh
+ufw default deny outgoing
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/tests/reject.pass.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_default_outgoing_rule/tests/reject.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ufw
+
+ufw allow ssh
+ufw default reject outgoing
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/ufw_disabled_routed/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_disabled_routed/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ubuntu,multi_platform_debian
+
+ufw default deny routed

--- a/linux_os/guide/system/network/network-ufw/ufw_disabled_routed/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ufw/ufw_disabled_routed/oval/shared.xml
@@ -1,0 +1,21 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure ufw default routed policy is disabled or deny", rule_title=rule_title) }}}
+    <criteria>
+      <criterion comment="DEFAULT_FORWARD_POLICY is DROP or REJECT in /etc/default/ufw"
+        test_ref="{{{ rule_id }}}_test_default_forward_policy" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+    id="{{{ rule_id }}}_test_default_forward_policy" version="1"
+    comment="Check DEFAULT_FORWARD_POLICY is DROP or REJECT in /etc/default/ufw">
+    <ind:object object_ref="{{{ rule_id }}}_obj_default_forward_policy"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_default_forward_policy" version="1">
+    <ind:filepath>/etc/default/ufw</ind:filepath>
+    <ind:pattern operation="pattern match">^DEFAULT_FORWARD_POLICY="(DROP|REJECT)"$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/network/network-ufw/ufw_disabled_routed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_disabled_routed/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'Ensure ufw Default Policy for Routed (Forwarded) Traffic is Disabled'
+
+description: |-
+    The default policy for routed (forwarded) traffic in ufw should be set to
+    disabled or deny, ensuring that the system does not forward packets between
+    interfaces unless explicitly configured to do so.
+
+rationale: |-
+    Unless the system is intended to act as a router, forwarding traffic between
+    network interfaces should be disabled. Disabling the routed default policy
+    prevents the system from accidentally or maliciously forwarding traffic.
+
+severity: medium
+
+platform: package[ufw]
+
+ocil_clause: 'the default policy for routed traffic is not set to disabled or deny'
+
+ocil: |-
+    Run the following command and verify that the default policy for routed
+    traffic is disabled or deny:
+    <pre># ufw status verbose | grep Default:</pre>
+    Example output:
+    <pre>Default: ..., disabled (routed)</pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.


### PR DESCRIPTION
Add three new rules for UFW firewall default policies:

- ufw_default_incoming_rule: ensure DEFAULT_INPUT_POLICY is DROP or REJECT in /etc/default/ufw
- ufw_default_outgoing_rule: ensure DEFAULT_OUTPUT_POLICY is DROP or REJECT in /etc/default/ufw
- ufw_disabled_routed: ensure DEFAULT_FORWARD_POLICY is DROP or REJECT in /etc/default/ufw

All three rules use OVAL checks that read /etc/default/ufw directly, avoiding the SCE approach which fails silently when /tmp is mounted noexec (required by CIS 1.1.2.4). Map the new rules to the ufw component.

#### Description:

  - Add three new rules for UFW firewall default policies:
    - `ufw_default_incoming_rule`: ensure `DEFAULT_INPUT_POLICY` is `DROP`
      or `REJECT` in `/etc/default/ufw`
    - `ufw_default_outgoing_rule`: ensure `DEFAULT_OUTPUT_POLICY` is `DROP`
      or `REJECT` in `/etc/default/ufw`
    - `ufw_disabled_routed`: ensure `DEFAULT_FORWARD_POLICY` is `DROP` or
      `REJECT` in `/etc/default/ufw`
  - All three rules use OVAL checks that read `/etc/default/ufw` directly.
  - Map the new rules to the `ufw` component.

#### Rationale:

  - A default deny policy on incoming, outgoing and forwarded connections
    ensures only explicitly allowed traffic is permitted, reducing the
    attack surface.
  - SCE scripts fail silently when `/tmp` is mounted `noexec` (required by
    CIS 1.1.2.4). The OVAL approach reads the UFW configuration file
    directly and is not affected by mount options.

#### Review Hints:

  - New rule directories under `linux_os/guide/system/network/network-ufw/`.
  - `ufw_default_outgoing_rule` was created directly with OVAL (no SCE),
    consistent with the OVAL checks added for `check_ufw_active`,
    `ufw_default_incoming_rule` and `ufw_disabled_routed`.
  - Build to verify: `./build_product debian13 --datastream-only`
  - Build ubuntu2404 to verify no regression:
    `./build_product ubuntu2404 --datastream-only`

