### PR TITLE
Add sysctl_kernel_apparmor_restrict_unprivileged_unconfined rule

### DIFF
--- a/components/apparmor.yml
+++ b/components/apparmor.yml
@@ -12,4 +12,4 @@ rules:
 - package_apparmor_installed
 - package_apparmor-utils_installed
 - package_pam_apparmor_installed
-- sysctl_kernel_apparmor_restrict_unprivileged_unconfined
+

--- a/components/apparmor.yml
+++ b/components/apparmor.yml
@@ -12,3 +12,4 @@ rules:
 - package_apparmor_installed
 - package_apparmor-utils_installed
 - package_pam_apparmor_installed
+- sysctl_kernel_apparmor_restrict_unprivileged_unconfined

--- a/components/kernel.yml
+++ b/components/kernel.yml
@@ -132,6 +132,7 @@ rules:
 - sysctl_fs_protected_regular
 - sysctl_fs_protected_symlinks
 - sysctl_fs_suid_dumpable
+- sysctl_kernel_apparmor_restrict_unprivileged_unconfined
 - sysctl_kernel_core_pattern
 - sysctl_kernel_core_pattern_empty_string
 - sysctl_kernel_core_uses_pid

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_apparmor_restrict_unprivileged_unconfined/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_apparmor_restrict_unprivileged_unconfined/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Enable kernel.apparmor_restrict_unprivileged_unconfined'
+
+description: '{{{ describe_sysctl_option_value(sysctl="kernel.apparmor_restrict_unprivileged_unconfined", value="1") }}}'
+
+rationale: |-
+    Restricting unprivileged unconfined processes with AppArmor reduces the
+    attack surface available to local users and helps enforce additional
+    kernel-level hardening.
+
+severity: medium
+
+{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.apparmor_restrict_unprivileged_unconfined", value="1") }}}
+
+fixtext: |-
+    Configure {{{ full_name }}} to enable AppArmor restrictions for
+    unprivileged unconfined processes.
+    {{{ fixtext_sysctl("kernel.apparmor_restrict_unprivileged_unconfined", "1") | indent(4) }}}
+
+platform: system_with_kernel
+
+template:
+    name: sysctl
+    vars:
+        sysctlvar: kernel.apparmor_restrict_unprivileged_unconfined
+        datatype: int

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_apparmor_restrict_unprivileged_unconfined_value.var
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_apparmor_restrict_unprivileged_unconfined_value.var
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: kernel.apparmor_restrict_unprivileged_unconfined
+
+description: |-
+    Prevent unprivileged and unconfined processes.
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    default: 1
+    1: "1"
+    2: "2"

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_apparmor_restrict_unprivileged_unconfined_value.var
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_apparmor_restrict_unprivileged_unconfined_value.var
@@ -13,5 +13,5 @@ interactive: false
 
 options:
     default: 1
+    0: "0"
     1: "1"
-    2: "2"


### PR DESCRIPTION
Add a new rule and variable to enforce
kernel.apparmor_restrict_unprivileged_unconfined=1 via the sysctl template. This sysctl prevents unprivileged processes from loading AppArmor profiles without confinement, reducing the local attack surface. Map the new rule to the apparmor component.

#### Description:

  - Add new rule `sysctl_kernel_apparmor_restrict_unprivileged_unconfined`
    and its associated variable
    `sysctl_kernel_apparmor_restrict_unprivileged_unconfined_value.var`
    to enforce `kernel.apparmor_restrict_unprivileged_unconfined=1`.
  - Uses the `sysctl` template.
  - Map the new rule to the `apparmor` component.

#### Rationale:

  - When `kernel.apparmor_restrict_unprivileged_unconfined` is set to `1`,
    unprivileged processes are prevented from loading AppArmor profiles
    without confinement. This reduces the local attack surface by limiting
    what an unprivileged user can do with AppArmor.

#### Review Hints:

  - One new rule directory and one `.var` file under
    `linux_os/guide/system/permissions/restrictions/`.
  - Build to verify: `./build_product debian13 --datastream-only`