### PR TITLE
nist_800_53: fix sync script variable lookup and complete CIS→NIST mappings

### DIFF
--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/ac.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/ac.yml
@@ -41,12 +41,11 @@ controls:
       levels:
           - moderate
       rules:
+          - var_accounts_tmout=15_min
           - accounts_tmout
           - no_invalid_shell_accounts_unlocked
           - no_password_auth_for_systemaccounts
           - no_shelllogin_for_systemaccounts
-          - inactivity_timeout_value=15_minutes
-          - var_accounts_tmout=15_min
       status: automated
     - id: ac-2.6
       title: Dynamic Privilege Management
@@ -91,6 +90,9 @@ controls:
       levels:
           - low
       rules:
+          - var_selinux_policy_name=targeted
+          - var_pam_wheel_group_for_su=cis
+          - var_accounts_user_umask=027
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs
           - accounts_umask_etc_profile
@@ -210,6 +212,7 @@ controls:
           - package_libselinux_installed
           - package_mcstrans_removed
           - package_setroubleshoot_removed
+          - rsyslog_filecreatemode
           - rsyslog_files_groupownership
           - rsyslog_files_ownership
           - rsyslog_files_permissions
@@ -219,9 +222,6 @@ controls:
           - sysctl_fs_protected_hardlinks
           - sysctl_fs_protected_symlinks
           - use_pam_wheel_group_for_su
-          - var_accounts_user_umask=027
-          - var_pam_wheel_group_for_su=cis
-          - var_selinux_policy_name=targeted
       status: automated
     - id: ac-3.1
       title: Restricted Access to Privileged Functions
@@ -495,15 +495,14 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
+          - var_accounts_passwords_pam_faillock_deny=5
+          - var_accounts_passwords_pam_faillock_unlock_time=900
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - accounts_passwords_pam_faillock_deny
           - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time_with_zero
-          - var_accounts_passwords_pam_faillock_deny=5
-          - var_accounts_passwords_pam_faillock_dir=run
-          - var_accounts_passwords_pam_faillock_root_unlock_time=60
-          - var_accounts_passwords_pam_faillock_unlock_time=900
       status: automated
     - id: ac-7.1
       title: Automatic Account Lock
@@ -526,6 +525,8 @@ controls:
       levels:
           - low
       rules:
+          - dconf_login_banner_text=cis_banners
+          - dconf_login_banner_contents=cis_default
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
       status: automated
@@ -560,11 +561,12 @@ controls:
       levels:
           - moderate
       rules:
+          - inactivity_timeout_value=15_minutes
+          - var_screensaver_lock_delay=5_seconds
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
           - dconf_gnome_screensaver_user_locks
           - dconf_gnome_session_idle_user_locks
-          - var_screensaver_lock_delay=5_seconds
       status: automated
     - id: ac-11.1
       title: Pattern-hiding Displays

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/au.yml
@@ -11,6 +11,10 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_admin_space_left_action=cis_rhel10
+          - var_audit_backlog_limit=8192
+          - var_auditd_space_left_action=cis_rhel10
+          - var_auditd_action_mail_acct=root
           - aide_build_database
           - aide_periodic_cron_checking
           - audit_rules_execution_chacl
@@ -33,10 +37,6 @@ controls:
           - service_systemd-journal-upload_enabled
           - service_systemd-journald_enabled
           - socket_systemd-journal-remote_disabled
-          - var_audit_backlog_limit=8192
-          - var_auditd_action_mail_acct=root
-          - var_auditd_admin_space_left_action=cis_rhel10
-          - var_auditd_space_left_action=cis_rhel10
       status: automated
     - id: au-2.1
       title: Compilation of Audit Records from Multiple Sources
@@ -59,6 +59,10 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - var_multiple_time_servers=rhel
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - sshd_max_auth_tries_value=4
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -125,8 +129,6 @@ controls:
           - sudo_custom_logfile
           - sysctl_net_ipv4_conf_all_log_martians
           - sysctl_net_ipv4_conf_default_log_martians
-          - sshd_max_auth_tries_value=4
-          - var_multiple_time_servers=rhel
       status: automated
     - id: au-3.1
       title: Additional Audit Information
@@ -158,10 +160,10 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_disk_full_action=cis_rhel10
+          - var_auditd_disk_error_action=cis_rhel10
           - auditd_data_disk_error_action
           - auditd_data_disk_full_action
-          - var_auditd_disk_error_action=cis_rhel10
-          - var_auditd_disk_full_action=cis_rhel10
       status: automated
     - id: au-5.1
       title: Storage Capacity Warning
@@ -262,10 +264,10 @@ controls:
       levels:
           - low
       rules:
-          - auditd_data_retention_max_log_file
-          - auditd_data_retention_max_log_file_action
           - var_auditd_max_log_file=8
           - var_auditd_max_log_file_action=keep_logs
+          - auditd_data_retention_max_log_file
+          - auditd_data_retention_max_log_file_action
       status: automated
     - id: au-8.1
       title: Synchronization with Authoritative Time Source
@@ -363,6 +365,8 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_passwords_pam_faillock_dir=run
+          - audit_rules_continue_loading
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -377,7 +381,6 @@ controls:
           - audit_rules_dac_modification_lsetxattr
           - audit_rules_dac_modification_removexattr
           - audit_rules_dac_modification_setxattr
-          - audit_rules_continue_loading
           - audit_rules_execution_chcon
           - audit_rules_file_deletion_events_rename
           - audit_rules_file_deletion_events_renameat

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/cm.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/cm.yml
@@ -5,6 +5,12 @@ controls:
       levels:
           - low
       rules:
