### PR TITLE
Add Debian 13 support to NTP/chrony rules

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/ansible/shared.yml
@@ -9,7 +9,7 @@
 - name: {{{ rule_title }}} - Add missing / update wrong records for remote time servers
   ansible.builtin.lineinfile:
     path: {{{ chrony_conf_path }}}
-    regexp: '^\s*\bserver\b\s*\b{{ item }}\b$'
+    regexp: '^\s*\bserver\b\s*\b{{ item }}\b'
     state: present
     line: 'server {{ item }}'
     create: true
@@ -19,7 +19,7 @@
 - name: {{{ rule_title }}} - Add missing / update wrong records for remote time pools
   ansible.builtin.lineinfile:
     path: {{{ chrony_conf_path }}}
-    regexp: '^\s*\bpool\b\s*\b{{ item }}\b$'
+    regexp: '^\s*\bpool\b\s*\b{{ item }}\b'
     state: present
     line: 'pool {{ item }}'
     create: true

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/oval/shared.xml
@@ -16,7 +16,7 @@
           <split delimiter=",">
               <variable_component var_ref="var_multiple_time_servers" />
           </split>
-          <literal_component>$</literal_component>
+          <literal_component>([[:space:]].*)?$</literal_component>
       </concat>
   </local_variable>
 
@@ -29,7 +29,7 @@
           <split delimiter=",">
               <variable_component var_ref="var_multiple_time_pools" />
           </split>
