### PR TITLE
Add APT repository security rules (CIS 1.3.x)

### DIFF
--- a/components/apt.yml
+++ b/components/apt.yml
@@ -5,4 +5,26 @@ packages:
 - apt
 rules:
 - apt_conf_disallow_unauthenticated
+- apt_disable_weak_dependencies
 - apt_sources_list_official
+- directory_groupowner_apt_auth_conf_d
+- directory_groupowner_apt_sources_list_d
+- directory_groupowner_apt_trusted_gpg_d
+- directory_groupowner_usr_share_keyrings
+- directory_owner_apt_auth_conf_d
+- directory_owner_apt_sources_list_d
+- directory_owner_apt_trusted_gpg_d
+- directory_owner_usr_share_keyrings
+- directory_permissions_apt_auth_conf_d
+- directory_permissions_apt_sources_list_d
+- directory_permissions_apt_trusted_gpg_d
+- directory_permissions_usr_share_keyrings
+- file_groupowner_apt_auth_conf_d
+- file_groupowner_apt_gpg_keys
+- file_groupowner_apt_sources_list_d
+- file_owner_apt_auth_conf_d
+- file_owner_apt_gpg_keys
+- file_owner_apt_sources_list_d
+- file_permissions_apt_auth_conf_d
+- file_permissions_apt_gpg_keys
+- file_permissions_apt_sources_list_d

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/bash/shared.sh
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_debian
+
+mkdir -p /etc/apt/apt.conf.d
+cat > /etc/apt/apt.conf.d/60-no-weak-dependencies <<'EOF'
+APT::Install-Recommends "0";
+APT::Install-Suggests "0";
+EOF

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/oval/shared.xml
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/oval/shared.xml
@@ -1,0 +1,40 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("APT weak dependencies should be disabled.", rule_title=rule_title) }}}
+
+    <criteria operator="AND">
+      <criterion comment="APT::Install-Recommends is disabled" test_ref="test_{{{ rule_id }}}_recommends" />
+      <criterion comment="APT::Install-Suggests is disabled" test_ref="test_{{{ rule_id }}}_suggests" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+      comment="Check APT::Install-Recommends"
+      id="test_{{{ rule_id }}}_recommends" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_recommends" />
+    <ind:state state_ref="state_{{{ rule_id }}}_disabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+      comment="Check APT::Install-Suggests"
+      id="test_{{{ rule_id }}}_suggests" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_suggests" />
+    <ind:state state_ref="state_{{{ rule_id }}}_disabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_recommends" version="1">
+    <ind:filepath operation="pattern match">/etc/apt/apt.conf(\.d/.*)?$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)APT::Install-Recommends(?-i)[\s]+(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_suggests" version="1">
+    <ind:filepath operation="pattern match">/etc/apt/apt.conf(\.d/.*)?$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)APT::Install-Suggests(?-i)[\s]+(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_disabled" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^"0";[\s]*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/rule.yml
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Disable APT Weak Dependencies'
+
+description: |-
+    APT should be configured to avoid installing packages listed only as
+    Recommends or Suggests dependencies.
+
+rationale: |-
+    Unless a system specifically requires the additional capabilities provided by
+    weak dependencies, those packages should not be installed in order to reduce
+    the potential attack surface.
+
+severity: medium
+
+ocil_clause: 'APT weak dependency options are not disabled'
+
+ocil: |-
+    Run the following command:
+    <pre>$ apt-config dump | grep "APT::Install-"</pre>
+    The output should include:
+    <pre>APT::Install-Recommends "0";
+    APT::Install-Suggests "0";</pre>
+
+fixtext: |-
+    Create an APT configuration file that disables weak dependencies:
+    <pre># printf '%s\n%s\n' 'APT::Install-Recommends "0";' 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/60-no-weak-dependencies</pre>

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/both_disabled.pass.sh
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/both_disabled.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_debian
+
+find /etc/apt/apt.conf.d/ -type f -exec sed -i '/APT::Install-Recommends/Id;/APT::Install-Suggests/Id' {} \;
+
+cat > /etc/apt/apt.conf.d/60-no-weak-dependencies << 'EOF'
+APT::Install-Recommends "0";
+APT::Install-Suggests "0";
+EOF

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/missing_config.fail.sh
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/missing_config.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+find /etc/apt/apt.conf.d/ -type f -exec sed -i '/APT::Install-Recommends/Id;/APT::Install-Suggests/Id' {} \;

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/recommends_enabled.fail.sh
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/recommends_enabled.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+find /etc/apt/apt.conf.d/ -type f -exec sed -i '/APT::Install-Recommends/Id;/APT::Install-Suggests/Id' {} \;
+
+cat > /etc/apt/apt.conf.d/60-no-weak-dependencies << 'EOF'
+APT::Install-Recommends "1";
+APT::Install-Suggests "0";
+EOF

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/suggests_enabled.fail.sh
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/tests/suggests_enabled.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+find /etc/apt/apt.conf.d/ -type f -exec sed -i '/APT::Install-Recommends/Id;/APT::Install-Suggests/Id' {} \;
+
+cat > /etc/apt/apt.conf.d/60-no-weak-dependencies << 'EOF'
+APT::Install-Recommends "0";
+APT::Install-Suggests "1";
+EOF

--- a/linux_os/guide/services/apt/directory_groupowner_apt_auth_conf_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_groupowner_apt_auth_conf_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on /etc/apt/auth.conf.d Directory'
+
+description: '{{{ describe_directory_group_owner(directory="/etc/apt/auth.conf.d", group="root") }}}'
+
+rationale: |-
+    The /etc/apt/auth.conf.d directory should be group-owned by root to prevent
+    unauthorized changes to APT authentication configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_group_owner(directory="/etc/apt/auth.conf.d", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_group_owner(directory="/etc/apt/auth.conf.d", group="root") }}}
+
+fixtext: '{{{ fixtext_directory_group_owner(file="/etc/apt/auth.conf.d", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/apt/auth.conf.d/
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_groupowner_apt_sources_list_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_groupowner_apt_sources_list_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on /etc/apt/sources.list.d Directory'
+
+description: '{{{ describe_directory_group_owner(directory="/etc/apt/sources.list.d", group="root") }}}'
+
+rationale: |-
+    The /etc/apt/sources.list.d directory should be group-owned by root to
+    prevent unauthorized changes to APT repository configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_group_owner(directory="/etc/apt/sources.list.d", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_group_owner(directory="/etc/apt/sources.list.d", group="root") }}}
+
+fixtext: '{{{ fixtext_directory_group_owner(file="/etc/apt/sources.list.d", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/apt/sources.list.d/
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_groupowner_apt_trusted_gpg_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_groupowner_apt_trusted_gpg_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on /etc/apt/trusted.gpg.d Directory'
+
+description: '{{{ describe_directory_group_owner(directory="/etc/apt/trusted.gpg.d", group="root") }}}'
+
+rationale: |-
+    The /etc/apt/trusted.gpg.d directory should be group-owned by root to prevent
+    unauthorized changes to APT trusted keys.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_group_owner(directory="/etc/apt/trusted.gpg.d", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_group_owner(directory="/etc/apt/trusted.gpg.d", group="root") }}}
+
+fixtext: '{{{ fixtext_directory_group_owner(file="/etc/apt/trusted.gpg.d", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/apt/trusted.gpg.d/
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_groupowner_usr_share_keyrings/rule.yml
+++ b/linux_os/guide/services/apt/directory_groupowner_usr_share_keyrings/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on /usr/share/keyrings Directory'
+
+description: '{{{ describe_directory_group_owner(directory="/usr/share/keyrings", group="root") }}}'
+
+rationale: |-
+    The /usr/share/keyrings directory should be group-owned by root to prevent
+    unauthorized changes to package repository keys.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_group_owner(directory="/usr/share/keyrings", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_group_owner(directory="/usr/share/keyrings", group="root") }}}
+
+fixtext: '{{{ fixtext_directory_group_owner(file="/usr/share/keyrings", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /usr/share/keyrings/
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_owner_apt_auth_conf_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_owner_apt_auth_conf_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Owner on /etc/apt/auth.conf.d Directory'
+
+description: '{{{ describe_directory_owner(directory="/etc/apt/auth.conf.d", owner="root") }}}'
+
+rationale: |-
+    The /etc/apt/auth.conf.d directory should be owned by root to prevent
+    unauthorized changes to APT authentication configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_owner(directory="/etc/apt/auth.conf.d", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_owner(directory="/etc/apt/auth.conf.d", owner="root") }}}
+
+fixtext: '{{{ fixtext_directory_owner(file="/etc/apt/auth.conf.d", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/apt/auth.conf.d/
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_owner_apt_sources_list_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_owner_apt_sources_list_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Owner on /etc/apt/sources.list.d Directory'
+
+description: '{{{ describe_directory_owner(directory="/etc/apt/sources.list.d", owner="root") }}}'
+
+rationale: |-
+    The /etc/apt/sources.list.d directory should be owned by root to prevent
+    unauthorized changes to APT repository configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_owner(directory="/etc/apt/sources.list.d", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_owner(directory="/etc/apt/sources.list.d", owner="root") }}}
+
+fixtext: '{{{ fixtext_directory_owner(file="/etc/apt/sources.list.d", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/apt/sources.list.d/
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_owner_apt_trusted_gpg_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_owner_apt_trusted_gpg_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Owner on /etc/apt/trusted.gpg.d Directory'
+
+description: '{{{ describe_directory_owner(directory="/etc/apt/trusted.gpg.d", owner="root") }}}'
+
+rationale: |-
+    The /etc/apt/trusted.gpg.d directory should be owned by root to prevent
+    unauthorized changes to APT trusted keys.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_owner(directory="/etc/apt/trusted.gpg.d", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_owner(directory="/etc/apt/trusted.gpg.d", owner="root") }}}
+
+fixtext: '{{{ fixtext_directory_owner(file="/etc/apt/trusted.gpg.d", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/apt/trusted.gpg.d/
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_owner_usr_share_keyrings/rule.yml
+++ b/linux_os/guide/services/apt/directory_owner_usr_share_keyrings/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Owner on /usr/share/keyrings Directory'
+
+description: '{{{ describe_directory_owner(directory="/usr/share/keyrings", owner="root") }}}'
+
+rationale: |-
+    The /usr/share/keyrings directory should be owned by root to prevent
+    unauthorized changes to package repository keys.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_owner(directory="/usr/share/keyrings", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_directory_owner(directory="/usr/share/keyrings", owner="root") }}}
+
+fixtext: '{{{ fixtext_directory_owner(file="/usr/share/keyrings", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /usr/share/keyrings/
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/directory_permissions_apt_auth_conf_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_permissions_apt_auth_conf_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /etc/apt/auth.conf.d Directory'
+
+description: '{{{ describe_directory_permissions(directory="/etc/apt/auth.conf.d", perms="0755") }}}'
+
+rationale: |-
+    The /etc/apt/auth.conf.d directory contains configuration that may include
+    repository credentials. Its permissions should prevent unauthorized changes.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_permissions(directory="/etc/apt/auth.conf.d", perms="drwxr-xr-x") }}}'
+
+ocil: |-
+    {{{ ocil_directory_permissions(directory="/etc/apt/auth.conf.d", perms="drwxr-xr-x") }}}
+
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/apt/auth.conf.d", mode="0755") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/apt/auth.conf.d/
+        filemode: '0755'