+          - var_user_initialization_files_regex=all_dotfiles
+          - var_sshd_set_maxstartups=10:30:60
+          - sshd_idle_timeout_value=5_minutes
+          - var_sshd_set_keepalive=1
+          - var_accounts_maximum_age_login_defs=365
+          - var_sshd_max_sessions=10
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - account_unique_id
@@ -55,6 +61,7 @@ controls:
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           - sysctl_net_ipv4_ip_forward
           - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra
           - sysctl_net_ipv6_conf_all_accept_redirects
           - sysctl_net_ipv6_conf_all_accept_source_route
@@ -62,13 +69,6 @@ controls:
           - sysctl_net_ipv6_conf_default_accept_ra
           - sysctl_net_ipv6_conf_default_accept_redirects
           - sysctl_net_ipv6_conf_default_accept_source_route
-          - sshd_idle_timeout_value=5_minutes
-          - sysctl_net_ipv4_tcp_syncookies_value=enabled
-          - var_accounts_maximum_age_login_defs=365
-          - var_sshd_max_sessions=10
-          - var_sshd_set_keepalive=1
-          - var_sshd_set_maxstartups=10:30:60
-          - var_user_initialization_files_regex=all_dotfiles
       status: automated
     - id: cm-2
       title: Baseline Configuration
@@ -215,6 +215,31 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - cis_banner_text=cis
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - var_accounts_user_umask=027
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - var_sshd_set_login_grace_time=60
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - accounts_password_pam_modules_in_authselect_profile
           - accounts_password_pam_pwquality_password_auth
           - accounts_password_pam_pwquality_system_auth
           - accounts_umask_etc_bashrc
@@ -225,6 +250,7 @@ controls:
           - banner_etc_issue_cis
           - banner_etc_issue_net_cis
           - banner_etc_motd_cis
+          - chronyd_run_as_chrony_user
           - coredump_disable_backtraces
           - coredump_disable_storage
           - dconf_db_up_to_date
@@ -285,32 +311,6 @@ controls:
           - sysctl_net_ipv6_conf_default_accept_redirects
           - sysctl_net_ipv6_conf_default_accept_source_route
           - sysctl_net_ipv6_conf_default_forwarding
-          - cis_banner_text=cis
-          - dconf_login_banner_contents=cis_default
-          - dconf_login_banner_text=cis_banners
-          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_default_forwarding_value=disabled
-          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
-          - var_accounts_user_umask=027
-          - var_sshd_set_login_grace_time=60
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -337,6 +337,7 @@ controls:
       levels:
           - low
       rules:
+          - var_postfix_inet_interfaces=loopback-only
           - dconf_gnome_disable_autorun
           - disable_weak_deps
           - file_ownership_var_log_audit_stig
@@ -394,7 +395,6 @@ controls:
           - sshd_disable_forwarding
           - wireless_disable_interfaces
           - xwayland_disabled
-          - var_postfix_inet_interfaces=loopback-only
       status: automated
     - id: cm-7.1
       title: Periodic Review

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/ia.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/ia.yml
@@ -105,9 +105,9 @@ controls:
       levels:
           - low
       rules:
+          - var_account_disable_post_pw_expiration=45
           - account_disable_post_pw_expiration
           - accounts_set_post_pw_existing
-          - var_account_disable_post_pw_expiration=45
       status: automated
     - id: ia-4.1
       title: Prohibit Account Identifiers as Public Identifiers
@@ -152,6 +152,16 @@ controls:
       levels:
           - low
       rules:
+          - var_password_hashing_algorithm_pam=cis_rhel10
+          - var_password_hashing_algorithm=cis_rhel10
+          - var_accounts_minimum_age_login_defs=1
+          - var_password_pam_maxsequence=3
+          - var_password_pam_maxrepeat=3
+          - var_accounts_password_warn_age_login_defs=7
+          - var_password_pam_dictcheck=1
+          - var_password_pam_minclass=4
+          - var_password_pam_minlen=14
+          - var_password_pam_difok=2
           - accounts_minimum_age_login_defs
           - accounts_password_all_shadowed
           - accounts_password_last_change_is_in_past
@@ -174,28 +184,18 @@ controls:
           - set_password_hashing_algorithm_logindefs
           - set_password_hashing_algorithm_passwordauth
           - set_password_hashing_algorithm_systemauth
-          - var_accounts_minimum_age_login_defs=1
-          - var_accounts_password_warn_age_login_defs=7
-          - var_password_hashing_algorithm=cis_rhel10
-          - var_password_hashing_algorithm_pam=cis_rhel10
-          - var_password_pam_dictcheck=1
-          - var_password_pam_difok=2
-          - var_password_pam_maxrepeat=3
-          - var_password_pam_maxsequence=3
-          - var_password_pam_minclass=4
-          - var_password_pam_minlen=14
       status: automated
     - id: ia-5.1
       title: Password-based Authentication
       levels:
           - low
       rules:
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=24
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
           - accounts_password_pam_unix_enabled
           - accounts_password_pam_unix_no_remember
-          - var_password_pam_remember=24
-          - var_password_pam_remember_control_flag=requisite_or_required
       status: automated
     - id: ia-5.2
       title: Public Key-based Authentication
@@ -338,8 +338,8 @@ controls:
       levels:
           - low
       rules:
-          - sudo_require_reauthentication
           - var_sudo_timestamp_timeout=15_minutes
+          - sudo_require_reauthentication
       status: automated
     - id: ia-12
       title: Identity Proofing

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/sc.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/sc.yml
@@ -26,9 +26,9 @@ controls:
       levels:
           - high
       rules:
+          - var_selinux_state=enforcing
           - selinux_not_disabled
           - selinux_state
-          - var_selinux_state=enforcing
       status: automated
     - id: sc-3.1
       title: Hardware Separation
@@ -71,6 +71,7 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv4_tcp_syncookies
       status: automated
     - id: sc-5.1

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/ac.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/ac.yml
@@ -41,12 +41,11 @@ controls:
       levels:
           - moderate
       rules:
+          - var_accounts_tmout=15_min
           - accounts_tmout
           - no_invalid_shell_accounts_unlocked
           - no_password_auth_for_systemaccounts
           - no_shelllogin_for_systemaccounts
-          - inactivity_timeout_value=15_minutes
-          - var_accounts_tmout=15_min
       status: automated
     - id: ac-2.6
       title: Dynamic Privilege Management
@@ -91,6 +90,9 @@ controls:
       levels:
           - low
       rules:
+          - var_pam_wheel_group_for_su=cis
+          - var_accounts_user_umask=027
+          - var_selinux_policy_name=targeted
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs
           - accounts_umask_etc_profile
@@ -224,9 +226,6 @@ controls:
           - sysctl_fs_protected_hardlinks
           - sysctl_fs_protected_symlinks
           - use_pam_wheel_group_for_su
-          - var_accounts_user_umask=027
-          - var_pam_wheel_group_for_su=cis
-          - var_selinux_policy_name=targeted
       status: automated
     - id: ac-3.1
       title: Restricted Access to Privileged Functions
@@ -500,15 +499,14 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_passwords_pam_faillock_unlock_time=900
+          - var_accounts_passwords_pam_faillock_deny=5
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - accounts_passwords_pam_faillock_deny
           - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time_with_zero
-          - var_accounts_passwords_pam_faillock_deny=5
-          - var_accounts_passwords_pam_faillock_dir=run
-          - var_accounts_passwords_pam_faillock_root_unlock_time=60
-          - var_accounts_passwords_pam_faillock_unlock_time=900
       status: automated
     - id: ac-7.1
       title: Automatic Account Lock
@@ -531,6 +529,8 @@ controls:
       levels:
           - low
       rules:
+          - dconf_login_banner_text=cis_banners
+          - dconf_login_banner_contents=cis_default
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
       status: automated
@@ -565,11 +565,12 @@ controls:
       levels:
           - moderate
       rules:
+          - var_screensaver_lock_delay=5_seconds
+          - inactivity_timeout_value=15_minutes
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
           - dconf_gnome_screensaver_user_locks
           - dconf_gnome_session_idle_user_locks
-          - var_screensaver_lock_delay=5_seconds
       status: automated
     - id: ac-11.1
       title: Pattern-hiding Displays

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/au.yml
@@ -11,6 +11,9 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_admin_space_left_action=cis_rhel8
+          - var_auditd_space_left_action=cis_rhel8
+          - var_audit_backlog_limit=8192
           - aide_build_database
           - aide_periodic_cron_checking
           - audit_rules_execution_chacl
@@ -33,9 +36,6 @@ controls:
           - service_systemd-journal-upload_enabled
           - service_systemd-journald_enabled
           - socket_systemd-journal-remote_disabled
-          - var_audit_backlog_limit=8192
-          - var_auditd_admin_space_left_action=cis_rhel8
-          - var_auditd_space_left_action=cis_rhel8
       status: automated
     - id: au-2.1
       title: Compilation of Audit Records from Multiple Sources
@@ -58,6 +58,10 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sshd_max_auth_tries_value=4
+          - var_multiple_time_servers=rhel
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -119,8 +123,6 @@ controls:
           - sudo_custom_logfile
           - sysctl_net_ipv4_conf_all_log_martians
           - sysctl_net_ipv4_conf_default_log_martians
-          - sshd_max_auth_tries_value=4
-          - var_multiple_time_servers=rhel
       status: automated
     - id: au-3.1
       title: Additional Audit Information
@@ -152,10 +154,10 @@ controls:
       levels:
           - low
       rules:
-          - auditd_data_disk_error_action
-          - auditd_data_disk_full_action
           - var_auditd_disk_error_action=cis_rhel8
           - var_auditd_disk_full_action=cis_rhel8
+          - auditd_data_disk_error_action
+          - auditd_data_disk_full_action
       status: automated
     - id: au-5.1
       title: Storage Capacity Warning
@@ -256,10 +258,10 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_max_log_file_action=keep_logs
+          - var_auditd_max_log_file=8
           - auditd_data_retention_max_log_file
           - auditd_data_retention_max_log_file_action
-          - var_auditd_max_log_file=8
-          - var_auditd_max_log_file_action=keep_logs
       status: automated
     - id: au-8.1
       title: Synchronization with Authoritative Time Source
@@ -357,6 +359,8 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_passwords_pam_faillock_dir=run
+          - audit_rules_continue_loading
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -370,7 +374,6 @@ controls:
           - audit_rules_dac_modification_lsetxattr
           - audit_rules_dac_modification_removexattr
           - audit_rules_dac_modification_setxattr
-          - audit_rules_continue_loading
           - audit_rules_execution_chcon
           - audit_rules_file_deletion_events_rename
           - audit_rules_file_deletion_events_renameat

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/cm.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/cm.yml
@@ -5,6 +5,12 @@ controls:
       levels:
           - low
       rules:
+          - sshd_idle_timeout_value=5_minutes
+          - var_sshd_max_sessions=10
+          - var_sshd_set_keepalive=1
+          - var_sshd_set_maxstartups=10:30:60
+          - var_user_initialization_files_regex=all_dotfiles
+          - var_accounts_maximum_age_login_defs=365
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - account_unique_id
@@ -55,6 +61,7 @@ controls:
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           - sysctl_net_ipv4_ip_forward
           - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra
           - sysctl_net_ipv6_conf_all_accept_redirects
           - sysctl_net_ipv6_conf_all_accept_source_route
@@ -62,13 +69,6 @@ controls:
           - sysctl_net_ipv6_conf_default_accept_ra
           - sysctl_net_ipv6_conf_default_accept_redirects
           - sysctl_net_ipv6_conf_default_accept_source_route
