### PR TITLE
Add component integration and viewer improvements to NIST viewer

### DIFF
--- a/utils/nist_sync/README.md
+++ b/utils/nist_sync/README.md
@@ -91,6 +91,16 @@ Each control file contains:
 - **`generate_nist_based_cis_profile.py`** - Generate CIS-NIST profiles
 - **`test_workflow_local.sh`** - Local testing script
 
+## Component Integration
+
+NIST controls reference rules, and those rules are mapped to software components in `components/*.yml`. The **control → rule → component** chain is exposed in the NIST viewer:
+
+- **`components.html`** — Grid of all components with control counts and drill-down detail grouped by family
+- **`control-detail.html`** — "Related Components" section on each control's page
+- **`statistics.html`** — "Component Coverage" table
+
+See `docs/manual/developer/15_components_and_controls.md` for documentation including the Python API for querying component relationships programmatically.
+
 ### Deprecated Scripts (Removed)
 
 - ~~`generate_product_family_guards.py`~~ - No longer needed (product-specific files instead of guards)

--- a/utils/nist_sync/generate_nist_viewer.py
+++ b/utils/nist_sync/generate_nist_viewer.py
@@ -10,14 +10,21 @@ This script:
 """
 
 import json
+import re
 import yaml
 import argparse
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 import sys
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+try:
+    import ssg.components
+    _HAS_SSG_COMPONENTS = True
+except ImportError:
+    _HAS_SSG_COMPONENTS = False
 
 try:
     from ruamel.yaml import YAML
@@ -108,27 +115,97 @@ def load_product_controls(product: str, repo_root: Path) -> Dict[str, Any]:
     }
 
 
+def _build_params_map(oscal_data: Dict[str, Any]) -> Dict[str, str]:
+    """Build {param_id: label} from OSCAL params list."""
+    params = {}
+    for param in oscal_data.get('parameters', []):
+        pid = param.get('id', '')
+        label = param.get('label', pid)
+        if pid:
+            params[pid] = label
+    return params
+
+
+def _process_prose(prose: str, params_map: Dict[str, str]) -> str:
+    """Process OSCAL prose: resolve param refs and convert cross-control links.
+
+    - {{ insert: param, param_id }} -> <span class="odp" title="param_id">[label]</span>
+    - [text](#anchor) markdown links -> internal viewer links
+    """
+    if not prose:
+        return ''
+
+    def replace_param(m):
+        param_id = m.group(1).strip()
+        label = params_map.get(param_id, param_id)
+        return f'<span class="odp" title="{param_id}">[{label}]</span>'
+
+    prose = re.sub(r'\{\{\s*insert:\s*param,\s*([^}]+?)\s*\}\}', replace_param, prose)
+
+    def replace_link(m):
+        text = m.group(1)
+        anchor = m.group(2)
+        # Anchor examples: #ac-2.4  #ac-2_smt.a  #cm-6_gp  -> extract ctrl ID
+        ctrl_id = re.split(r'[_#]', anchor.lstrip('#'))[0]
+        return f'<a href="control-detail.html?id={ctrl_id}" class="ctrl-ref">{text}</a>'
+
+    prose = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', replace_link, prose)
+    return prose
+
+
+def _extract_statement(parts: List[Dict], params_map: Dict[str, str]) -> Dict[str, Any]:
+    """Extract control statement as structured {prose, items:[{prose, items:[...]}]}."""
+    for part in parts:
+        if part.get('name') != 'statement':
+            continue
+        top_prose = _process_prose(part.get('prose', ''), params_map)
+
+        def extract_items(container):
+            result = []
+            for sub in container.get('parts', []):
+                if sub.get('name') == 'item':
+                    result.append({
+                        'prose': _process_prose(sub.get('prose', ''), params_map),
+                        'items': extract_items(sub),
+                    })
+            return result
+
+        return {'prose': top_prose, 'items': extract_items(part)}
+    return {}
+
+
+def _extract_guidance(parts: List[Dict], params_map: Dict[str, str]) -> List[str]:
+    """Extract guidance prose as a list of paragraphs."""
+    for part in parts:
+        if part.get('name') == 'guidance':
+            prose = _process_prose(part.get('prose', ''), params_map)
+            return [p.strip() for p in prose.split('\n\n') if p.strip()]
+    return []
+
+
+def _build_params_display(oscal_data: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Return list of {id, label} for display in the Parameters section."""
+    result = []
+    for param in oscal_data.get('parameters', []):
+        pid = param.get('id', '')
+        label = param.get('label', '')
+        if pid:
+            result.append({'id': pid, 'label': label})
+    return result
+
+
 def merge_control_data(product_controls: Dict[str, Any], oscal_controls: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Merge product control data with OSCAL metadata."""
     merged = []
 
     for control in product_controls.get('controls', []):
         ctrl_id = control.get('id', '').lower()
-
-        # Get OSCAL metadata
         oscal_data = oscal_controls.get(ctrl_id, {})
 
-        # Extract description from OSCAL parts
-        description = ""
-        guidance = ""
-        if oscal_data.get('parts'):
-            for part in oscal_data['parts']:
-                if part.get('name') == 'statement':
-                    description = part.get('prose', '')
-                elif part.get('name') == 'guidance':
-                    guidance = part.get('prose', '')
+        params_map = _build_params_map(oscal_data)
+        oscal_parts = oscal_data.get('parts', [])
 
-        # Extract related controls from OSCAL
+        # Extract related controls from OSCAL properties
         related_controls = []
         for prop in oscal_data.get('properties', []):
             if prop.get('name') == 'related':
@@ -141,14 +218,14 @@ def merge_control_data(product_controls: Dict[str, Any], oscal_controls: Dict[st
             'rules': control.get('rules', []),
             'status': control.get('status', 'pending'),
             'notes': control.get('notes', ''),
-            # OSCAL metadata
-            'description': description,
-            'guidance': guidance,
-            'parameters': oscal_data.get('parameters', []),
+            # OSCAL metadata — structured for rich rendering
+            'statement': _extract_statement(oscal_parts, params_map),
+            'guidance': _extract_guidance(oscal_parts, params_map),
+            'parameters': _build_params_display(oscal_data),
             'related_controls': related_controls,
             'class': oscal_data.get('class', ''),
             'parent': oscal_data.get('parent', ''),
-            # Gap analysis
+            # Gap analysis flags
             'has_rules': len(control.get('rules', [])) > 0,
             'is_automated': control.get('status') == 'automated',
             'is_manual': control.get('status') == 'manual',
@@ -163,6 +240,86 @@ def merge_control_data(product_controls: Dict[str, Any], oscal_controls: Dict[st
     return merged
 
 
+GITHUB_BASE = "https://github.com/ComplianceAsCode/content/tree/master"
+
+
+def _build_rule_url_map(repo_root: Path) -> Dict[str, str]:
+    """Walk the repo and build {rule_id: github_url} by finding rule.yml files."""
+    rule_map: Dict[str, str] = {}
+    for search_root in [repo_root / 'linux_os', repo_root / 'applications']:
+        if not search_root.exists():
+            continue
+        for rule_yml in search_root.rglob('rule.yml'):
+            rule_dir = rule_yml.parent
+            rule_id = rule_dir.name
+            rel = rule_dir.relative_to(repo_root)
+            rule_map[rule_id] = f"{GITHUB_BASE}/{rel}/rule.yml"
+    return rule_map
+
+
+def _load_components_data(repo_root: Path):
+    """Load component definitions and return (components_dict, rule_to_components_mapping).
+
+    Returns (None, {}) if ssg.components is unavailable or the directory is missing.
+    """
+    if not _HAS_SSG_COMPONENTS:
+        print("Warning: ssg.components not available; component data will be omitted from viewer.")
+        return None, {}
+    components_dir = repo_root / 'components'
+    if not components_dir.exists():
+        print(f"Warning: Components directory not found: {components_dir}")
+        return None, {}
+    print("Loading components...")
+    components = ssg.components.load(str(components_dir))
+    rule_to_components = ssg.components.rule_component_mapping(components)
+    return components, rule_to_components
+
+
+def _enrich_controls_with_components(
+    merged: List[Dict[str, Any]],
+    rule_to_components: Dict[str, List[str]],
+) -> None:
+    """Add 'components' and 'component_count' fields to each merged control (in-place)."""
+    for control in merged:
+        comp_map: Dict[str, List[str]] = {}
+        for rule_id in control.get('rules', []):
+            if '=' in str(rule_id):
+                continue
+            for comp in rule_to_components.get(rule_id, []):
+                comp_map.setdefault(comp, []).append(rule_id)
+        control['components'] = comp_map
+        control['component_count'] = len(comp_map)
+
+
+def _build_component_stats(
+    products_data: Dict[str, Any],
+    components_dict,
+) -> Dict[str, Any]:
+    """Build per-product component summary statistics."""
+    component_stats: Dict[str, Any] = {}
+    for product, data in products_data.items():
+        comp_summary: Dict[str, Any] = {}
+        for control in data['controls']:
+            ctrl_id = control['id']
+            for comp_name, rules in control.get('components', {}).items():
+                if comp_name not in comp_summary:
+                    packages = []
+                    if components_dict and comp_name in components_dict:
+                        packages = list(components_dict[comp_name].packages)
+                    comp_summary[comp_name] = {
+                        'name': comp_name,
+                        'control_count': 0,
+                        'rule_count': 0,
+                        'controls': [],
+                        'packages': packages,
+                    }
+                comp_summary[comp_name]['control_count'] += 1
+                comp_summary[comp_name]['rule_count'] += len(rules)
+                comp_summary[comp_name]['controls'].append(ctrl_id)
+        component_stats[product] = comp_summary
+    return component_stats
+
+
 def generate_viewer_data(products: List[str], repo_root: Path) -> Dict[str, Any]:
     """Generate complete data structure for the viewer."""
     data_dir = repo_root / 'utils' / 'nist_sync' / 'data'
@@ -170,6 +327,13 @@ def generate_viewer_data(products: List[str], repo_root: Path) -> Dict[str, Any]
     # Load OSCAL catalog
     print("Loading OSCAL catalog...")
     oscal_controls = load_oscal_catalog(data_dir)
+
+    # Load component definitions (centralized, shared across products)
+    components_dict, rule_to_components = _load_components_data(repo_root)
+
+    # Build rule → GitHub URL map
+    print("Indexing rule paths...")
+    rule_url_map = _build_rule_url_map(repo_root)
 
     # Load controls for each product
     products_data = {}
@@ -179,6 +343,15 @@ def generate_viewer_data(products: List[str], repo_root: Path) -> Dict[str, Any]
 
         if product_controls:
             merged = merge_control_data(product_controls, oscal_controls)
+            # Enrich each control with component information
+            _enrich_controls_with_components(merged, rule_to_components)
+            # Attach GitHub URL to each rule entry
+            for control in merged:
+                control['rule_urls'] = {
+                    r: rule_url_map[r]
+                    for r in control.get('rules', [])
+                    if '=' not in str(r) and r in rule_url_map
+                }
             products_data[product] = {
                 'metadata': product_controls.get('metadata', {}),
                 'controls': merged
@@ -200,9 +373,13 @@ def generate_viewer_data(products: List[str], repo_root: Path) -> Dict[str, Any]
             'without_rules': sum(1 for c in controls if not c['has_rules']),
         }
 
+    # Build component statistics per product
+    component_stats = _build_component_stats(products_data, components_dict)
+
     return {
         'products': products_data,
         'statistics': stats,
+        'component_stats': component_stats,
         'families': [
             {'id': 'ac', 'name': 'Access Control'},
             {'id': 'at', 'name': 'Awareness and Training'},
@@ -243,7 +420,8 @@ def generate_html_viewer(output_dir: Path, templates_dir: Path, viewer_data: Dic
         'control-detail.html',
         'gaps.html',
         'statistics.html',
-        'family.html'
+        'family.html',
+        'components.html',
     ]
 
     # Generate pages for each product in separate subdirectories
@@ -255,6 +433,7 @@ def generate_html_viewer(output_dir: Path, templates_dir: Path, viewer_data: Dic
         product_data = {
             'products': {product: viewer_data['products'][product]},
             'statistics': {product: viewer_data['statistics'][product]},
+            'component_stats': {product: viewer_data['component_stats'].get(product, {})},
             'families': viewer_data['families']
         }
 

--- a/utils/nist_sync/generate_nist_viewer.py
+++ b/utils/nist_sync/generate_nist_viewer.py
@@ -14,7 +14,7 @@ import re
 import yaml
 import argparse
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Tuple
 import sys
 
 # Add parent directory to path for imports
@@ -135,14 +135,14 @@ def _process_prose(prose: str, params_map: Dict[str, str]) -> str:
     if not prose:
         return ''
 
-    def replace_param(m):
+    def replace_param(m: re.Match) -> str:
         param_id = m.group(1).strip()
         label = params_map.get(param_id, param_id)
         return f'<span class="odp" title="{param_id}">[{label}]</span>'
 
     prose = re.sub(r'\{\{\s*insert:\s*param,\s*([^}]+?)\s*\}\}', replace_param, prose)
 
-    def replace_link(m):
+    def replace_link(m: re.Match) -> str:
         text = m.group(1)
         anchor = m.group(2)
         # Anchor examples: #ac-2.4  #ac-2_smt.a  #cm-6_gp  -> extract ctrl ID
@@ -257,7 +257,7 @@ def _build_rule_url_map(repo_root: Path) -> Dict[str, str]:
     return rule_map
 
 
-def _load_components_data(repo_root: Path):
+def _load_components_data(repo_root: Path) -> Tuple[Any, Dict[str, List[str]]]:
     """Load component definitions and return (components_dict, rule_to_components_mapping).
 
     Returns (None, {}) if ssg.components is unavailable or the directory is missing.

--- a/utils/nist_sync/templates/_shared_header.html
+++ b/utils/nist_sync/templates/_shared_header.html
@@ -12,6 +12,7 @@
         <li><a href="gaps.html" id="nav-gaps">Gaps</a></li>
         <li><a href="statistics.html" id="nav-statistics">Statistics</a></li>
         <li><a href="family.html" id="nav-families">Families</a></li>
+        <li><a href="components.html" id="nav-components">Components</a></li>
     </ul>
 </nav>
 
@@ -24,7 +25,8 @@ document.addEventListener('DOMContentLoaded', function() {
         'controls.html': 'nav-controls',
         'gaps.html': 'nav-gaps',
         'statistics.html': 'nav-statistics',
-        'family.html': 'nav-families'
+        'family.html': 'nav-families',
+        'components.html': 'nav-components'
     };
 
     const activeNav = document.getElementById(navLinks[currentPage]);

--- a/utils/nist_sync/templates/components.html
+++ b/utils/nist_sync/templates/components.html
@@ -361,6 +361,18 @@
             });
         }
 
