### PR TITLE
add grub2_ipv6_disable_argument rule to general sle15 control

### DIFF
--- a/controls/general_sle15.yml
+++ b/controls/general_sle15.yml
@@ -1041,6 +1041,14 @@ controls:
       rules:
           - kernel_module_sctp_disabled
 
+    - id: SLES-15-450300075
+      title: Disable IPv6 Support
+      levels:
+          - medium
+      status: automated
+      rules:
+          - grub2_ipv6_disable_argument
+
     - id: SLES-15-450450015
       title: Disable IP forwarding
       levels:


### PR DESCRIPTION
#### Description:

- Enable grub2_ipv6_disable_argument rule in SLE15's general control file

#### Rationale:

- Include the oval check and ansible+bash remediation in that profile