-          - sshd_idle_timeout_value=5_minutes
-          - sysctl_net_ipv4_tcp_syncookies_value=enabled
-          - var_accounts_maximum_age_login_defs=365
-          - var_sshd_max_sessions=10
-          - var_sshd_set_keepalive=1
-          - var_sshd_set_maxstartups=10:30:60
-          - var_user_initialization_files_regex=all_dotfiles
       status: automated
     - id: cm-2
       title: Baseline Configuration
@@ -215,6 +215,32 @@ controls:
       levels:
           - low
       rules:
+          - var_sshd_set_login_grace_time=60
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - cis_banner_text=cis
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - var_accounts_user_umask=027
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - var_authselect_profile=sssd
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_forwarding_value=disabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - accounts_password_pam_modules_in_authselect_profile
           - accounts_password_pam_pwquality_password_auth
           - accounts_password_pam_pwquality_system_auth
           - accounts_umask_etc_bashrc
@@ -225,6 +251,7 @@ controls:
           - banner_etc_issue_cis
           - banner_etc_issue_net_cis
           - banner_etc_motd_cis
+          - chronyd_run_as_chrony_user
           - coredump_disable_backtraces
           - coredump_disable_storage
           - dconf_db_up_to_date
@@ -256,6 +283,8 @@ controls:
           - no_empty_passwords_etc_shadow
           - no_files_or_dirs_ungroupowned
           - no_files_or_dirs_unowned_by_user
+          - package_authselect_installed
+          - package_pam_installed
           - package_pam_pwquality_installed
           - package_rsync_removed
           - package_rsyslog_installed
@@ -296,33 +325,6 @@ controls:
           - sysctl_net_ipv6_conf_default_accept_redirects
           - sysctl_net_ipv6_conf_default_accept_source_route
           - sysctl_net_ipv6_conf_default_forwarding
-          - cis_banner_text=cis
-          - dconf_login_banner_contents=cis_default
-          - dconf_login_banner_text=cis_banners
-          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_default_forwarding_value=disabled
-          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
-          - var_accounts_user_umask=027
-          - var_authselect_profile=sssd
-          - var_sshd_set_login_grace_time=60
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -349,6 +351,7 @@ controls:
       levels:
           - low
       rules:
+          - var_postfix_inet_interfaces=loopback-only
           - dconf_gnome_disable_autorun
           - disable_weak_deps
           - file_ownership_var_log_audit_stig
@@ -375,7 +378,6 @@ controls:
           - mount_option_tmp_nodev
           - mount_option_tmp_noexec
           - mount_option_tmp_nosuid
-          - package_authselect_installed
           - package_bind_removed
           - package_cyrus-imapd_removed
           - package_dhcp_removed
@@ -386,7 +388,6 @@ controls:
           - package_net-snmp_removed
           - package_nginx_removed
           - package_openldap-clients_removed
-          - package_pam_installed
           - package_telnet-server_removed
           - package_telnet_removed
           - package_tftp-server_removed
@@ -410,7 +411,6 @@ controls:
           - sshd_disable_forwarding
           - wireless_disable_interfaces
           - xwayland_disabled
-          - var_postfix_inet_interfaces=loopback-only
       status: automated
     - id: cm-7.1
       title: Periodic Review

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/ia.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/ia.yml
@@ -105,9 +105,9 @@ controls:
       levels:
           - low
       rules:
+          - var_account_disable_post_pw_expiration=45
           - account_disable_post_pw_expiration
           - accounts_set_post_pw_existing
-          - var_account_disable_post_pw_expiration=45
       status: automated
     - id: ia-4.1
       title: Prohibit Account Identifiers as Public Identifiers
@@ -152,7 +152,14 @@ controls:
       levels:
           - low
       rules:
-          - accounts_minimum_age_login_defs
+          - var_password_pam_maxrepeat=3
+          - var_password_pam_minlen=14
+          - var_password_hashing_algorithm=cis_rhel8
+          - var_password_hashing_algorithm_pam=cis_rhel8
+          - var_password_pam_maxsequence=3
+          - var_accounts_password_warn_age_login_defs=7
+          - var_password_pam_dictcheck=1
+          - var_password_pam_difok=2
           - accounts_password_all_shadowed
           - accounts_password_last_change_is_in_past
           - accounts_password_pam_dictcheck
@@ -160,13 +167,11 @@ controls:
           - accounts_password_pam_enforce_root
           - accounts_password_pam_maxrepeat
           - accounts_password_pam_maxsequence
-          - accounts_password_pam_minclass
           - accounts_password_pam_minlen
           - accounts_password_pam_modules_in_authselect_profile
           - accounts_password_pam_pwhistory_enforce_for_root
           - accounts_password_pam_pwhistory_use_authtok
           - accounts_password_pam_unix_authtok
-          - accounts_password_set_min_life_existing
           - accounts_password_set_warn_age_existing
           - accounts_password_warn_age_login_defs
           - ensure_root_password_configured
@@ -174,28 +179,18 @@ controls:
           - set_password_hashing_algorithm_logindefs
           - set_password_hashing_algorithm_passwordauth
           - set_password_hashing_algorithm_systemauth
-          - var_accounts_minimum_age_login_defs=1
-          - var_accounts_password_warn_age_login_defs=7
-          - var_password_hashing_algorithm=cis_rhel8
-          - var_password_hashing_algorithm_pam=cis_rhel8
-          - var_password_pam_dictcheck=1
-          - var_password_pam_difok=2
-          - var_password_pam_maxrepeat=3
-          - var_password_pam_maxsequence=3
-          - var_password_pam_minclass=4
-          - var_password_pam_minlen=14
       status: automated
     - id: ia-5.1
       title: Password-based Authentication
       levels:
           - low
       rules:
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=24
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
           - accounts_password_pam_unix_enabled
           - accounts_password_pam_unix_no_remember
-          - var_password_pam_remember=24
-          - var_password_pam_remember_control_flag=requisite_or_required
       status: automated
     - id: ia-5.2
       title: Public Key-based Authentication
