### PR TITLE
Fix sshd_enable_warning_banner_net crash on Debian products

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -41,7 +41,7 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue.net") }}}
 
-{{% if 'ubuntu' not in product %}}
+{{% if 'ubuntu' not in product and 'debian' not in product %}}
 conflicts:
     - sshd_enable_warning_banner
 {{% endif %}}


### PR DESCRIPTION
The rule had `conflicts: sshd_enable_warning_banner` active for Debian. Since sshd_enable_warning_banner is not included in Debian data streams, OpenSCAP asserts: `xccdf_policy_is_item_selected: Assertion 'false' failed`.

Extend the exclusion condition from Ubuntu-only to cover all Debian products.

#### Description:

  - Extend the `conflicts: sshd_enable_warning_banner` exclusion condition
    from Ubuntu-only to all Debian products in `sshd_enable_warning_banner_net/rule.yml`.

#### Rationale:

 - The rule had `conflicts: sshd_enable_warning_banner` active for Debian.
    Since `sshd_enable_warning_banner` is not included in Debian data streams,
    OpenSCAP asserts: `xccdf_policy_is_item_selected: Assertion 'false' failed`.


#### Review Hints:

  - One-line change: `'ubuntu' not in product` →
    `'ubuntu' not in product and 'debian' not in product`
  - Build and scan to verify: `./build_product debian13 --datastream-only`