--- a/linux_os/guide/services/apt/directory_permissions_apt_sources_list_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_permissions_apt_sources_list_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /etc/apt/sources.list.d Directory'
+
+description: '{{{ describe_directory_permissions(directory="/etc/apt/sources.list.d", perms="0755") }}}'
+
+rationale: |-
+    A non-root user should not be able to add or remove APT repository
+    configuration from /etc/apt/sources.list.d.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_permissions(directory="/etc/apt/sources.list.d", perms="drwxr-xr-x") }}}'
+
+ocil: |-
+    {{{ ocil_directory_permissions(directory="/etc/apt/sources.list.d", perms="drwxr-xr-x") }}}
+
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/apt/sources.list.d", mode="0755") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/apt/sources.list.d/
+        filemode: '0755'

--- a/linux_os/guide/services/apt/directory_permissions_apt_trusted_gpg_d/rule.yml
+++ b/linux_os/guide/services/apt/directory_permissions_apt_trusted_gpg_d/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /etc/apt/trusted.gpg.d Directory'
+
+description: '{{{ describe_directory_permissions(directory="/etc/apt/trusted.gpg.d", perms="0755") }}}'
+
+rationale: |-
+    A non-privileged user with write access to /etc/apt/trusted.gpg.d can
+    compromise the APT chain of trust by adding trusted keys.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_permissions(directory="/etc/apt/trusted.gpg.d", perms="drwxr-xr-x") }}}'
+
+ocil: |-
+    {{{ ocil_directory_permissions(directory="/etc/apt/trusted.gpg.d", perms="drwxr-xr-x") }}}
+
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/apt/trusted.gpg.d", mode="0755") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/apt/trusted.gpg.d/
+        filemode: '0755'

