### PR TITLE
Fix pam_pwquality bash remediation for Debian products

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/bash/shared.sh
@@ -1,6 +1,6 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu,multi_platform_debian
 
-{{% if product in ['sle15', 'sle16'] %}}
+{{% if product in ['sle15', 'sle16'] or 'debian' in product %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'requisite', 'pam_pwquality.so', '', '', 'BOF') }}}
 {{% else %}}
 {{{ bash_pam_pwquality_enable() }}}

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -27,7 +27,7 @@ fi
 }}}
 {{% endif %}}
 
-{{% if product == "ubuntu2404" or product == "debian13" %}}
+{{% if product == "ubuntu2404" %}}
 {{{ bash_pam_pwquality_enable() }}}
 {{% endif %}}
 


### PR DESCRIPTION
Two related fixes:

1. accounts_password/bash.template: remove debian13 from the ubuntu2404 guard that calls bash_pam_pwquality_enable() for parameter rules. This was introduced by commit 86030e2318 (add debian13 support for rule package_pam_pwquality_installed) which incorrectly copied the ubuntu2404 approach. debian12 was not affected; its support was added correctly without this guard (commit e6f0f0d1).

2. accounts_password_pam_pwquality_enabled/bash/shared.sh: extend the SLE condition to all Debian products so that bash_ensure_pam_module_configuration is used (direct PAM file edit) instead of bash_pam_pwquality_enable(). The latter creates a pam-auth-update config with Conflicts: pwquality that removes the active pam_pwquality.so entry from /etc/pam.d/common-password, causing all downstream accounts_password_pam_* OVAL checks to fail.

#### Description:

  - `accounts_password_pam_pwquality_enabled/bash/shared.sh`: extend the
    platform line to `multi_platform_debian` and use
    `bash_ensure_pam_module_configuration` (direct PAM file edit) instead
    of `bash_pam_pwquality_enable()` for all Debian products.
  - `shared/templates/accounts_password/bash.template`: remove `debian13`
    from the `ubuntu2404` guard that calls `bash_pam_pwquality_enable()`
    for password parameter rules.

#### Rationale:

  - `bash_pam_pwquality_enable()` creates a pam-auth-update config with
    `Conflicts: pwquality` and calls `pam-auth-update`, which removes the
    active `pam_pwquality.so` entry from `/etc/pam.d/common-password`.
    This causes all downstream `accounts_password_pam_*` OVAL checks to fail.
  - The `debian13` entry in the `bash.template` guard was introduced by
    commit 86030e2318 alongside `package_pam_pwquality_installed` support.
    debian12 was not affected — its support was added correctly without
    this guard (commit e6f0f0d1).

#### Review Hints:

  - Two passes of remediation are required on a clean Debian 13 VM: the
    first installs `libpam-pwquality`, the second configures the parameters
    (OpenSCAP CPE session limitation, not a content bug).
  - After two passes, all `accounts_password_pam_*` rules should pass.
