### PR TITLE
CMP-4341: added kubernetes files

### DIFF
--- a/applications/openshift/kubelet/kubelet_anonymous_auth/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/kubernetes/shared.yml
@@ -1,0 +1,3 @@
+---
+# platform = multi_platform_ocp
+{{{ kubelet_config_fixed(path='kubeletConfig.authentication.anonymous',parameter='enabled', value='false') }}}

--- a/applications/openshift/kubelet/kubelet_authorization_mode/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/kubernetes/shared.yml
@@ -1,0 +1,3 @@
+---
+# platform = multi_platform_ocp
+{{{ kubelet_config_fixed(path='kubeletConfig.authorization',parameter='mode', value='Webhook') }}}

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/kubernetes/shared.yml
@@ -1,0 +1,3 @@
+---
+# platform = multi_platform_ocp
+{{{ kubelet_config_fixed(path='kubeletConfig.authentication.x509',parameter='clientCAFile', value='/etc/kubernetes/kubelet-ca.crt') }}}

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/kubernetes/shared.yml
@@ -1,0 +1,3 @@
+---
+# platform = multi_platform_ocp
+{{{ kubelet_config_fixed(path='kubeletConfig',parameter='serverTLSBootstrap', value='true') }}}


### PR DESCRIPTION
#### Description:

- Created Kubernetes remediation files for 4 kubelet security configuration rules:
    - `kubelet_anonymous_auth`: Disable anonymous authentication to the kubelet
    - `kubelet_authorization_mode`: Configure kubelet authorization mode
    - `kubelet_configure_client_ca`: Configure kubelet client certificate authority
    - `kubelet_enable_server_cert_rotation`: Enable kubelet server certificate rotation

#### Rationale:

- These 4 kubelet rules previously had no automated Kubernetes/OpenShift remediations,
  requiring manual intervention to fix non-compliant configurations.
- The remediation files use the `kubelet_config_fixed` macro to generate KubeletConfig
  objects that the Machine Config Operator can apply to OpenShift nodes.
- This enables automated remediation of these security controls in OpenShift 4.x
  environments, improving compliance automation coverage.

- Fixes CMP-4341

#### Review Hints:

- Each remediation file follows the same pattern: using the `kubelet_config_fixed`
  macro to set specific kubelet configuration parameters via KubeletConfig custom
  resources.
- You can verify the macro usage is correct by checking that the `path`, `parameter`,
  and `value` arguments match the kubelet configuration requirements described in each
  rule's `rule.yml` file.
- To test locally, you can build the content and run compliance scans on an OpenShift
  4.x cluster to verify the remediations are generated and can be applied successfully.

