### PR TITLE
Add Debian 13 package and service name overrides for CIS section 2

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/package_avahi_removed/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/package_avahi_removed/rule.yml
@@ -42,5 +42,6 @@ template:
     name: package_removed
     vars:
         pkgname: avahi
+        pkgname@debian13: avahi-daemon
         pkgname@ubuntu2204: avahi-daemon
         pkgname@ubuntu2404: avahi-daemon

--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -47,5 +47,6 @@ template:
     vars:
         servicename: avahi-daemon
         packagename: avahi
+        packagename@debian13: avahi-daemon
         packagename@ubuntu2204: avahi-daemon
         packagename@ubuntu2404: avahi-daemon

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -45,5 +45,6 @@ template:
         pkgname@rhel9:
             - bind
             - bind9.18
+        pkgname@debian13: bind9
         pkgname@ubuntu2204: bind9
         pkgname@ubuntu2404: bind9

--- a/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
@@ -43,4 +43,5 @@ template:
     vars:
         servicename: named
         packagename: bind
+        packagename@debian13: bind9
         packagename@ubuntu2404: bind9

--- a/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'debian' in product %}}
   {{%- set package = "apache2" %}}
 {{% else %}}
   {{%- set package = "httpd" %}}

--- a/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'debian' in product %}}
 {{% set service_name = "apache2" %}}
 {{% else %}}
 {{% set service_name = "httpd" %}}

--- a/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
@@ -1,4 +1,4 @@
-{{% if 'ubuntu' not in product %}}
+{{% if 'ubuntu' not in product and 'debian' not in product %}}
  {{%- set package = "dovecot" %}}
 {{% else %}}
  {{%- set package = "dovecot-core" %}}
@@ -35,5 +35,6 @@ template:
     name: package_removed
     vars:
         pkgname: dovecot
+        pkgname@debian13: dovecot-core
         pkgname@ubuntu2204: dovecot-core
         pkgname@ubuntu2404: dovecot-core

--- a/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
@@ -34,4 +34,5 @@ template:
     name: service_disabled
     vars:
         servicename: dovecot
+        packagename@debian13: dovecot-core
         packagename@ubuntu2404: dovecot-core

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
@@ -1,6 +1,6 @@
 {{% if product in ["sle12", "sle15", "slmicro5"] %}}
   {{%- set package = "openldap2-client" %}}
-{{% elif "ubuntu" in product %}}
+{{% elif "ubuntu" in product or "debian" in product %}}
   {{%- set package = "ldap-utils" %}}
 {{% else %}}
   {{%- set package = "openldap-clients" %}}
@@ -46,3 +46,4 @@ template:
         pkgname@slmicro5: openldap2-client
         pkgname@ubuntu2204: ldap-utils
         pkgname@ubuntu2404: ldap-utils
+        pkgname@debian13: ldap-utils

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -1,6 +1,6 @@
 {{% if product in ["sle12", "sle15", "slmicro5"] %}}
   {{%- set package = "openldap2" %}}
-{{% elif "ubuntu" in product %}}
+{{% elif "debian" in product or "ubuntu" in product %}}
   {{%- set package = "slapd" %}}
 {{% else %}}
   {{%- set package = "openldap-servers" %}}
@@ -47,6 +47,7 @@ template:
     name: package_removed
     vars:
         pkgname: openldap-servers
+        pkgname@debian13: slapd
         pkgname@sle12: openldap2
         pkgname@sle15: openldap2
         pkgname@slmicro5: openldap2

--- a/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
@@ -30,4 +30,5 @@ template:
     vars:
         servicename: slapd
         packagename: openldap-servers
+        packagename@debian13: slapd
         packagename@ubuntu2404: slapd

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -44,5 +44,6 @@ template:
     vars:
         servicename: nfs-server
         packagename: nfs-utils
+        packagename@debian13: nfs-kernel-server
         packagename@ubuntu2404: nfs-kernel-server
         packagename@sle15: nfs-kernel-server

