### PR TITLE
Add sshd_set_allow_groups rule for SSH group-based access control

### DIFF
--- a/components/openssh.yml
+++ b/components/openssh.yml
@@ -71,6 +71,7 @@ rules:
 - sshd_enable_x11_forwarding
 - sshd_limit_user_access
 - sshd_print_last_log
+- sshd_set_allow_groups
 - sshd_rekey_limit
 - sshd_set_idle_timeout
 - sshd_set_keepalive

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_allow_groups/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_allow_groups/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'Set SSH AllowGroups'
+
+description: |-
+    The <tt>AllowGroups</tt> parameter restricts which groups of users
+    can log in via SSH. To configure it, edit <tt>/etc/ssh/sshd_config</tt>:
+    <pre>AllowGroups {{{ xccdf_value("var_sshd_allow_groups") }}}</pre>
+
+rationale: |-
+    Restricting SSH access to specific groups reduces the attack surface by
+    ensuring only authorized users can connect remotely.
+
+severity: medium
+
+ocil_clause: 'AllowGroups is not set to the required group'
+
+ocil: |-
+    Run the following command to verify the <tt>AllowGroups</tt> setting:
+    <pre>$ sudo grep -i AllowGroups /etc/ssh/sshd_config</pre>
+    The output should contain:
+    <pre>AllowGroups {{{ xccdf_value("var_sshd_allow_groups") }}}</pre>
+
+platform: package[openssh-server]
+
+template:
+    name: sshd_lineinfile
+    vars:
+        parameter: AllowGroups
+        xccdf_variable: var_sshd_allow_groups
+        datatype: string

--- a/linux_os/guide/services/ssh/var_sshd_allow_groups.var
+++ b/linux_os/guide/services/ssh/var_sshd_allow_groups.var
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'SSH AllowGroups'
+
+description: 'Space-separated list of groups allowed to log in via SSH.'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    root: root
+    users: users
+    default: users


### PR DESCRIPTION
Add a new rule and variable to enforce the AllowGroups directive in /etc/ssh/sshd_config via the sshd_lineinfile template. The rule restricts SSH access to members of a configurable group, reducing the attack surface by ensuring only authorized users can connect remotely. Map the new rule to the openssh component.

#### Description:
  
  - Add new rule `sshd_set_allow_groups` and variable `var_sshd_allow_groups`
    to enforce the `AllowGroups` directive in `/etc/ssh/sshd_config`.
  - Uses the `sshd_lineinfile` template.
  - Map the new rule to the `openssh` component.

#### Rationale:
  
  - Restricting SSH access to members of a specific group reduces the attack
    surface by ensuring only explicitly authorized users can connect remotely.
  - The existing rule `sshd_limit_user_access` covers `AllowUsers` and
    `DenyUsers`/`DenyGroups` but not the `AllowGroups` directive.

#### Review Hints:
  
  - One new rule directory under
    `linux_os/guide/services/ssh/ssh_server/` and one `.var` file under
    `linux_os/guide/services/ssh/`.
  - The variable `var_sshd_allow_groups` has no default value — it must be
    set explicitly in the profile (e.g. `var_sshd_allow_groups=users`).
  - Build to verify: `./build_product debian13 --datastream-only`