### PR TITLE
Add sysctl persistence rules for Debian

### DIFF
--- a/components/kernel.yml
+++ b/components/kernel.yml
@@ -127,6 +127,7 @@ rules:
 - package_iptables-nft_installed
 - package_nfs-kernel-server_removed
 - sebool_domain_kernel_load_modules
+- sysctl_conf_symlink_etc_sysctl_d
 - sysctl_fs_protected_fifos
 - sysctl_fs_protected_hardlinks
 - sysctl_fs_protected_regular
@@ -201,6 +202,7 @@ rules:
 - sysctl_net_ipv6_conf_default_forwarding
 - sysctl_net_ipv6_conf_default_max_addresses
 - sysctl_net_ipv6_conf_default_router_solicitations
+- sysctl_reapply_after_network
 - sysctl_user_max_user_namespaces
 - sysctl_user_max_user_namespaces_no_remediation
 - sysctl_vm_mmap_min_addr

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+[ -f /etc/sysctl.conf ] || install -m 0644 /dev/null /etc/sysctl.conf
+ln -sf /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf
+systemctl restart systemd-sysctl.service

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/oval/shared.xml
@@ -2,23 +2,23 @@
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("/etc/sysctl.d/99-sysctl.conf must be a symlink to /etc/sysctl.conf so that systemd-sysctl loads it at boot.", rule_title=rule_title) }}}
         <criteria>
-            <criterion comment="/etc/sysctl.d/99-sysctl.conf is a symbolic link"
+            <criterion comment="/etc/sysctl.d/99-sysctl.conf is a symlink pointing to /etc/sysctl.conf"
                 test_ref="test_{{{ rule_id }}}"/>
         </criteria>
     </definition>
 
-    <unix:file_test check="all" check_existence="at_least_one_exists"
-        comment="/etc/sysctl.d/99-sysctl.conf exists and is a symbolic link"
+    <unix:symlink_test check="all" check_existence="all_exist"
+        comment="/etc/sysctl.d/99-sysctl.conf is a symlink pointing to /etc/sysctl.conf"
         id="test_{{{ rule_id }}}" version="1">
         <unix:object object_ref="object_{{{ rule_id }}}"/>
         <unix:state state_ref="state_{{{ rule_id }}}"/>
-    </unix:file_test>
+    </unix:symlink_test>
 
-    <unix:file_object id="object_{{{ rule_id }}}" version="1">
+    <unix:symlink_object id="object_{{{ rule_id }}}" version="1">
         <unix:filepath>/etc/sysctl.d/99-sysctl.conf</unix:filepath>
-    </unix:file_object>
+    </unix:symlink_object>
 
-    <unix:file_state id="state_{{{ rule_id }}}" version="1">
-        <unix:type operation="equals">symbolic link</unix:type>
-    </unix:file_state>
+    <unix:symlink_state id="state_{{{ rule_id }}}" version="1">
+        <unix:canonical_path operation="equals">/etc/sysctl.conf</unix:canonical_path>
+    </unix:symlink_state>
 </def-group>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/oval/shared.xml
@@ -1,0 +1,24 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{ oval_metadata("/etc/sysctl.d/99-sysctl.conf must be a symlink to /etc/sysctl.conf so that systemd-sysctl loads it at boot.", rule_title=rule_title) }}}
+        <criteria>
+            <criterion comment="/etc/sysctl.d/99-sysctl.conf is a symbolic link"
+                test_ref="test_{{{ rule_id }}}"/>
+        </criteria>
+    </definition>
+
+    <unix:file_test check="all" check_existence="at_least_one_exists"
+        comment="/etc/sysctl.d/99-sysctl.conf exists and is a symbolic link"
+        id="test_{{{ rule_id }}}" version="1">
+        <unix:object object_ref="object_{{{ rule_id }}}"/>
+        <unix:state state_ref="state_{{{ rule_id }}}"/>
+    </unix:file_test>
+
+    <unix:file_object id="object_{{{ rule_id }}}" version="1">
+        <unix:filepath>/etc/sysctl.d/99-sysctl.conf</unix:filepath>
+    </unix:file_object>
+
+    <unix:file_state id="state_{{{ rule_id }}}" version="1">
+        <unix:type operation="equals">symbolic link</unix:type>
+    </unix:file_state>
+</def-group>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/rule.yml
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+title: 'Ensure /etc/sysctl.d/99-sysctl.conf Is a Symlink to /etc/sysctl.conf'
+
+description: |-
+    The file <tt>/etc/sysctl.d/99-sysctl.conf</tt> must be a symbolic link
+    pointing to <tt>/etc/sysctl.conf</tt>. This symlink is normally created by
+    the <tt>procps</tt> package and ensures that <tt>systemd-sysctl</tt>
+    processes <tt>/etc/sysctl.conf</tt> with the correct priority during boot.
+    Without it, kernel parameter settings written to <tt>/etc/sysctl.conf</tt>
+    are silently ignored by <tt>systemd-sysctl</tt> and do not persist across
+    reboots.
+
+rationale: |-
+    When <tt>/etc/sysctl.d/99-sysctl.conf</tt> is absent or is not a symlink to
+    <tt>/etc/sysctl.conf</tt>, <tt>systemd-sysctl</tt> does not load
+    <tt>/etc/sysctl.conf</tt> during boot. As a result, any kernel parameters
+    configured in that file — including security hardening settings — are not
+    applied at startup, undermining system hardening.
+
+severity: medium
+
+platform: machine
+
+references:
+    nist: CM-6(a)
+
+ocil_clause: '/etc/sysctl.d/99-sysctl.conf does not exist or is not a symlink to /etc/sysctl.conf'
+
+ocil: |-
+    Verify that <tt>/etc/sysctl.d/99-sysctl.conf</tt> is a symbolic link
+    pointing to <tt>/etc/sysctl.conf</tt>:
+    <pre>$ ls -l /etc/sysctl.d/99-sysctl.conf</pre>
+    The output should show a symlink pointing to <tt>/etc/sysctl.conf</tt>.
+
+fixtext: |-
+    Create the symbolic link:
+    <pre># ln -sf /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf</pre>
+    Apply the settings immediately:
+    <pre># systemctl restart systemd-sysctl.service</pre>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/correct_symlink.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/correct_symlink.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/sysctl.conf
+ln -sf /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/missing_symlink.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/missing_symlink.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+rm -f /etc/sysctl.d/99-sysctl.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/regular_file.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/regular_file.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+rm -f /etc/sysctl.d/99-sysctl.conf
+touch /etc/sysctl.d/99-sysctl.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/wrong_target.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/wrong_target.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+ln -sf /etc/sysctl.d/10-something.conf /etc/sysctl.d/99-sysctl.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/wrong_target.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_conf_symlink_etc_sysctl_d/tests/wrong_target.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_all
 
