### PR TITLE
Add Debian 13 auditd variable options and grub2 UEFI password OVAL

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
@@ -28,3 +28,4 @@ options:
     cis_ubuntu2204: syslog|single|halt
     cis_ubuntu2404: syslog|single|halt
     cis_debian12: syslog|single|halt
+    cis_debian13: syslog|single|halt

--- a/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
@@ -29,3 +29,4 @@ options:
     cis_ubuntu2204: halt|single
     cis_ubuntu2404: halt|single
     cis_debian12: halt|single
+    cis_debian13: halt|single

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/debian.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/debian.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="grub2_uefi_password" version="1">
+    {{{ oval_metadata("The UEFI grub2 boot loader should have password protection enabled.", rule_title=rule_title) }}}
+
+    <criteria operator="AND">
+      <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_grub2_uefi_password_grubcfg" />
+      <criterion comment="make sure a superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" id="test_bootloader_uefi_superuser" version="2">
+    <ind:object object_ref="object_bootloader_uefi_superuser" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bootloader_uefi_superuser" version="2">
+    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" id="test_grub2_uefi_password_grubcfg" version="1">
+    <ind:object object_ref="object_grub2_uefi_password_grubcfg" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_grub2_uefi_password_grubcfg" version="1">
+    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>


### PR DESCRIPTION
- var_auditd_disk_error_action: add cis_debian13=syslog|single|halt matching the CIS Debian 13 allowed values (same as cis_debian12).
- var_auditd_disk_full_action: add cis_debian13=halt|single matching the CIS Debian 13 allowed values (same as cis_debian12).
- grub2_uefi_password/oval/debian.xml: add Debian-specific OVAL check that verifies superusers and password_pbkdf2 entries in grub2_uefi_boot_path/grub.cfg (Debian stores GRUB config in a different path than RHEL, requiring a separate OVAL file).

#### Description:
  - `var_auditd_disk_error_action`: add `cis_debian13: syslog|single|halt`
    (same allowed values as `cis_debian12`, per CIS Debian 13 section 6.3.4.x).
  - `var_auditd_disk_full_action`: add `cis_debian13: halt|single`
    (same allowed values as `cis_debian12`).
  - `grub2_uefi_password/oval/debian.xml`: new Debian-specific OVAL that
    checks for `superusers` and `password_pbkdf2` entries in
    `{{{ grub2_uefi_boot_path }}}/grub.cfg`. Debian stores the GRUB
    configuration in a different path than RHEL and requires its own OVAL file.

#### Rationale:
  Without the `cis_debian13` variable options the profile cannot set the
  correct allowed values via `var_auditd_disk_error_action=cis_debian13`
  in the profile selections. The GRUB UEFI OVAL is needed because the
  existing RHEL OVAL uses a different boot path macro value.
  
#### Review Hints:
  - `var_auditd_disk_*`: one-line additions, mirror the `cis_debian12` entries.
  - `grub2_uefi_password/oval/debian.xml`: follows the same structure as
    the existing Ubuntu OVAL in the same directory.