@@ -338,8 +333,8 @@ controls:
       levels:
           - low
       rules:
-          - sudo_require_reauthentication
           - var_sudo_timestamp_timeout=15_minutes
+          - sudo_require_reauthentication
       status: automated
     - id: ia-12
       title: Identity Proofing

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/sc.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/sc.yml
@@ -26,9 +26,9 @@ controls:
       levels:
           - high
       rules:
+          - var_selinux_state=enforcing
           - selinux_not_disabled
           - selinux_state
-          - var_selinux_state=enforcing
       status: automated
     - id: sc-3.1
       title: Hardware Separation
@@ -71,6 +71,7 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv4_tcp_syncookies
       status: automated
     - id: sc-5.1

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/ac.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/ac.yml
@@ -41,12 +41,11 @@ controls:
       levels:
           - moderate
       rules:
+          - var_accounts_tmout=15_min
           - accounts_tmout
           - no_invalid_shell_accounts_unlocked
           - no_password_auth_for_systemaccounts
           - no_shelllogin_for_systemaccounts
-          - inactivity_timeout_value=15_minutes
-          - var_accounts_tmout=15_min
       status: automated
     - id: ac-2.6
       title: Dynamic Privilege Management
@@ -91,6 +90,9 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_user_umask=027
+          - var_pam_wheel_group_for_su=cis
+          - var_selinux_policy_name=targeted
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs
           - accounts_umask_etc_profile
@@ -203,6 +205,7 @@ controls:
           - package_libselinux_installed
           - package_mcstrans_removed
           - package_setroubleshoot_removed
+          - rsyslog_filecreatemode
           - rsyslog_files_groupownership
           - rsyslog_files_ownership
           - rsyslog_files_permissions
@@ -210,9 +213,6 @@ controls:
           - selinux_policytype
           - sshd_limit_user_access
           - use_pam_wheel_group_for_su
-          - var_accounts_user_umask=027
-          - var_pam_wheel_group_for_su=cis
-          - var_selinux_policy_name=targeted
       status: automated
     - id: ac-3.1
       title: Restricted Access to Privileged Functions
@@ -486,15 +486,14 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_passwords_pam_faillock_deny=5
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
+          - var_accounts_passwords_pam_faillock_unlock_time=900
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - accounts_passwords_pam_faillock_deny
           - accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time
           - accounts_passwords_pam_faillock_unlock_time
-          - var_accounts_passwords_pam_faillock_deny=5
-          - var_accounts_passwords_pam_faillock_dir=run
-          - var_accounts_passwords_pam_faillock_root_unlock_time=60
-          - var_accounts_passwords_pam_faillock_unlock_time=900
       status: automated
     - id: ac-7.1
       title: Automatic Account Lock
@@ -517,6 +516,8 @@ controls:
       levels:
           - low
       rules:
+          - dconf_login_banner_contents=cis_default
+          - dconf_login_banner_text=cis_banners
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
       status: automated
@@ -551,11 +552,12 @@ controls:
       levels:
           - moderate
       rules:
+          - inactivity_timeout_value=15_minutes
+          - var_screensaver_lock_delay=5_seconds
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
           - dconf_gnome_screensaver_user_locks
           - dconf_gnome_session_idle_user_locks
-          - var_screensaver_lock_delay=5_seconds
       status: automated
     - id: ac-11.1
       title: Pattern-hiding Displays

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/au.yml
@@ -11,6 +11,10 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_action_mail_acct=root
+          - var_auditd_space_left_action=cis_rhel9
+          - var_auditd_admin_space_left_action=cis_rhel9
+          - var_audit_backlog_limit=8192
           - aide_build_database
           - aide_periodic_cron_checking
           - audit_rules_execution_chacl
@@ -30,10 +34,6 @@ controls:
           - service_auditd_enabled
           - service_systemd-journald_enabled
           - socket_systemd-journal-remote_disabled
-          - var_audit_backlog_limit=8192
-          - var_auditd_action_mail_acct=root
-          - var_auditd_admin_space_left_action=cis_rhel9
-          - var_auditd_space_left_action=cis_rhel9
       status: automated
     - id: au-2.1
       title: Compilation of Audit Records from Multiple Sources
@@ -56,6 +56,10 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - var_multiple_time_servers=rhel
+          - sshd_max_auth_tries_value=4
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -119,8 +123,6 @@ controls:
           - sudo_custom_logfile
           - sysctl_net_ipv4_conf_all_log_martians
           - sysctl_net_ipv4_conf_default_log_martians
-          - sshd_max_auth_tries_value=4
-          - var_multiple_time_servers=rhel
       status: automated
     - id: au-3.1
       title: Additional Audit Information
@@ -152,10 +154,10 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_disk_full_action=cis_rhel9
+          - var_auditd_disk_error_action=cis_rhel9
           - auditd_data_disk_error_action
           - auditd_data_disk_full_action
-          - var_auditd_disk_error_action=cis_rhel9
-          - var_auditd_disk_full_action=cis_rhel9
       status: automated
     - id: au-5.1
       title: Storage Capacity Warning
@@ -256,10 +258,10 @@ controls:
       levels:
           - low
       rules:
+          - var_auditd_max_log_file_action=keep_logs
+          - var_auditd_max_log_file=6
           - auditd_data_retention_max_log_file
           - auditd_data_retention_max_log_file_action
-          - var_auditd_max_log_file=6
-          - var_auditd_max_log_file_action=keep_logs
       status: automated
     - id: au-8.1
       title: Synchronization with Authoritative Time Source
@@ -357,6 +359,7 @@ controls:
       levels:
           - low
       rules:
+          - var_accounts_passwords_pam_faillock_dir=run
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/cm.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/cm.yml
@@ -5,6 +5,12 @@ controls:
       levels:
           - low
       rules:
+          - var_sshd_max_sessions=10
+          - var_user_initialization_files_regex=all_dotfiles
+          - var_sshd_set_keepalive=1
+          - var_sshd_set_maxstartups=10:30:60
+          - sshd_idle_timeout_value=5_minutes
+          - var_accounts_maximum_age_login_defs=365
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - account_unique_id
@@ -55,6 +61,7 @@ controls:
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           - sysctl_net_ipv4_ip_forward
           - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra
           - sysctl_net_ipv6_conf_all_accept_redirects
           - sysctl_net_ipv6_conf_all_accept_source_route
@@ -62,13 +69,6 @@ controls:
           - sysctl_net_ipv6_conf_default_accept_ra
           - sysctl_net_ipv6_conf_default_accept_redirects
           - sysctl_net_ipv6_conf_default_accept_source_route
-          - sshd_idle_timeout_value=5_minutes
-          - sysctl_net_ipv4_tcp_syncookies_value=enabled
-          - var_accounts_maximum_age_login_defs=365
-          - var_sshd_max_sessions=10
-          - var_sshd_set_keepalive=1
-          - var_sshd_set_maxstartups=10:30:60
-          - var_user_initialization_files_regex=all_dotfiles
       status: automated
     - id: cm-2
       title: Baseline Configuration
@@ -215,6 +215,30 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - var_sshd_set_login_grace_time=60
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - cis_banner_text=cis
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - var_accounts_user_umask=027
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - var_authselect_profile=sssd
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - accounts_password_pam_modules_in_authselect_profile
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs
           - accounts_umask_etc_profile
@@ -223,6 +247,7 @@ controls:
           - banner_etc_issue_cis
           - banner_etc_issue_net_cis
           - banner_etc_motd_cis
+          - chronyd_run_as_chrony_user
           - coredump_disable_backtraces
           - coredump_disable_storage
           - dconf_db_up_to_date
@@ -279,31 +304,6 @@ controls:
           - sysctl_net_ipv6_conf_default_accept_ra
           - sysctl_net_ipv6_conf_default_accept_redirects
           - sysctl_net_ipv6_conf_default_accept_source_route
-          - cis_banner_text=cis
-          - dconf_login_banner_contents=cis_default
-          - dconf_login_banner_text=cis_banners
-          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-          - var_accounts_user_umask=027
-          - var_authselect_profile=sssd
-          - var_sshd_set_login_grace_time=60
       status: automated
     - id: cm-6.1
       title: Automated Management, Application, and Verification
@@ -330,6 +330,7 @@ controls:
       levels:
           - low
       rules:
+          - var_postfix_inet_interfaces=loopback-only
           - dconf_gnome_disable_autorun
           - file_ownership_var_log_audit_stig
           - gnome_gdm_disable_xdmcp
@@ -381,7 +382,6 @@ controls:
           - service_nftables_disabled
           - sshd_disable_forwarding
           - wireless_disable_interfaces
-          - var_postfix_inet_interfaces=loopback-only
       status: automated
     - id: cm-7.1
       title: Periodic Review

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/ia.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/ia.yml
@@ -105,9 +105,9 @@ controls:
       levels:
           - low
       rules:
+          - var_account_disable_post_pw_expiration=45
           - account_disable_post_pw_expiration
           - accounts_set_post_pw_existing
-          - var_account_disable_post_pw_expiration=45
       status: automated
     - id: ia-4.1
       title: Prohibit Account Identifiers as Public Identifiers
@@ -152,6 +152,16 @@ controls:
       levels:
           - low
       rules:
+          - var_password_pam_minlen=14
+          - var_password_pam_dictcheck=1
+          - var_password_hashing_algorithm_pam=sha512
+          - var_accounts_password_warn_age_login_defs=7
+          - var_password_hashing_algorithm=SHA512
+          - var_password_pam_maxrepeat=3
+          - var_password_pam_maxsequence=3
+          - var_password_pam_minclass=4
+          - var_password_pam_difok=2
+          - var_accounts_minimum_age_login_defs=1
           - accounts_minimum_age_login_defs
           - accounts_password_all_shadowed
           - accounts_password_last_change_is_in_past
@@ -173,27 +183,17 @@ controls:
           - set_password_hashing_algorithm_logindefs
           - set_password_hashing_algorithm_passwordauth
           - set_password_hashing_algorithm_systemauth
-          - var_accounts_minimum_age_login_defs=1
-          - var_accounts_password_warn_age_login_defs=7
-          - var_password_hashing_algorithm=SHA512
-          - var_password_hashing_algorithm_pam=sha512
-          - var_password_pam_dictcheck=1
-          - var_password_pam_difok=2
-          - var_password_pam_maxrepeat=3
-          - var_password_pam_maxsequence=3
-          - var_password_pam_minclass=4
-          - var_password_pam_minlen=14
       status: automated
     - id: ia-5.1
       title: Password-based Authentication
       levels:
           - low
       rules:
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=24
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
           - accounts_password_pam_unix_no_remember
-          - var_password_pam_remember=24
-          - var_password_pam_remember_control_flag=requisite_or_required
       status: automated
     - id: ia-5.2
       title: Public Key-based Authentication
@@ -336,8 +336,8 @@ controls:
       levels:
           - low
       rules:
-          - sudo_require_reauthentication
           - var_sudo_timestamp_timeout=15_minutes
+          - sudo_require_reauthentication
       status: automated
     - id: ia-12
       title: Identity Proofing

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/sc.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/sc.yml
@@ -25,9 +25,9 @@ controls:
       levels:
           - high
       rules:
+          - var_selinux_state=enforcing
           - selinux_not_disabled
           - selinux_state
-          - var_selinux_state=enforcing
       status: automated
     - id: sc-3.1
       title: Hardware Separation
@@ -70,6 +70,7 @@ controls:
       levels:
           - low
       rules:
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv4_tcp_syncookies
       status: automated
     - id: sc-5.1