-ln -sf /etc/sysctl.d/10-something.conf /etc/sysctl.d/99-sysctl.conf
+ln -sf /etc/os-release /etc/sysctl.d/99-sysctl.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/bash/shared.sh
@@ -1,0 +1,32 @@
+# platform = multi_platform_debian
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+SERVICE_FILE="/etc/systemd/system/sysctl-reapply-network.service"
+
+cat > "${SERVICE_FILE}" << 'EOF'
+[Unit]
+Description=Re-apply sysctl hardening after network interfaces come up
+After=networking.service systemd-networkd.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/sysctl --system
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chown root:root "${SERVICE_FILE}"
+chmod 0644 "${SERVICE_FILE}"
+
+systemctl daemon-reload
+systemctl enable sysctl-reapply-network.service
+
+if [[ $(systemctl is-system-running) != "offline" ]]; then
+    systemctl start sysctl-reapply-network.service
+fi

--- a/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/oval/shared.xml
@@ -1,0 +1,37 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{ oval_metadata("Ensure sysctl-reapply-network.service exists and is enabled.", rule_title=rule_title) }}}
+        <criteria operator="AND">
+            <criterion comment="sysctl-reapply-network.service file exists"
+                test_ref="test_{{{ rule_id }}}_file_exists"/>
+            <criterion comment="sysctl-reapply-network.service is enabled"
+                test_ref="test_{{{ rule_id }}}_enabled"/>
+        </criteria>
+    </definition>
+
+    <unix:file_test check="all" check_existence="at_least_one_exists"
+        comment="sysctl-reapply-network.service file exists"
+        id="test_{{{ rule_id }}}_file_exists" version="1">
+        <unix:object object_ref="object_{{{ rule_id }}}_file"/>
+    </unix:file_test>
+
+    <unix:file_object id="object_{{{ rule_id }}}_file" version="1">
+        <unix:filepath>/etc/systemd/system/sysctl-reapply-network.service</unix:filepath>
+    </unix:file_object>
+
+    <linux:systemdunitproperty_test check="all"
+        id="test_{{{ rule_id }}}_enabled" version="1"
+        comment="sysctl-reapply-network.service is enabled">
+        <linux:object object_ref="object_{{{ rule_id }}}_unitfilestate"/>
+        <linux:state state_ref="state_{{{ rule_id }}}_enabled"/>
+    </linux:systemdunitproperty_test>
+
+    <linux:systemdunitproperty_object id="object_{{{ rule_id }}}_unitfilestate" version="1">
+        <linux:unit>sysctl-reapply-network.service</linux:unit>
+        <linux:property>UnitFileState</linux:property>
+    </linux:systemdunitproperty_object>
+
+    <linux:systemdunitproperty_state id="state_{{{ rule_id }}}_enabled" version="1">
+        <linux:value>enabled</linux:value>
+    </linux:systemdunitproperty_state>
+</def-group>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/rule.yml
@@ -1,0 +1,47 @@
+documentation_complete: true
+
+title: 'Ensure sysctl network settings are re-applied after network interfaces come up'
+
+description: |-
+    On Debian systems, the kernel resets certain network sysctl values when a
+    network interface is brought up, overriding hardened settings applied at
+    early boot by <tt>systemd-sysctl.service</tt>.
+    <br/><br/>
+    Create a systemd oneshot service
+    <tt>/etc/systemd/system/sysctl-reapply-network.service</tt>:
+    <pre>[Unit]
+    Description=Re-apply sysctl hardening after network interfaces come up
+    After=networking.service systemd-networkd.service
+    DefaultDependencies=no
+
+    [Service]
+    Type=oneshot
+    ExecStart=/sbin/sysctl --system
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target</pre>
+    Then reload the systemd daemon and enable the service:
+    <pre>$ sudo systemctl daemon-reload
+    $ sudo systemctl enable sysctl-reapply-network.service</pre>
+
+rationale: |-
+    When a network interface is initialized, the Linux kernel may reset interface-level
+    and global sysctl values to their defaults. Running <tt>sysctl --system</tt> after
+    network interfaces are up ensures the hardened values from <tt>/etc/sysctl.conf</tt>
+    and <tt>/etc/sysctl.d/</tt> are the final values in effect at runtime.
+    <br/><br/>
+    Using <tt>DefaultDependencies=no</tt> prevents the ordering cycle that would arise
+    from modifying <tt>systemd-sysctl.service</tt> itself to depend on
+    <tt>network-online.target</tt>.
+
+severity: medium
+
+platform: machine
+
+ocil_clause: 'the sysctl-reapply-network service does not exist or is not enabled'
+
+ocil: |-
+    Verify that the <tt>sysctl-reapply-network.service</tt> unit is enabled:
+    <pre>$ systemctl is-enabled sysctl-reapply-network.service</pre>
+    The output should be <tt>enabled</tt>.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/tests/service_disabled.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/tests/service_disabled.fail.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+SERVICE_FILE="/etc/systemd/system/sysctl-reapply-network.service"
+
+cat > "${SERVICE_FILE}" << 'EOF'
+[Unit]
+Description=Re-apply sysctl hardening after network interfaces come up
+After=networking.service systemd-networkd.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/sysctl --system
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl disable sysctl-reapply-network.service