--- a/linux_os/guide/services/apt/directory_permissions_usr_share_keyrings/rule.yml
+++ b/linux_os/guide/services/apt/directory_permissions_usr_share_keyrings/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /usr/share/keyrings Directory'
+
+description: '{{{ describe_directory_permissions(directory="/usr/share/keyrings", perms="0755") }}}'
+
+rationale: |-
+    A non-root user should not be able to add or remove package repository keys
+    from /usr/share/keyrings.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_directory_permissions(directory="/usr/share/keyrings", perms="drwxr-xr-x") }}}'
+
+ocil: |-
+    {{{ ocil_directory_permissions(directory="/usr/share/keyrings", perms="drwxr-xr-x") }}}
+
+fixtext: '{{{ fixtext_directory_permissions(file="/usr/share/keyrings", mode="0755") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /usr/share/keyrings/
+        filemode: '0755'

--- a/linux_os/guide/services/apt/file_groupowner_apt_auth_conf_d/rule.yml
+++ b/linux_os/guide/services/apt/file_groupowner_apt_auth_conf_d/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on Files in /etc/apt/auth.conf.d'
+
+description: '{{{ describe_file_group_owner(file="/etc/apt/auth.conf.d/*.conf", group="root") }}}'
+
+rationale: |-
+    Files in /etc/apt/auth.conf.d should be group-owned by root to prevent
+    unauthorized changes to APT authentication configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/apt/auth.conf.d/*.conf", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/apt/auth.conf.d/*.conf", group="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/apt/auth.conf.d/*.conf", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/apt/auth.conf.d/
+        file_regex: ^.*\.conf$
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/file_groupowner_apt_gpg_keys/rule.yml
+++ b/linux_os/guide/services/apt/file_groupowner_apt_gpg_keys/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on APT GPG Key Files'
+
+description: '{{{ describe_file_group_owner(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", group="root") }}}'
+
+rationale: |-
+    APT GPG key files should be group-owned by root to prevent unauthorized
+    modification of package trust anchors.
+
+severity: medium
+
+ocil_clause: 'APT GPG key files are not group-owned by root'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", group="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath:
+            - /usr/share/keyrings/
+            - /etc/apt/trusted.gpg.d/
+        file_regex:
+            - ^.*gpg$
+            - ^.*gpg$
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/file_groupowner_apt_gpg_keys/rule.yml
+++ b/linux_os/guide/services/apt/file_groupowner_apt_gpg_keys/rule.yml
@@ -24,6 +24,6 @@ template:
             - /usr/share/keyrings/
             - /etc/apt/trusted.gpg.d/
         file_regex:
-            - ^.*gpg$
-            - ^.*gpg$
+            - ^.*\.gpg$
+            - ^.*\.gpg$
         gid_or_name: '0'

--- a/linux_os/guide/services/apt/file_groupowner_apt_sources_list_d/rule.yml
+++ b/linux_os/guide/services/apt/file_groupowner_apt_sources_list_d/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify Group Owner on Files in /etc/apt/sources.list.d'
+
+description: '{{{ describe_file_group_owner(file="/etc/apt/sources.list.d/*", group="root") }}}'
+
+rationale: |-
+    Files in /etc/apt/sources.list.d should be group-owned by root to prevent
+    unauthorized changes to APT repository configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/apt/sources.list.d/*", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/apt/sources.list.d/*", group="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/apt/sources.list.d/*", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/apt/sources.list.d/
+        file_regex: ^.*$
+        gid_or_name: '0'

--- a/linux_os/guide/services/apt/file_owner_apt_auth_conf_d/rule.yml
+++ b/linux_os/guide/services/apt/file_owner_apt_auth_conf_d/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify Owner on Files in /etc/apt/auth.conf.d'
+
+description: '{{{ describe_file_owner(file="/etc/apt/auth.conf.d/*.conf", owner="root") }}}'
+
+rationale: |-
+    Files in /etc/apt/auth.conf.d should be owned by root to prevent
+    unauthorized changes to APT authentication configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/apt/auth.conf.d/*.conf", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/apt/auth.conf.d/*.conf", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/apt/auth.conf.d/*.conf", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/apt/auth.conf.d/
+        file_regex: ^.*\.conf$
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/file_owner_apt_gpg_keys/rule.yml
+++ b/linux_os/guide/services/apt/file_owner_apt_gpg_keys/rule.yml
@@ -24,6 +24,6 @@ template:
             - /usr/share/keyrings/
             - /etc/apt/trusted.gpg.d/
         file_regex:
-            - ^.*gpg$
-            - ^.*gpg$
+            - ^.*\.gpg$
+            - ^.*\.gpg$
         uid_or_name: '0'

--- a/linux_os/guide/services/apt/file_owner_apt_gpg_keys/rule.yml
+++ b/linux_os/guide/services/apt/file_owner_apt_gpg_keys/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Owner on APT GPG Key Files'
+
+description: '{{{ describe_file_owner(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", owner="root") }}}'
+
+rationale: |-
+    APT GPG key files should be owned by root to prevent unauthorized modification
+    of package trust anchors.
+
+severity: medium
+
+ocil_clause: 'APT GPG key files are not owned by root'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath:
+            - /usr/share/keyrings/
+            - /etc/apt/trusted.gpg.d/
+        file_regex:
+            - ^.*gpg$
+            - ^.*gpg$
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/file_owner_apt_sources_list_d/rule.yml
+++ b/linux_os/guide/services/apt/file_owner_apt_sources_list_d/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify Owner on Files in /etc/apt/sources.list.d'
+
+description: '{{{ describe_file_owner(file="/etc/apt/sources.list.d/*", owner="root") }}}'
+
+rationale: |-
+    Files in /etc/apt/sources.list.d should be owned by root to prevent
+    unauthorized changes to APT repository configuration.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/apt/sources.list.d/*", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/apt/sources.list.d/*", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/apt/sources.list.d/*", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/apt/sources.list.d/
+        file_regex: ^.*$
+        uid_or_name: '0'

--- a/linux_os/guide/services/apt/file_permissions_apt_auth_conf_d/rule.yml
+++ b/linux_os/guide/services/apt/file_permissions_apt_auth_conf_d/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify Permissions on Files in /etc/apt/auth.conf.d'
+
+description: '{{{ describe_file_permissions(file="/etc/apt/auth.conf.d/*.conf", perms="0640") }}}'
+
+rationale: |-
+    Files in /etc/apt/auth.conf.d may contain credentials for private
+    repositories or proxies and should not be readable by unauthorized users.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/apt/auth.conf.d/*.conf", perms="-rw-r-----") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/apt/auth.conf.d/*.conf", perms="-rw-r-----") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/apt/auth.conf.d/*.conf", mode="0640") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/apt/auth.conf.d/
+        file_regex: ^.*\.conf$
+        filemode: '0640'

--- a/linux_os/guide/services/apt/file_permissions_apt_gpg_keys/rule.yml
+++ b/linux_os/guide/services/apt/file_permissions_apt_gpg_keys/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Permissions on APT GPG Key Files'
+
+description: '{{{ describe_file_permissions(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", perms="0644") }}}'
+
+rationale: |-
+    APT GPG key files are used to verify package authenticity. Restricting their
+    permissions prevents unauthorized modification while keeping them readable by APT.
+
+severity: medium
+
+ocil_clause: 'APT GPG key files have permissions more permissive than 0644'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", perms="-rw-r--r--") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/usr/share/keyrings/*.gpg and /etc/apt/trusted.gpg.d/*.gpg", mode="0644") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath:
+            - /usr/share/keyrings/
+            - /etc/apt/trusted.gpg.d/
+        file_regex:
+            - ^.*gpg$
+            - ^.*gpg$
+        filemode: '0644'

--- a/linux_os/guide/services/apt/file_permissions_apt_sources_list_d/rule.yml
+++ b/linux_os/guide/services/apt/file_permissions_apt_sources_list_d/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify Permissions on Files in /etc/apt/sources.list.d'
+
+description: '{{{ describe_file_permissions(file="/etc/apt/sources.list.d/*", perms="0644") }}}'
+
+rationale: |-
+    Files in /etc/apt/sources.list.d contain APT repository configuration. They
+    should not be writable by non-root users.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/apt/sources.list.d/*", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/apt/sources.list.d/*", perms="-rw-r--r--") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/apt/sources.list.d/*", mode="0644") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/apt/sources.list.d/
+        file_regex: ^.*$
+        filemode: '0644'


### PR DESCRIPTION
Add 23 new rules covering ownership, group ownership, and permissions for APT configuration directories and files:

Directories (owner root, group root, mode 0755):
- directory_owner/groupowner/permissions_apt_sources_list_d
- directory_owner/groupowner/permissions_apt_auth_conf_d
- directory_owner/groupowner/permissions_apt_trusted_gpg_d
- directory_owner/groupowner/permissions_usr_share_keyrings

Files (owner root, group root, mode 0644):
- file_owner/groupowner/permissions_apt_sources_list_d
- file_owner/groupowner/permissions_apt_auth_conf_d
- file_owner/groupowner/permissions_apt_gpg_keys (for /usr/share/keyrings/)

Additional:
- apt_disable_weak_dependencies: ensure APT::Install-Recommends and APT::Install-Suggests are set to "0" in apt.conf.d/

All ownership and permission rules use the file_owner, file_groupowner, file_permissions, directory_owner, directory_groupowner, and directory_permissions templates. Map all new rules to the apt component.

#### Description:
  
- Add 23 new rules covering ownership, group ownership, and permissions
  for APT configuration directories and files:
  - Directories (`owner root`, `group root`, mode `0755`):
    `directory_owner/groupowner/permissions_apt_sources_list_d`,
    `directory_owner/groupowner/permissions_apt_auth_conf_d`,
    `directory_owner/groupowner/permissions_apt_trusted_gpg_d`,
    `directory_owner/groupowner/permissions_usr_share_keyrings`
  - Files (`owner root`, `group root`, mode `0644`):
    `file_owner/groupowner/permissions_apt_sources_list_d`,
    `file_owner/groupowner/permissions_apt_auth_conf_d`,
    `file_owner/groupowner/permissions_apt_gpg_keys`
    (covers files under `/usr/share/keyrings/`)
  - `apt_disable_weak_dependencies`: ensure `APT::Install-Recommends`
    and `APT::Install-Suggests` are set to `"0"` in `apt.conf.d/`
- Map all new rules to the `apt` component.

#### Rationale:

- APT configuration files and GPG keyrings must be owned by root and
  have restrictive permissions to prevent unauthorized modification of
  package sources or trust anchors.
- These rules did not previously exist for any product. They provide
  reusable coverage for any Debian-based system.

#### Review Hints:

- All ownership and permission rules use the `file_owner`,
  `file_groupowner`, `file_permissions`, `directory_owner`,
  `directory_groupowner`, and `directory_permissions` templates.
- `apt_disable_weak_dependencies` uses a custom OVAL that scans
  `/etc/apt/apt.conf` and `/etc/apt/apt.conf.d/` for the relevant
  directives.
- Build to verify: `./build_product debian13 --datastream-only`