--- a/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'Uninstall rsh Package'
 
 description: |-
-    {{% if 'ubuntu' not in product %}}
+    {{% if 'ubuntu' not in product and 'debian' not in product %}}
     The <tt>rsh</tt> package contains the client commands
     {{% else %}}
     The <tt>rsh-client</tt> package contains the client commands
@@ -16,7 +16,7 @@ rationale: |-
     been replaced with the more secure SSH package. Even if the server is removed,
     it is best to ensure the clients are also removed to prevent users from
     inadvertently attempting to use these commands and therefore exposing
-    {{% if 'ubuntu' not in product %}}
+    {{% if 'ubuntu' not in product and 'debian' not in product %}}
     their credentials. Note that removing the <tt>rsh</tt> package removes
     {{% else %}}
     their credentials. Note that removing the <tt>rsh-client</tt> package removes
@@ -40,7 +40,7 @@ references:
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
     iso27001-2013: A.8.2.3,A.13.1.1,A.13.2.1,A.13.2.3,A.14.1.2,A.14.1.3
 
-{{% if 'ubuntu' not in product %}}
+{{% if 'ubuntu' not in product and 'debian' not in product %}}
 ocil: '{{{ describe_package_remove(package="rsh") }}}'
 {{% else %}}
 ocil: '{{{ describe_package_remove(package="rsh-client") }}}'
@@ -50,6 +50,7 @@ template:
     name: package_removed
     vars:
         pkgname: rsh
+        pkgname@debian13: rsh-client
         pkgname@ubuntu2204: rsh-client
         pkgname@ubuntu2404: rsh-client
 

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -38,6 +38,8 @@ template:
     vars:
         servicename: rsyncd
         packagename: rsync-daemon
+        packagename@debian13: rsync
+        servicename@debian13: rsync
         packagename@ol7: rsync
         packagename@sle12: rsync
         packagename@sle15: rsync

--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -1,4 +1,4 @@
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'debian' in product %}}
   {{%- set package = "tftpd-hpa" %}}
 {{% elif 'sle' in product %}}
   {{%- set package = "tftp" %}}

--- a/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'debian' in product %}}
   {{%- set service_name = "tftpd-hpa" %}}
   {{%- set package = "tftpd-hpa" %}}
 {{% elif 'sle' in product or product == "slmicro5" %}}

--- a/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
@@ -34,6 +34,7 @@ template:
     name: service_disabled
     vars:
         servicename: smb
+        servicename@debian13: smbd
         servicename@ubuntu2204: smbd
         servicename@ubuntu2404: smbd
         packagename: samba

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -43,5 +43,6 @@ template:
     vars:
         pkgname: net-snmp
         pkgname@debian11: snmp
+        pkgname@debian13: snmpd
         pkgname@ubuntu2204: snmp
         pkgname@ubuntu2404: snmpd

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -38,5 +38,6 @@ template:
         servicename: snmpd
         packagename@debian11: snmpd
         packagename@debian12: snmpd
+        packagename@debian13: snmpd
         packagename@ubuntu2404: snmpd
         packagename: net-snmp

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
@@ -60,5 +60,6 @@ template:
     name: package_removed
     vars:
         pkgname: xorg-x11-server-common
+        pkgname@debian13: xserver-common
         pkgname@ubuntu2204: xserver-common
         pkgname@ubuntu2404: xserver-common

--- a/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'Remove the GDM Package Group'
 
 description: |-
-    {{% if 'ubuntu' not in product %}}
+    {{% if 'ubuntu' not in product and 'debian' not in product %}}
     By removing the <tt>gdm</tt> package, the system no longer has GNOME installed.
     {{% else %}}
     By removing the <tt>gdm3</tt> package, the system no longer has GNOME installed.
@@ -12,7 +12,7 @@ description: |-
     If X Windows is not installed then the system cannot boot into graphical user mode.
     This prevents the system from being accidentally or maliciously booted into a <tt>graphical.target</tt>
     mode. To do so, run the following command:
-    {{% if 'ubuntu' not in product %}}
+    {{% if 'ubuntu' not in product and 'debian' not in product %}}
     <pre>$ sudo yum remove gdm</pre>
     {{% else %}}
     <pre>$ sudo apt remove gdm3</pre>
@@ -38,7 +38,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     srg: SRG-OS-000480-GPOS-00227
 
-{{% if 'ubuntu' not in product %}}
+{{% if 'ubuntu' not in product and 'debian' not in product %}}
 ocil_clause: 'gdm has not been removed'
 
 ocil: |-
@@ -66,5 +66,6 @@ template:
     name: package_removed
     vars:
         pkgname: gdm
+        pkgname@debian13: gdm3
         pkgname@ubuntu2204: gdm3
         pkgname@ubuntu2404: gdm3

--- a/shared/templates/service_disabled_guard_var/bash.template
+++ b/shared/templates/service_disabled_guard_var/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu,multi_platform_debian
 # reboot = false
 # strategy = disable
 # complexity = low


### PR DESCRIPTION
Extend existing service-disable and package-remove rules to support Debian 13 by adding pkgname@debian13 and servicename@debian13 overrides, and extending 'ubuntu' conditions to cover 'debian' products:

- avahi: pkgname@debian13=avahi-daemon, packagename@debian13=avahi-daemon
- bind: pkgname@debian13=bind9, packagename@debian13=bind9
- httpd/apache2: extend ubuntu condition to debian (package=apache2, service=apache2)
- dovecot: pkgname@debian13=dovecot-core, packagename@debian13=dovecot-core
- openldap-clients: pkgname@debian13=ldap-utils
- openldap-servers/slapd: pkgname@debian13=slapd, packagename@debian13=slapd
- nfs: packagename@debian13=nfs-kernel-server
- rsh: pkgname@debian13=rsh-client, extend ubuntu condition to debian
- rsyncd: packagename@debian13=rsync, servicename@debian13=rsync
- tftp: extend ubuntu condition to debian (package/service=tftpd-hpa)
- smb/samba: servicename@debian13=smbd
- snmp: pkgname@debian13=snmpd, packagename@debian13=snmpd
- xorg: pkgname@debian13=xserver-common
- gdm: pkgname@debian13=gdm3, extend ubuntu condition to debian
- service_disabled_guard_var template: add multi_platform_debian to the platform line so chrony/timesyncd guard rules apply to Debian

#### Description:
  Extend existing service-disable and package-remove rules to support
  Debian 13 by adding `pkgname@debian13` and `servicename@debian13`
  overrides, and widening `'ubuntu' in product` guards to cover
  `'debian' in product` where needed:
  
  - avahi: `avahi-daemon`
  - bind: `bind9`
  - httpd/apache2: extend ubuntu → debian (package=`apache2`, service=`apache2`)
  - dovecot: `dovecot-core`
  - openldap-clients: `ldap-utils`
  - openldap-servers/slapd: `slapd`
  - nfs: `nfs-kernel-server`
  - rsh: `rsh-client`; extend ubuntu → debian
  - rsyncd: package=`rsync`, service=`rsync`
  - tftp: extend ubuntu → debian (package/service=`tftpd-hpa`)
  - smb/samba: service=`smbd`
  - snmp: `snmpd`
  - xorg: `xserver-common`
  - gdm: `gdm3`; extend ubuntu → debian
  - `service_disabled_guard_var` bash template: add `multi_platform_debian`
    so the chrony/timesyncd guard logic applies to Debian products.

#### Rationale:
  Without these overrides the `package_removed` and `service_disabled`
  templates fall back to RHEL package/service names, causing incorrect
  checks and remediations on Debian 13.

#### Review Hints:
  All changes are additive overrides or condition extensions — no existing
  RHEL/Ubuntu behaviour is modified. The `service_disabled_guard_var`
  template change adds Debian to the platform list so that the
  `chronyd_or_timesyncd` guard runs correctly on Debian 13.

