### PR TITLE
apparmor_configured: add packagename override for Debian 13

### DIFF
--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -59,3 +59,4 @@ template:
         packagename@ubuntu2204: apparmor
         packagename@ubuntu2404: apparmor
         packagename@debian12: apparmor
+        packagename@debian13: apparmor


### PR DESCRIPTION
The service_enabled template needs an explicit packagename@debian13 override to use the correct package name on Debian 13 (same as debian12: apparmor).

#### Description:
- Add `packagename@debian13: apparmor` override to the `apparmor_configured`
  rule so that the `service_enabled` template uses the correct package name
  on Debian 13 (the package is named `apparmor`, same as on Debian 12).
  
#### Rationale:
- Without this override, the template falls back to `apparmor-parser` (the
  default for SUSE/SLE), which is not the correct package on Debian 13.

#### Review Hints:
- One-line change, mirrors the existing `packagename@debian12: apparmor`.