### PR TITLE
Add an SCE rule to ubuntu2604

### DIFF
--- a/products/ubuntu2604/profiles/default.profile
+++ b/products/ubuntu2604/profiles/default.profile
@@ -9,3 +9,4 @@ description: |-
 
 selections:
     - installed_OS_is_vendor_supported
+    - ufw_rules_for_open_ports


### PR DESCRIPTION


#### Description:

Add an SCE rule to ubuntu2604

#### Rationale:

An SCE is needed to make the tests pass
#### Review Hints:

Build ubuntu2604 and run `ctest`.
