### PR TITLE
template: kernel_module_disabled, use rule_id in OVAL definition name

### DIFF
--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance"
-  id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
+  id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.", rule_title=rule_title) }}}
     <criteria operator="OR">
       {{% if product in ["rhcos4", "fedora"] or 'ol' in families or 'rhel' in product or 'sle' in product or 'slmicro' in product or 'ubuntu' in product %}}


### PR DESCRIPTION
#### Description:

- Modify the `kernel_module_disabled` template OVAL definition to use the built-in `_RULE_ID` Jinja variable for the OVAL definition `id` attribute instead of constructing it from the `KERNMODULE` parameter.

#### Rationale:

- The previous OVAL definition ID `kernel_module_{KERNMODULE}_disabled` did not always match the actual rule ID that uses the template. Using `_RULE_ID` ensures the OVAL definition name is consistent with the rule that instantiates it, which is the standard convention used by other templates.

#### Review Hints:

- Single-line change in `shared/templates/kernel_module_disabled/oval.template`.
- Build any product that uses `kernel_module_disabled` rules to verify no build regressions: `./build_product --datastream-only rhel9`
- Check that OVAL definitions in the built data stream now use the rule ID as definition name instead of `kernel_module_<modname>_disabled`.