--- a/utils/nist_sync/data/cis_nist_mappings.json
+++ b/utils/nist_sync/data/cis_nist_mappings.json
@@ -1,5 +1,8 @@
 {
   "rules": {
+    "account_disable_post_pw_expiration": [
+      "ia-4"
+    ],
     "account_password_pam_faillock_password_auth": [
       "ac-7",
       "cm-1"
@@ -27,6 +30,9 @@
     "accounts_password_all_shadowed": [
       "ia-5"
     ],
+    "accounts_password_last_change_is_in_past": [
+      "ia-5"
+    ],
     "accounts_password_pam_dictcheck": [
       "ia-5"
     ],
@@ -46,6 +52,10 @@
       "ia-5"
     ],
     "accounts_password_pam_minlen": [
+      "ia-5"
+    ],
+    "accounts_password_pam_modules_in_authselect_profile": [
+      "cm-6",
       "ia-5"
     ],
     "accounts_password_pam_pwhistory_enforce_for_root": [
@@ -72,17 +82,44 @@
     "accounts_password_pam_unix_enabled": [
       "ia-5.1"
     ],
+    "accounts_password_pam_unix_no_remember": [
+      "ia-5.1"
+    ],
     "accounts_password_set_max_life_existing": [
       "cm-1"
     ],
     "accounts_password_set_min_life_existing": [
       "ia-5"
     ],
+    "accounts_password_set_warn_age_existing": [
+      "ia-5"
+    ],
+    "accounts_password_warn_age_login_defs": [
+      "ia-5"
+    ],
+    "accounts_passwords_pam_faillock_deny": [
+      "ac-7"
+    ],
+    "accounts_passwords_pam_faillock_even_deny_root_or_root_unlock_time": [
+      "ac-7"
+    ],
+    "accounts_passwords_pam_faillock_unlock_time": [
+      "ac-7"
+    ],
+    "accounts_passwords_pam_faillock_unlock_time_with_zero": [
+      "ac-7"
+    ],
     "accounts_root_gid_zero": [
       "cm-1"
     ],
     "accounts_root_path_dirs_no_write": [
       "cm-1"
+    ],
+    "accounts_set_post_pw_existing": [
+      "ia-4"
+    ],
+    "accounts_tmout": [
+      "ac-2.5"
     ],
     "accounts_umask_etc_bashrc": [
       "ac-3",
@@ -111,8 +148,14 @@
     "aide_build_database": [
       "au-2"
     ],
+    "aide_check_audit_tools": [
+      "au-9.3"
+    ],
     "aide_periodic_cron_checking": [
       "au-2"
+    ],
+    "audit_rules_continue_loading": [
+      "au-12"
     ],
     "audit_rules_dac_modification_chmod": [
       "au-12",
@@ -363,6 +406,9 @@
       "au-12",
       "au-3"
     ],
+    "audit_sudo_log_events": [
+      "au-12"
+    ],
     "auditd_data_disk_error_action": [
       "au-2",
       "au-5"
@@ -395,6 +441,10 @@
     "banner_etc_motd_cis": [
       "cm-6"
     ],
+    "chronyd_run_as_chrony_user": [
+      "au-3",
+      "cm-6"
+    ],
     "chronyd_specify_remote_server": [
       "au-3"
     ],
@@ -410,6 +460,9 @@
       "cm-6"
     ],
     "coredump_disable_storage": [
+      "cm-6"
+    ],
+    "dconf_db_up_to_date": [
       "cm-6"
     ],
     "dconf_gnome_banner_enabled": [
@@ -465,17 +518,29 @@
     "disable_users_coredumps": [
       "cm-6"
     ],
+    "disable_weak_deps": [
+      "cm-7"
+    ],
+    "enable_authselect": [
+      "cm-6"
+    ],
     "ensure_gpgcheck_globally_activated": [
       "si-2"
     ],
     "ensure_gpgcheck_never_disabled": [
       "si-2"
     ],
+    "ensure_journald_and_rsyslog_not_active_together": [
+      "au-2"
+    ],
     "ensure_pam_wheel_group_empty": [
       "ac-3"
     ],
     "ensure_redhat_gpgkey_installed": [
       "si-2"
+    ],
+    "ensure_root_password_configured": [
+      "ia-5"
     ],
     "file_at_allow_exists": [
       "ac-3"
@@ -491,6 +556,9 @@
     ],
     "file_etc_security_opasswd": [
       "ac-3"
+    ],
+    "file_group_ownership_var_log_audit": [
+      "au-9.4"
     ],
     "file_groupowner_at_allow": [
       "ac-3"
@@ -589,6 +657,9 @@
     ],
     "file_groupownership_audit_binaries": [
       "au-3"
+    ],
+    "file_groupownership_audit_configuration": [
+      "au-9"
     ],
     "file_groupownership_sshd_private_key": [
       "ac-3",
@@ -692,6 +763,12 @@
     "file_owner_user_cfg": [
       "ac-3",
       "cm-6"
+    ],
+    "file_ownership_audit_binaries": [
+      "au-9"
+    ],
+    "file_ownership_audit_configuration": [
+      "au-9"
     ],
     "file_ownership_home_directories": [
       "cm-6"
@@ -833,6 +910,9 @@
       "ac-3",
       "cm-6"
     ],
+    "file_permissions_var_log_audit": [
+      "au-9.4"
+    ],
     "firewalld-backend": [
       "ca-9"
     ],
@@ -844,6 +924,9 @@
     ],
     "gid_passwd_group_same": [
       "cm-1"
+    ],
+    "gnome_gdm_disable_xdmcp": [
+      "cm-7"
     ],
     "group_unique_id": [
       "cm-1"
@@ -1048,6 +1131,9 @@
     "package_audit_installed": [
       "au-2"
     ],
+    "package_authselect_installed": [
+      "cm-6"
+    ],
     "package_bind_removed": [
       "cm-7"
     ],
@@ -1070,6 +1156,9 @@
       "ca-9"
     ],
     "package_ftp_removed": [
+      "cm-7"
+    ],
+    "package_gdm_removed": [
       "cm-7"
     ],
     "package_httpd_removed": [
@@ -1096,8 +1185,14 @@
     "package_openldap-clients_removed": [
       "cm-7"
     ],
+    "package_pam_installed": [
+      "cm-6"
+    ],
     "package_pam_pwquality_installed": [
       "cm-6"
+    ],
+    "package_postfix_installed": [
+      "cm-7"
     ],
     "package_rsync_removed": [
       "cm-6"
@@ -1107,6 +1202,9 @@
     ],
     "package_samba_removed": [
       "cm-6"
+    ],
+    "package_sequoia-sq_installed": [
+      "cm-7"
     ],
     "package_setroubleshoot_removed": [
       "ac-3"
@@ -1232,8 +1330,14 @@
     "service_dnsmasq_disabled": [
       "cm-7"
     ],
+    "service_firewalld_enabled": [
+      "sc-7"
+    ],
     "service_nfs_disabled": [
       "cm-6"
+    ],
+    "service_nftables_disabled": [
+      "cm-7"
     ],
     "service_rpcbind_disabled": [
       "cm-6"
@@ -1332,6 +1436,9 @@
     ],
     "sysctl_fs_protected_symlinks": [
       "ac-3"
+    ],
+    "sysctl_fs_suid_dumpable": [
+      "cm-6"
     ],
     "sysctl_kernel_dmesg_restrict": [
       "sc-2"
@@ -1454,6 +1561,9 @@
       "ac-18",
       "cm-7"
     ],
+    "xwayland_disabled": [
+      "cm-7"
+    ],
     "xwindows_runlevel_target": [
       "cm-11"
     ]
@@ -1563,15 +1673,33 @@
     "sysctl_net_ipv6_conf_default_forwarding_value=disabled": [
       "cm-6"
     ],
+    "var_account_disable_post_pw_expiration=45": [
+      "ia-4"
+    ],
     "var_accounts_maximum_age_login_defs=365": [
       "cm-1"
     ],
     "var_accounts_minimum_age_login_defs=1": [
       "ia-5"
     ],
+    "var_accounts_password_warn_age_login_defs=7": [
+      "ia-5"
+    ],
+    "var_accounts_passwords_pam_faillock_deny=5": [
+      "ac-7"
+    ],
     "var_accounts_passwords_pam_faillock_dir=run": [
       "au-12",
       "au-3"
+    ],
+    "var_accounts_passwords_pam_faillock_root_unlock_time=60": [
+      "ac-7"
+    ],
+    "var_accounts_passwords_pam_faillock_unlock_time=900": [
+      "ac-7"
+    ],
+    "var_accounts_tmout=15_min": [
+      "ac-2.5"
     ],
     "var_accounts_user_umask=027": [
       "ac-3",
@@ -1627,6 +1755,9 @@
     ],
     "var_auditd_space_left_action=cis_rhel9": [
       "au-2"
+    ],
+    "var_authselect_profile=sssd": [
+      "cm-6"
     ],
     "var_multiple_time_servers=rhel": [
       "au-3"

--- a/utils/nist_sync/sync_nist_split.py
+++ b/utils/nist_sync/sync_nist_split.py
@@ -466,12 +466,17 @@ class NISTSplitSync:
                 # Filter rules: only include if in target product's CIS control file
                 filtered_rules = [r for r in mapped_rules if r in all_cis_items]
 
-                # Filter variables: only include the specific assignment for target product
+                # Filter variables: only include the specific assignment for target product.
+                # mapped_vars may contain full assignments as keys (e.g. 'var_x=value')
+                # because cis_nist_mappings.json uses full assignments in the variables
+                # section.  all_cis_items_with_values is keyed by the stripped name
+                # ('var_x'), so we must strip before looking up.
                 filtered_vars = []
                 for var_name in mapped_vars:
-                    if var_name in all_cis_items_with_values:
-                        # Get all assignments for this variable
-                        assignments = all_cis_items_with_values[var_name]
+                    stripped_name = var_name.split('=')[0] if '=' in var_name else var_name
+                    if stripped_name in all_cis_items_with_values:
+                        # Get all assignments for this variable in the target product
+                        assignments = all_cis_items_with_values[stripped_name]
                         # Add all assignments (should only be one per product)
                         filtered_vars.extend(sorted(assignments))
 
@@ -506,8 +511,11 @@ class NISTSplitSync:
             family = self.extract_family(ctrl_id)
             controls_by_family[family].append(control_entry)
 
-        # Add unmapped CIS items (items in CIS control files but not in mapping file)
-        unmapped_item_names = all_cis_items - mapped_items
+        # Add unmapped CIS items (items in CIS control files but not in mapping file).
+        # all_cis_items uses stripped names ('var_x') while mapped_items may contain
+        # full assignments ('var_x=value') for variables.  Normalise both sides.
+        mapped_names = set(item.split('=')[0] if '=' in item else item for item in mapped_items)
+        unmapped_item_names = all_cis_items - mapped_names
 
         # Build list of unmapped items WITH their values (for variables)
         unmapped_items_full = []


### PR DESCRIPTION
#### Description:

- nist_800_53: fix sync script variable lookup and complete CIS→NIST mappings
  - Fix two bugs in sync_nist_split.py that caused mapped variables to land in other.yml instead of their NIST family files, and add 42 missing CIS→NIST rule/variable mappings so all reference files are fully populated with no other.yml remaining.

#### Rationale:

- Prevents PRs such as https://github.com/ComplianceAsCode/content/pull/14748 and https://github.com/ComplianceAsCode/content/pull/14784 from spawning without actual changes to the CIS profiles.

- There shouldn't be any substantial change to the profiles itself, it's only a matter of updating the reference files.
