### PR TITLE
logging_services_active: add syslog-ng as a recognized logging service

### DIFF
--- a/linux_os/guide/system/logging/logging_services_active/oval/shared.xml
+++ b/linux_os/guide/system/logging/logging_services_active/oval/shared.xml
@@ -11,7 +11,7 @@
   <!-- Objects and states to identify active logging_service services -->
   <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_logging_services" version="1"
       comment="All active logging_service services">
-    <linux:unit operation="pattern match">^(rsyslog|systemd-journald).service$</linux:unit>
+    <linux:unit operation="pattern match">^(rsyslog|syslog-ng|systemd-journald).service$</linux:unit>
     <linux:property>ActiveState</linux:property>
     <filter action="include">ste_{{{ rule_id }}}_logging_services</filter>
   </linux:systemdunitproperty_object>

--- a/linux_os/guide/system/logging/logging_services_active/rule.yml
+++ b/linux_os/guide/system/logging/logging_services_active/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure One Logging Service Is In Use'
 description: |-
     Ensure that a logging system is active and in use.
     <pre>
-    systemctl is-active rsyslog systemd-journald
+    systemctl is-active rsyslog syslog-ng systemd-journald
     </pre>
     The command should return at least one <tt>active</tt>.
 


### PR DESCRIPTION
The OVAL check and description only listed rsyslog and systemd-journald. Add syslog-ng to the unit pattern so the rule passes on systems that use syslog-ng as their primary logging daemon (e.g. Debian 13 CIS profile).

#### Description:
- Add `syslog-ng` to the systemd unit pattern in the `logging_services_active`
  OVAL check and to the example command in the rule description.

- Previously the rule only recognized `rsyslog` and `systemd-journald` as
  valid active logging services. Systems that use syslog-ng as their primary
  logging daemon (e.g. Debian 13 with the CIS profile) would fail this check
  even when a logging service is correctly active.
  
#### Rationale:
- syslog-ng is a widely-used alternative to rsyslog. The rule intent is
  "at least one logging service is active", so syslog-ng should be included
  alongside rsyslog and systemd-journald.

#### Review Hints:
- Two-line change: one in the OVAL unit pattern, one in the description example.
