### PR TITLE
Fix log file permission rules for Debian (CIS 6.1.3.1)

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -57,10 +57,12 @@ template:
         excluded_files@slmicro5: ['*[bw]tmp', '*lastlog']
         excluded_files@slmicro6: ['*[bw]tmp', '*lastlog']
         excluded_files@ubuntu2204: ['history.log*', 'eipp.log.xz*', '[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*']
+        excluded_files@debian13: ['history.log*', 'eipp.log.xz*', '[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*']
         excluded_files@ubuntu2404: ['history.log*', 'eipp.log.xz*', '[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*', 'cloud-init.log*', 'localmessages*', 'waagent.log*']
         file_regex: '.*'
         filemode: '0640'
         filepath: /var/log/
+        recursive@debian13: 'true'
         recursive@sle12: 'true'
         recursive@sle15: 'true'
         recursive@sle16: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns /var/log/messages File'
 
-{{%- if product in ['ubuntu2404'] %}}
+{{%- if product in ['ubuntu2404'] or 'debian' in product %}}
 description: '{{{ describe_file_group_owner(file="/var/log/messages", group="adm|root") }}}'
 {{%- else %}}
 description: '{{{ describe_file_group_owner(file="/var/log/messages", group="root") }}}'
@@ -23,7 +23,7 @@ references:
     srg: SRG-OS-000206-GPOS-00084
     stigid@ol8: OL08-00-010230
 
-{{%- if product in ['ubuntu2404'] %}}
+{{%- if product in ['ubuntu2404'] or 'debian' in product %}}
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/messages", group="adm|root") }}}'
 
 ocil: |-

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_messages/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify Permissions on /var/log/messages File'
 
-{{%  if product in ['ubuntu2404','ol9','ol8'] %}}
+{{%  if product in ['ubuntu2404','ol9','ol8'] or 'debian' in product %}}
     {{% set target_perms_octal="0640" %}}
     {{% set target_perms="-rw-r-----" %}}
 {{% else %}}


### PR DESCRIPTION
Debian uses group `adm` (not root) and mode 0640 for /var/log/messages, and APT writes log files under /var/log/apt/ that CIS allows at 0644.

- file_groupowner_var_log_messages: extend ubuntu2404 condition to all Debian products so the rule accepts group adm|root instead of GID 0.
- file_permissions_var_log_messages: extend condition to all Debian products so the rule checks for 0640 instead of 0600.
- permissions_local_var_log: add excluded_files@debian13 to skip APT log files and [bw]tmp/lastlog; add recursive@debian13 to also check /var/log/apt/ subdirectory.

#### Description:

  - `file_groupowner_var_log_messages/rule.yml`: extend the `ubuntu2404`
    condition to `or 'debian' in product` so the rule accepts group
    `adm|root` instead of requiring GID 0.
  - `file_permissions_var_log_messages/rule.yml`: extend condition to
    `or 'debian' in product` so the rule checks for mode `0640` instead
    of `0600`.
  - `permissions_local_var_log/rule.yml`: add `excluded_files@debian13`
    to skip APT log files and `[bw]tmp`/`lastlog`; add
    `recursive@debian13: 'true'` to also check `/var/log/apt/`.

#### Rationale:

  - Debian uses group `adm` (not `root`) for `/var/log/messages` and
    mode `0640`, matching the existing ubuntu2404 behaviour. APT writes
    log files under `/var/log/apt/` that CIS Debian 13 section 6.1.3.1
    allows at `0644` and are therefore excluded.

#### Review Hints:

  - The existing `ubuntu2404` special cases in these rules are the
    reference for the Debian additions.
  - Build and scan: `./build_product debian13 --datastream-only`