+        window.addEventListener('popstate', function() {
+            const compParam = getQueryParam('component');
+            if (compParam) {
+                document.getElementById('grid-view').style.display = 'none';
+                document.getElementById('detail-view').style.display = 'block';
+                renderComponentDetail(compParam);
+            } else {
+                document.getElementById('grid-view').style.display = 'block';
+                document.getElementById('detail-view').style.display = 'none';
+            }
+        });
+
         document.addEventListener('DOMContentLoaded', initComponents);
     </script>
 </body>

--- a/utils/nist_sync/templates/components.html
+++ b/utils/nist_sync/templates/components.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NIST 800-53 Control Viewer - Components</title>
+    <!-- SHARED_STYLES_PLACEHOLDER -->
+    <style>
+        .component-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 15px;
+            margin-top: 20px;
+        }
+
+        .component-card {
+            background: #fff;
+            border: 1px solid #e1e4e8;
+            border-left: 4px solid #6f42c1;
+            border-radius: 6px;
+            padding: 15px;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .component-card:hover {
+            box-shadow: 0 2px 8px rgba(111, 66, 193, 0.15);
+            border-color: #6f42c1;
+        }
+
+        .component-card-name {
+            font-size: 16px;
+            font-weight: 600;
+            color: #6f42c1;
+            margin-bottom: 8px;
+        }
+
+        .component-card-meta {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            font-size: 12px;
+            color: #586069;
+            margin-bottom: 8px;
+        }
+
+        .component-card-packages {
+            font-size: 11px;
+            color: #586069;
+            font-family: monospace;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .detail-view {
+            display: none;
+        }
+
+        .detail-header {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            margin-bottom: 20px;
+        }
+
+        .detail-back-btn {
+            color: #6f42c1;
+            text-decoration: none;
+            font-size: 14px;
+            cursor: pointer;
+            background: none;
+            border: none;
+            padding: 0;
+        }
+
+        .detail-back-btn:hover {
+            text-decoration: underline;
+        }
+
+        .controls-by-family {
+            margin-top: 20px;
+        }
+
+        .family-group {
+            margin-bottom: 25px;
+        }
+
+        .family-group-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: #24292e;
+            border-bottom: 2px solid #e1e4e8;
+            padding-bottom: 8px;
+            margin-bottom: 12px;
+        }
+
+        .control-entry {
+            background: #f6f8fa;
+            border-left: 3px solid #0366d6;
+            padding: 10px 15px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+        }
+
+        .control-entry-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 6px;
+        }
+
+        .control-entry-id {
+            font-weight: 600;
+            color: #0366d6;
+            font-size: 14px;
+        }
+
+        .control-entry-title {
+            color: #586069;
+            font-size: 13px;
+        }
+
+        .control-entry-rules {
+            font-size: 11px;
+            color: #586069;
+            line-height: 1.8;
+        }
+
+        .rule-code {
+            display: inline-block;
+            background: #e1e4e8;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: monospace;
+            font-size: 11px;
+            margin: 2px;
+        }
+
+        .search-bar {
+            width: 100%;
+            max-width: 400px;
+            padding: 8px 12px;
+            border: 1px solid #e1e4e8;
+            border-radius: 4px;
+            font-size: 14px;
+            margin-bottom: 20px;
+        }
+
+        .package-badge {
+            display: inline-block;
+            background: #f1e8ff;
+            color: #6f42c1;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-family: monospace;
+            margin: 2px;
+        }
+    </style>
+</head>
+<body>
+    <!-- SHARED_HEADER_PLACEHOLDER -->
+
+    <div class="container">
+        <!-- Grid View -->
+        <div id="grid-view">
+            <div class="page-header">
+                <h2>Components</h2>
+                <p>Software components and their NIST 800-53 control relationships</p>
+            </div>
+
+            <input type="text" id="component-search" class="search-bar" placeholder="Search components...">
+
+            <div id="component-grid" class="component-grid">
+                <!-- Populated by JavaScript -->
+            </div>
+        </div>
+
+        <!-- Detail View -->
+        <div id="detail-view" class="detail-view">
+            <div class="detail-header">
+                <button class="detail-back-btn" onclick="showGridView()">← Back to Components</button>
+            </div>
+            <div id="detail-content">
+                <!-- Populated by JavaScript -->
+            </div>
+        </div>
+    </div>
+
+    <script>
+        /* DATA_PLACEHOLDER */
+
+        function getQueryParam(param) {
+            return new URLSearchParams(window.location.search).get(param);
+        }
+
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function showGridView() {
+            document.getElementById('grid-view').style.display = 'block';
+            document.getElementById('detail-view').style.display = 'none';
+            history.pushState({}, '', 'components.html');
+        }
+
+        function showDetailView(compName) {
+            document.getElementById('grid-view').style.display = 'none';
+            document.getElementById('detail-view').style.display = 'block';
+            history.pushState({}, '', `components.html?component=${compName}`);
+            renderComponentDetail(compName);
+        }
+
+        function getFamilyName(familyId) {
+            const family = EMBEDDED_DATA.families.find(f => f.id === familyId);
+            return family ? family.name : familyId.toUpperCase();
+        }
+
+        function renderComponentGrid(filter) {
+            const compStats = (EMBEDDED_DATA.component_stats || {})[CURRENT_PRODUCT] || {};
+            const grid = document.getElementById('component-grid');
+            const entries = Object.entries(compStats)
+                .filter(([name]) => !filter || name.toLowerCase().includes(filter.toLowerCase()))
+                .sort((a, b) => b[1].control_count - a[1].control_count);
+
+            if (entries.length === 0) {
+                grid.innerHTML = '<div class="empty-state"><h3>No components found</h3></div>';
+                return;
+            }
+
+            grid.innerHTML = entries.map(([compName, data]) => {
+                const pkgPreview = (data.packages || []).slice(0, 3).join(', ');
+                const morePkgs = (data.packages || []).length > 3 ?
+                    ` +${(data.packages || []).length - 3} more` : '';
+                return `
+                    <div class="component-card" onclick="showDetailView('${compName}')">
+                        <div class="component-card-name">${compName}</div>
+                        <div class="component-card-meta">
+                            <span>📋 ${data.control_count} controls</span>
+                            <span>📦 ${data.rule_count} rule refs</span>
+                        </div>
+                        <div class="component-card-packages">${pkgPreview}${morePkgs}</div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        function renderComponentDetail(compName) {
+            const compStats = (EMBEDDED_DATA.component_stats || {})[CURRENT_PRODUCT] || {};
+            const data = compStats[compName];
+            const controls = EMBEDDED_DATA.products[CURRENT_PRODUCT]?.controls || [];
+
+            if (!data) {
+                const el = document.getElementById('detail-content');
+                const div = document.createElement('div');
+                div.className = 'empty-state';
+                const h3 = document.createElement('h3');
+                h3.textContent = `Component '${compName}' not found`;
+                div.appendChild(h3);
+                el.replaceChildren(div);
+                return;
+            }
+
+            // Gather control data for this component
+            const controlsForComp = controls.filter(c => c.components && c.components[compName]);
+
+            // Group by family
+            const byFamily = {};
+            controlsForComp.forEach(c => {
+                const familyId = c.id.split('-')[0];
+                byFamily[familyId] = byFamily[familyId] || [];
+                byFamily[familyId].push(c);
+            });
+
+            const packagesHtml = (data.packages || [])
+                .map(p => `<span class="package-badge">${p}</span>`)
+                .join('');
+
+            let html = `
+                <div class="page-header">
+                    <h2>${escapeHtml(compName)}</h2>
+                    <p>Software component — NIST 800-53 control relationships</p>
+                </div>
+
+                <div class="card" style="margin-bottom: 20px;">
+                    <h3>Overview</h3>
+                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); gap: 15px; margin-bottom: 15px;">
+                        <div style="background: #f6f8fa; padding: 12px; border-radius: 4px;">
+                            <div style="font-size: 12px; font-weight: 600; color: #586069; text-transform: uppercase; margin-bottom: 5px;">Controls</div>
+                            <div style="font-size: 24px; font-weight: 700; color: #6f42c1;">${data.control_count}</div>
+                        </div>
+                        <div style="background: #f6f8fa; padding: 12px; border-radius: 4px;">
+                            <div style="font-size: 12px; font-weight: 600; color: #586069; text-transform: uppercase; margin-bottom: 5px;">Rule References</div>
+                            <div style="font-size: 24px; font-weight: 700; color: #6f42c1;">${data.rule_count}</div>
+                        </div>
+                        <div style="background: #f6f8fa; padding: 12px; border-radius: 4px;">
+                            <div style="font-size: 12px; font-weight: 600; color: #586069; text-transform: uppercase; margin-bottom: 5px;">Families</div>
+                            <div style="font-size: 24px; font-weight: 700; color: #6f42c1;">${Object.keys(byFamily).length}</div>
+                        </div>
+                    </div>
+                    <div>
+                        <div style="font-size: 12px; font-weight: 600; color: #586069; text-transform: uppercase; margin-bottom: 8px;">Packages</div>
+                        <div>${packagesHtml || '<span style="color: #586069;">none</span>'}</div>
+                    </div>
+                </div>
+
+                <div class="card controls-by-family">
+                    <h3>Controls by Family</h3>
+            `;
+
+            Object.entries(byFamily)
+                .sort((a, b) => b[1].length - a[1].length)
+                .forEach(([familyId, familyControls]) => {
+                    html += `
+                        <div class="family-group">
+                            <div class="family-group-title">${getFamilyName(familyId)} (${familyControls.length})</div>
+                    `;
+                    familyControls.forEach(c => {
+                        const rules = c.components[compName] || [];
+                        html += `
+                            <div class="control-entry">
+                                <div class="control-entry-header">
+                                    <a href="control-detail.html?id=${c.id}" class="control-entry-id">${c.id.toUpperCase()}</a>
+                                    <span class="control-entry-title">${c.title}</span>
+                                    <span class="badge" style="background:#6f42c1;color:white;margin-left:auto;">${rules.length} rules</span>
+                                </div>
+                                <div class="control-entry-rules">
+                                    ${rules.map(r => {
+                                        const url = (c.rule_urls || {})[r];
+                                        return url
+                                            ? `<a href="${url}" target="_blank" rel="noopener" class="rule-code" style="text-decoration:none;">${r} ↗</a>`
+                                            : `<code class="rule-code">${r}</code>`;
+                                    }).join('')}
+                                </div>
+                            </div>
+                        `;
+                    });
+                    html += '</div>';
+                });
+
+            html += '</div>';
+            document.getElementById('detail-content').innerHTML = html;
+        }
+
+        function initComponents() {
+            const compParam = getQueryParam('component');
+            if (compParam) {
+                showDetailView(compParam);
+            } else {
+                renderComponentGrid('');
+            }
+
+            document.getElementById('component-search').addEventListener('input', function() {
+                renderComponentGrid(this.value);
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', initComponents);
+    </script>
+</body>
+</html>

--- a/utils/nist_sync/templates/control-detail.html
+++ b/utils/nist_sync/templates/control-detail.html
@@ -178,6 +178,128 @@
         .breadcrumb a:hover {
             text-decoration: underline;
         }
+
+        /* Statement / description */
+        .statement-intro {
+            margin-bottom: 10px;
+            color: #24292e;
+            line-height: 1.6;
+        }
+
+        .statement-list {
+            padding-left: 22px;
+            margin: 0;
+        }
+
+        .statement-list li {
+            padding: 5px 0;
+            line-height: 1.65;
+            color: #24292e;
+        }
+
+        .statement-list li + li {
+            border-top: 1px solid #f0f0f0;
+        }
+
+        .statement-list ol {
+            padding-left: 22px;
+            margin-top: 6px;
+        }
+
+        /* Guidance paragraphs */
+        .guidance-text p {
+            margin: 0 0 14px 0;
+            line-height: 1.7;
+            color: #24292e;
+        }
+
+        .guidance-text p:last-child {
+            margin-bottom: 0;
+        }
+
+        /* ODP — Organization-Defined Parameter placeholders */
+        .odp {
+            display: inline;
+            background: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 3px;
+            padding: 1px 5px;
+            font-size: 0.92em;
+            color: #856404;
+            font-style: italic;
+            cursor: help;
+        }
+
+        /* Cross-control links inside prose */
+        .ctrl-ref {
+            color: #0366d6;
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .ctrl-ref:hover {
+            text-decoration: underline;
+        }
+
+        /* Rule list — clickable links */
+        .rule-list li a {
+            color: #24292e;
+            text-decoration: none;
+        }
+
+        .rule-list li a:hover {
+            color: #0366d6;
+            text-decoration: underline;
+        }
+
+        .rule-list li a::after {
+            content: ' ↗';
+            font-size: 10px;
+            color: #586069;
+        }
+
+        .component-item {
+            background: #f6f8fa;
+            border-left: 3px solid #6f42c1;
+            padding: 12px 15px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+        }
+
+        .component-item-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 6px;
+        }
+
+        .component-name-link {
+            font-weight: 600;
+            color: #6f42c1;
+            text-decoration: none;
+            font-size: 15px;
+        }
+
+        .component-name-link:hover {
+            text-decoration: underline;
+        }
+
+        .component-rules-list {
+            margin-top: 6px;
+            font-size: 12px;
+            color: #586069;
+            line-height: 1.8;
+        }
+
+        .component-rule-code {
+            display: inline-block;
+            background: #e1e4e8;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: monospace;
+            font-size: 11px;
+            margin: 2px;
+        }
     </style>
 </head>
 <body>
@@ -278,22 +400,34 @@
                 </div>
             `;
 
-            // Description
-            if (control.description) {
+            // Statement (structured OSCAL)
+            const stmt = control.statement;
+            if (stmt && (stmt.prose || (stmt.items && stmt.items.length > 0))) {
+                function renderItems(items, tag) {
+                    if (!items || items.length === 0) return '';
+                    const inner = items.map(item => {
+                        const sub = renderItems(item.items, 'ol');
+                        return `<li>${item.prose}${sub}</li>`;
+                    }).join('');
+                    return `<${tag} class="statement-list">${inner}</${tag}>`;
+                }
                 html += `
                     <div class="card detail-section">
-                        <h3>Description</h3>
-                        <div class="detail-content">${control.description}</div>
+                        <h3>Control Statement</h3>
+                        ${stmt.prose ? `<p class="statement-intro">${stmt.prose}</p>` : ''}
+                        ${renderItems(stmt.items, 'ol')}
                     </div>
                 `;
             }
 
             // Guidance
-            if (control.guidance) {
+            if (control.guidance && control.guidance.length > 0) {
                 html += `
                     <div class="card detail-section">
                         <h3>Supplemental Guidance</h3>
-                        <div class="detail-content">${control.guidance}</div>
+                        <div class="guidance-text">
+                            ${control.guidance.map(p => `<p>${p}</p>`).join('')}
+                        </div>
                     </div>
                 `;
             }
@@ -320,12 +454,19 @@
             }
 
             // Rules
+            const ruleUrls = control.rule_urls || {};
             if (control.rules && control.rules.length > 0) {
                 html += `
                     <div class="card detail-section">
                         <h3>Mapped Rules</h3>
                         <ul class="rule-list">
-                            ${control.rules.map(rule => `<li>${rule}</li>`).join('')}
+                            ${control.rules.map(rule => {
+                                const url = ruleUrls[rule];
+                                const inner = url
+                                    ? `<a href="${url}" target="_blank" rel="noopener">${rule}</a>`
+                                    : rule;
+                                return `<li>${inner}</li>`;
+                            }).join('')}
                         </ul>
                     </div>
                 `;
@@ -337,6 +478,38 @@
                             <p style="color: #d73a49;">⚠️ No rules mapped to this control</p>
                             <p style="color: #586069; margin-top: 10px;">This control needs implementation. Add TODO items below to track the work.</p>
                         </div>
+                    </div>
+                `;
+            }
+
+            // Components
+            if (control.components && Object.keys(control.components).length > 0) {
+                const sortedComps = Object.entries(control.components)
+                    .sort((a, b) => b[1].length - a[1].length);
+                html += `
+                    <div class="card detail-section">
+                        <h3>Related Components</h3>
+                        <p style="color: #586069; margin-bottom: 15px; font-size: 13px;">
+                            Software components whose rules implement this control
+                            (<a href="components.html" style="color: #6f42c1;">view all components</a>)
+                        </p>
+                        ${sortedComps.map(([compName, rules]) => `
+                            <div class="component-item">
+                                <div class="component-item-header">
+                                    <a href="components.html?component=${compName}"
+                                       class="component-name-link">${compName}</a>
+                                    <span class="badge" style="background: #6f42c1; color: white;">${rules.length} rules</span>
+                                </div>
+                                <div class="component-rules-list">
+                                    ${rules.map(r => {
+                                        const url = ruleUrls[r];
+                                        return url
+                                            ? `<a href="${url}" target="_blank" rel="noopener" class="component-rule-code" style="background:#e1e4e8;padding:2px 6px;border-radius:3px;font-size:11px;font-family:monospace;text-decoration:none;color:#0366d6;">${r} ↗</a>`
+                                            : `<code class="component-rule-code">${r}</code>`;
+                                    }).join('')}
+                                </div>
+                            </div>
+                        `).join('')}
                     </div>
                 `;
             }

--- a/utils/nist_sync/templates/controls.html
+++ b/utils/nist_sync/templates/controls.html
@@ -362,6 +362,7 @@
                         <div class="control-meta">
                             ${levels ? `<span>📊 Baselines: ${levels}</span>` : ''}
                             <span>📋 Rules: ${ruleCount}</span>
+                            ${control.component_count > 0 ? `<span>📦 Components: ${control.component_count}</span>` : ''}
                         </div>
                     </div>
                 `;

--- a/utils/nist_sync/templates/statistics.html
+++ b/utils/nist_sync/templates/statistics.html
@@ -396,8 +396,54 @@
                 });
         }
 
+        function renderComponentStatistics() {
+            const compStats = (EMBEDDED_DATA.component_stats || {})[CURRENT_PRODUCT] || {};
+            const entries = Object.entries(compStats);
+            if (entries.length === 0) return;
+
+            const section = document.createElement('div');
+            section.className = 'card';
+            section.innerHTML = `
+                <h3>Component Coverage</h3>
+                <p style="color: #586069; margin-bottom: 15px; font-size: 13px;">
+                    Software components referenced by NIST 800-53 controls
+                    (<a href="components.html" style="color: #6f42c1;">view component details</a>)
+                </p>
+                <table class="comparison-table" id="component-stats-table">
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Controls</th>
+                            <th>Rule Refs</th>
+                            <th>Packages</th>
+                        </tr>
+                    </thead>
+                    <tbody id="component-stats-tbody"></tbody>
+                </table>
+            `;
+            document.querySelector('.container').appendChild(section);
+
+            const tbody = document.getElementById('component-stats-tbody');
+            entries
+                .sort((a, b) => b[1].control_count - a[1].control_count)
+                .forEach(([compName, data]) => {
+                    const row = document.createElement('tr');
+                    row.innerHTML = `
+                        <td><a href="components.html?component=${compName}"
+                               style="color: #6f42c1; font-weight: 600;">${compName}</a></td>
+                        <td>${data.control_count}</td>
+                        <td>${data.rule_count}</td>
+                        <td style="font-size: 12px; color: #586069;">${(data.packages || []).join(', ')}</td>
+                    `;
+                    tbody.appendChild(row);
+                });
+        }
+
         // Initialize on page load
-        document.addEventListener('DOMContentLoaded', renderStatistics);
+        document.addEventListener('DOMContentLoaded', function() {
+            renderStatistics();
+            renderComponentStatistics();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
#### Description:

- Extend the NIST viewer to expose the control→rule→component relationship: new Components page with grid and per-component detail view, "Related Components" section on control detail pages, component coverage table in statistics, and component count badges on the controls list.
- Improve control detail rendering: OSCAL statements as structured numbered lists, guidance split into paragraphs, ODP parameter references highlighted inline, cross-control references as clickable links, and rule IDs linking to their `rule.yml` on GitHub.
- Add `docs/manual/developer/15_components_and_controls.md` documenting the component architecture, the control→rule→component chain, and how to query relationships via the viewer and Python API.

#### Rationale:

- The control→rule→component relationship was implicit and invisible — authors had no way to see which components a control requires or which controls a component satisfies.
- OSCAL prose was rendered as raw text blobs and rule IDs had no link to their source.

- https://github.com/ComplianceAsCode/content/issues/14758 type of issue was taken into account when developing this feature, so it should not manifest here.

#### Review Hints:

- Download the OSCAL catalog first: `cd utils/nist_sync && python3 download_oscal.py`
- Generate and serve the viewer: `PYTHONPATH=$(pwd) python3 utils/nist_sync/generate_nist_viewer.py --products rhel9 --output-dir /tmp/nist-viewer --repo-root . && python3 -m http.server 8080 --directory /tmp/nist-viewer`
- Key pages to check: `components.html`, `control-detail.html?id=au-2`, `statistics.html`

- Changes will propagate to https://complianceascode.github.io/content-pages/nist-viewer/
