### PR TITLE
lint: disable yamllint line-length check

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -18,5 +18,4 @@ rules:
   indentation:
     # pass if spaces are used for indentation and number of spaces is consistent through a file
     spaces: consistent
-  line-length:
-    max: 99 # allow lines up to 99 chars
+  line-length: disable

--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -146,7 +146,8 @@ and keep these guidelines in mind when writing new code.
     * Have words separated by an underscore
     * Have a total path length less than 250 characters
 * Shall not use "smart quotes" or curved quotes
-* Maximum line length should be 99 characters
+* Maximum line length of 99 characters is preferred but not enforced.
+    * YAML content in this project often contains URLs, HTML tags, and Jinja macros that are impractical to split. For new plain-text content, try to stay under 99 characters.
 
 ### Jinja
 


### PR DESCRIPTION
#### Description:

- Disable the yamllint `line-length` check and update the developer style guide to reflect that the 99-character limit is preferred but not enforced.

#### Rationale:

- YAML content in this project frequently embeds HTML tags, Jinja macros, and URLs that make strict line-length enforcement impractical. The check produces many false positives and is hard to comply with without degrading readability.

#### Review Hints:

- Two files changed: `.yamllint` (config change) and `docs/manual/developer/04_style_guide.md` (documentation update).
- The style guide still recommends 99 characters for new plain-text content — only the hard enforcement is removed.