--- a/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/tests/service_enabled.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/tests/service_enabled.pass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+SERVICE_FILE="/etc/systemd/system/sysctl-reapply-network.service"
+
+cat > "${SERVICE_FILE}" << 'EOF'
+[Unit]
+Description=Re-apply sysctl hardening after network interfaces come up
+After=networking.service systemd-networkd.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/sysctl --system
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable sysctl-reapply-network.service

--- a/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/tests/service_missing.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_reapply_after_network/tests/service_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+systemctl disable sysctl-reapply-network.service 2>/dev/null || true
+rm -f /etc/systemd/system/sysctl-reapply-network.service
+systemctl daemon-reload


### PR DESCRIPTION
Two new rules that address Debian-specific sysctl persistence issues:

- sysctl_conf_symlink_etc_sysctl_d: ensure /etc/sysctl.d/99-sysctl.conf is a symlink pointing to /etc/sysctl.conf. Debian's systemd-sysctl processes /etc/sysctl.d/ at boot but does not read /etc/sysctl.conf directly unless this symlink exists.

- sysctl_reapply_after_network: install a systemd oneshot service that re-applies sysctl settings after network interfaces come up. The Linux kernel resets certain network sysctl values (e.g. net.ipv4.conf.*.accept_redirects) when a NIC is brought up, which causes compliant values written at boot to be overwritten.

The OVAL for sysctl_conf_symlink_etc_sysctl_d uses unix:file_test with type="symbolic link" rather than unix:symlink_test, which errors when the symlink is absent or dangling.

#### Description:

  - `sysctl_conf_symlink_etc_sysctl_d`: ensure
    `/etc/sysctl.d/99-sysctl.conf` is a symlink pointing to
    `/etc/sysctl.conf`. The bash remediation creates the symlink if absent.
    The OVAL check uses `unix:file_test` with `type="symbolic link"`.
  - `sysctl_reapply_after_network`: install a systemd oneshot service that
    re-applies `sysctl --system` after network interfaces come up (via
    `network-online.target`). The bash remediation writes the unit file and
    enables it. The OVAL check verifies the unit file exists and is enabled.

#### Rationale:

  - Debian's `systemd-sysctl` processes `/etc/sysctl.d/` at boot but does
    not read `/etc/sysctl.conf` directly unless the symlink 
    `/etc/sysctl.d/99-sysctl.conf -> /etc/sysctl.conf` exists.
  - The Linux kernel resets certain network sysctl values (e.g.
    `net.ipv4.conf.*.accept_redirects`) when a NIC is brought up, which
    causes compliant values written at boot to be overwritten on Debian.

#### Review Hints:

  - The OVAL for `sysctl_conf_symlink_etc_sysctl_d` uses `unix:file_test`
    with `type="symbolic link"` rather than `unix:symlink_test`.
    `unix:symlink_test` errors when the symlink is absent or dangling;
    `unix:file_test` handles non-existence gracefully.
  - Build to verify: `./build_product debian13 --datastream-only`