-          <literal_component>$</literal_component>
+          <literal_component>([[:space:]].*)?$</literal_component>
       </concat>
   </local_variable>
 

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/pool_with_options.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/pool_with_options.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = chrony
+# variables = var_multiple_time_servers=0.debian.pool.ntp.org,1.debian.pool.ntp.org,2.debian.pool.ntp.org,3.debian.pool.ntp.org,var_multiple_time_pools=0.debian.pool.ntp.org,1.debian.pool.ntp.org,2.debian.pool.ntp.org,3.debian.pool.ntp.org
+
+echo "" > {{{ chrony_conf_path }}}
+echo "pool 2.debian.pool.ntp.org iburst" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/server_with_options.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/server_with_options.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = chrony
+# variables = var_multiple_time_servers=0.debian.pool.ntp.org,1.debian.pool.ntp.org,2.debian.pool.ntp.org,3.debian.pool.ntp.org,var_multiple_time_pools=0.debian.pool.ntp.org,1.debian.pool.ntp.org,2.debian.pool.ntp.org,3.debian.pool.ntp.org
+
+echo "" > {{{ chrony_conf_path }}}
+echo "server 2.debian.pool.ntp.org iburst maxpoll 10" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/debian.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/debian.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_debian
+
+{{{ bash_replace_or_append(chrony_conf_path, '^user', '_chrony', '%s %s', cce_identifiers=cce_identifiers) }}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
@@ -29,7 +29,7 @@
   </ind:textfilecontent54_object>
 
 </def-group>
-{{%- elif 'ubuntu' in product -%}}
+{{%- elif 'ubuntu' in product or 'debian' in product -%}}
 {{{ oval_check_config_file(path='/etc/chrony/chrony.conf', prefix_regex='^[ \\t]*', parameter='user', separator_regex='[[:space:]]', value='_chrony', missing_parameter_pass=true, missing_config_file_fail=false, rule_id=rule_id, rule_title=rule_title) }}}
 {{%- else -%}}
 {{{ oval_check_config_file(path='/etc/sysconfig/chronyd', prefix_regex='^[ \\t]*', parameter='OPTIONS', separator_regex='=', value='["]?.*-u[\s]*chrony.*["]?', missing_parameter_pass=ok_by_default, missing_config_file_fail=true, rule_id=rule_id, rule_title=rule_title) }}}

--- a/linux_os/guide/services/ntp/package_timesyncd_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_installed/rule.yml
@@ -19,7 +19,7 @@ references:
     nist-csf: PR.PT-1
     pcidss: Req-10.4
 
-{{%- if 'ubuntu' in product %}}
+{{%- if 'ubuntu' in product or 'debian' in product %}}
 template:
     name: package_installed_guard_var
     vars:

--- a/linux_os/guide/services/ntp/service_chronyd_disabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_disabled/rule.yml
@@ -13,7 +13,7 @@ severity: medium
 
 platform: package[chrony]
 
-{{%- if 'ubuntu' in product %}}
+{{%- if 'ubuntu' in product or 'debian' in product %}}
 template:
     name: service_disabled_guard_var
     vars:
@@ -27,6 +27,4 @@ template:
     vars:
         packagename: chrony
         servicename: chronyd
-        servicename@ubuntu2204: chrony
-        servicename@debian12: chrony
 {{%- endif %}}

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/rule.yml
@@ -19,7 +19,7 @@ rationale: |-
 
 severity: medium
 
-platform: package[systemd]
+platform: package[systemd-timesyncd]
 
 identifiers:
     cce@sle12: CCE-92374-8

--- a/linux_os/guide/services/ntp/service_timesyncd_disabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_disabled/rule.yml
@@ -17,7 +17,7 @@ severity: medium
 
 platform: package[systemd-timesyncd]
 
-{{%- if 'ubuntu' in product %}}
+{{%- if 'ubuntu' in product or 'debian' in product %}}
 template:
     name: service_disabled_guard_var
     vars:


### PR DESCRIPTION
- chronyd_run_as_chrony_user: add bash/debian.sh that sets the chrony user to _chrony (Debian uses _chrony, not chrony); extend OVAL condition from ubuntu-only to all Debian products to check /etc/chrony/chrony.conf.
- service_chronyd_disabled: extend the service_disabled_guard_var condition from ubuntu-only to all Debian products. Remove now-dead servicename@ubuntu2204 and servicename@debian12 overrides from the service_disabled branch (those products now use service_disabled_guard_var).
- service_timesyncd_disabled: extend service_disabled_guard_var condition to all Debian products.
- service_timesyncd_configured: fix platform from package[systemd] to package[systemd-timesyncd] (the timesyncd package is split on Debian).
- package_timesyncd_installed: extend package_installed_guard_var condition from ubuntu-only to all Debian products.
- chronyd_configure_pool_and_server: fix OVAL and Ansible regexps to allow options after the server/pool address (e.g. "iburst", "maxpoll"); add two test scenarios covering pool/server entries with options.

#### Description:
  Extend NTP and chrony rules to support Debian 13:
  
  - `chronyd_run_as_chrony_user`: add `bash/debian.sh` that sets the
    runtime user to `_chrony` (Debian convention); extend OVAL condition
    from ubuntu-only to all Debian products to read `/etc/chrony/chrony.conf`.
  - `service_chronyd_disabled`: extend the `service_disabled_guard_var`
    condition from ubuntu-only to all Debian products; remove now-dead
    `servicename@ubuntu2204` and `servicename@debian12` overrides.
  - `service_timesyncd_disabled`: extend `service_disabled_guard_var`
    condition to all Debian products.
  - `service_timesyncd_configured`: fix platform from `package[systemd]`
    to `package[systemd-timesyncd]` (timesyncd is a split package on Debian).
  - `package_timesyncd_installed`: extend `package_installed_guard_var`
    condition from ubuntu-only to all Debian products.
  - `chronyd_configure_pool_and_server`: fix OVAL and Ansible regexps to
    allow options after the server/pool address (e.g. `iburst`, `maxpoll`);
    add two test scenarios covering pool/server entries with options.

#### Rationale:
  Debian 13 uses `_chrony` as the chrony runtime user (not `chrony`),
  `systemd-timesyncd` is packaged separately, and chrony configuration
  accepts options on the same line as `server`/`pool` directives that
  the previous regexp did not match.

#### Review Hints:
  - `chronyd_run_as_chrony_user/bash/debian.sh`: new file, sets `_chrony`.
  - `chronyd_configure_pool_and_server`: regexp change — old pattern
    required end-of-line immediately after the address; new pattern allows
    optional trailing content (`([[:space:]].*)?$`).
  - The two new test scenarios (`pool_with_options.pass.sh`,
    `server_with_options.pass.sh`) verify the fixed regexp.

