### PR TITLE
no_invalid_shell_accounts_unlocked: fix OVAL check to catch valid and invalid shell accounts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
@@ -6,7 +6,7 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_{{{ rule_id }}}_no_invalid_shell_accounts" check="all" check_existence="at_least_one_exists"
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}_no_invalid_shell_accounts" check="at least one" check_existence="at_least_one_exists"
     version="1" comment="Verify there is no account with invalid shell which is not locked exists">
     <ind:object object_ref="obj_{{{ rule_id }}}_shells" />
     <ind:state state_ref="state_{{{ rule_id }}}_valid_shells" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/mixed_valid_invalid_shells.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/mixed_valid_invalid_shells.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# remediation = none
+
+# One unlocked user with a valid shell (/bin/bash in /etc/shells)
+useradd -u 8001 -s /bin/bash validuser
+echo "validuser:testpass" | chpasswd
+
+# One unlocked user with an invalid shell (not in /etc/shells)
+useradd -u 8002 -s /bin/invalid_shell invaliduser
+echo "invaliduser:testpass" | chpasswd
+
+echo "/bin/bash" >> /etc/shells


### PR DESCRIPTION
#### Description:

  - Fix the OVAL check for the `no_invalid_shell_accounts_unlocked` rule so it correctly detects systems with a mix of unlocked users having valid and invalid shells. Previously, the check used `check="all"` which could miss the failure case when both valid-shell and invalid-shell unlocked accounts coexisted. Changed to `check="at least one"` so the check properly triggers a finding.
- Add a new test scenario (`mixed_valid_invalid_shells.fail.sh`) that covers this mixed-user case with one unlocked user having a valid shell (`/bin/bash`) and another having an invalid shell (`/bin/invalid_shell`).

#### Rationale:

- The OVAL check logic did not correctly evaluate systems where unlocked accounts had a mixture of valid and invalid shells, leading to false negatives. This fix ensures compliance scanners properly flag such configurations.

Fixes: #14752 

#### Review Hints:

- Affected products: rhel8, rhel9, rhel10, sle15 (the OVAL is in `oval/shared.xml`)
- Build any affected product to verify:
  ```
  ./build_product --datastream-only rhel9
  ```
- Test with Automatus:
  ```
  ./tests/automatus.py rule --libvirt qemu:///session <vm_name> --datastream build/ssg-rhel9-ds.xml no_invalid_shell_accounts_unlocked
  ```
- Key files to review:
  - `linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml` — the OVAL fix (`check="all"` → `check="at least one"`)
  - `linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/mixed_valid_invalid_shells.fail.sh` — new test scenario
