### PR TITLE
Fixes issue when .bash_history is a symlink

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/ansible/shared.yml
@@ -26,3 +26,4 @@
   when:
     - item.stat is defined
     - item.stat.exists
+    - not item.stat.islink

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/ansible/shared.yml
@@ -26,4 +26,4 @@
   when:
     - item.stat is defined
     - item.stat.exists
-    - not item.stat.islink
+    - not item.stat.islnk

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/bash/shared.sh
@@ -12,7 +12,8 @@ USERS_IGNORED_REGEX='nobody|nfsnobody'
 
 for (( i=0; i<"${#interactive_users[@]}"; i++ )); do
     if ! grep -qP "$USERS_IGNORED_REGEX" <<< "${interactive_users[$i]}" && \
-        [ "${interactive_users_shell[$i]}" != "/sbin/nologin" ]; then
+        [ "${interactive_users_shell[$i]}" != "/sbin/nologin" ] && \
+        [ ! -L "${interactive_users_home[$i]}/.bash_history" ]; then
 
         chmod u-sx,go= "${interactive_users_home[$i]}/.bash_history"
     fi

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/oval/shared.xml
@@ -2,35 +2,39 @@
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("User Bash History File Has Correct Permissions", rule_title=rule_title) }}}
         <criteria>
-            <criterion comment="User Bash History File Has Correct Permissions"
+            <criterion comment="No regular .bash_history files have group or other permissions"
                 test_ref="test_{{{ rule_id }}}" />
         </criteria>
     </definition>
 
     <unix:file_test id="test_{{{ rule_id }}}" check="all"
-                    check_existence="any_exist" version="1"
-          comment="User Bash History File Has Correct Permissions">
+                    check_existence="none_exist" version="1"
+          comment="No regular .bash_history files have group or other permissions">
         <unix:object object_ref="object_{{{ rule_id }}}"/>
-        <unix:state state_ref="state_{{{ rule_id }}}"/>
     </unix:file_test>
 
     <unix:file_object id="object_{{{ rule_id }}}" version="1">
         <unix:path var_ref="var_{{{ rule_id }}}_home_dirs" var_check="at least one"/>
         <unix:filename operation="equals">.bash_history</unix:filename>
+        <filter action="include">state_{{{ rule_id }}}_group_other_permissions</filter>
+        <filter action="exclude">state_{{{ rule_id }}}_symlink</filter>
     </unix:file_object>
 
+    <unix:file_state id="state_{{{ rule_id }}}_symlink" version="1">
+        <unix:type operation="equals">symbolic link</unix:type>
+    </unix:file_state>
 
-    <unix:file_state id="state_{{{ rule_id }}}" operator="AND" version="1">
-        <unix:suid datatype="boolean">false</unix:suid>
-        <unix:sgid datatype="boolean">false</unix:sgid>
-        <unix:sticky datatype="boolean">false</unix:sticky>
-        <unix:uexec datatype="boolean">false</unix:uexec>
-        <unix:gread datatype="boolean">false</unix:gread>
-        <unix:gwrite datatype="boolean">false</unix:gwrite>
-        <unix:gexec datatype="boolean">false</unix:gexec>
-        <unix:oread datatype="boolean">false</unix:oread>
-        <unix:owrite datatype="boolean">false</unix:owrite>
-        <unix:oexec datatype="boolean">false</unix:oexec>
+    <unix:file_state id="state_{{{ rule_id }}}_group_other_permissions" operator="OR" version="1">
+        <unix:suid datatype="boolean">true</unix:suid>
+        <unix:sgid datatype="boolean">true</unix:sgid>
+        <unix:sticky datatype="boolean">true</unix:sticky>
+        <unix:uexec datatype="boolean">true</unix:uexec>
+        <unix:gread datatype="boolean">true</unix:gread>
+        <unix:gwrite datatype="boolean">true</unix:gwrite>
+        <unix:gexec datatype="boolean">true</unix:gexec>
+        <unix:oread datatype="boolean">true</unix:oread>
+        <unix:owrite datatype="boolean">true</unix:owrite>
+        <unix:oexec datatype="boolean">true</unix:oexec>
     </unix:file_state>
 
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/bash/shared.sh
@@ -16,7 +16,7 @@ for (( i=0; i<"${#interactive_users[@]}"; i++ )); do
     if ! grep -qP "$USERS_IGNORED_REGEX" <<< "${interactive_users[$i]}" && \
         [ "${interactive_users_shell[$i]}" != "/sbin/nologin" ]; then
         
-        readarray -t init_files < <(find "${interactive_users_home[$i]}" -maxdepth 1 \
+        readarray -t init_files < <(find "${interactive_users_home[$i]}" -maxdepth 1 -type f \
             -exec basename {} \; | grep -P "$var_user_initialization_files_regex")
         for file in "${init_files[@]}"; do
             chmod u-s,g-wxs,o= "${interactive_users_home[$i]}/$file"


### PR DESCRIPTION
#### Description:

A user may have its .bash_history file as a symlink. The current code follows the symlink and changes the target permission.

#### Rationale:
Since a user can create symlinks on its home directory, a malicious user could create a symlink pointing to a system executable file. When oscap runs it will change the executable file permission in behalf of the user to 0600. With that a least privileged user could change permission of files owned by root.

Also there is a practice to create a symlink for .bash_history pointing to /dev/null. In that scenario oscap would set /dev/null permission to 0600, breaking the system.

#### Review Hints:

Fixing a `.bash_history` as a regular file:
```
root@06ddb2fcb2d4:/content/build# chmod 644 /home/ubuntu/.bash_history 
root@06ddb2fcb2d4:/content/build# ls -l /home/ubuntu/.bash_history 
-rw-r--r-- 1 root root 0 Jun 18 00:14 /home/ubuntu/.bash_history
root@06ddb2fcb2d4:/content/build# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_level2_server --rule xccdf_org.ssgproject.content_rule_file_permission_user_bash_history --remediate ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Ensure User Bash History File Has Correct Permissions
Rule    xccdf_org.ssgproject.content_rule_file_permission_user_bash_history
Result  fail


--- Starting Remediation ---

Title   Ensure User Bash History File Has Correct Permissions
Rule    xccdf_org.ssgproject.content_rule_file_permission_user_bash_history
Result  fixed

root@06ddb2fcb2d4:/content/build# ls -l /home/ubuntu/.bash_history 
-rw------- 1 root root 0 Jun 18 00:14 /home/ubuntu/.bash_history
```

Skipping `.bash_history` when it is a symlink:
```
root@06ddb2fcb2d4:/content/build# ls -l /dev/null /home/ubuntu/.bash_history 
crw-rw-rw- 1 nobody nogroup 1, 3 Jun 17 11:20 /dev/null
lrwxrwxrwx 1 root   root       9 Jun 18 00:12 /home/ubuntu/.bash_history -> /dev/null
root@06ddb2fcb2d4:/content/build# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_level2_server --rule xccdf_org.ssgproject.content_rule_file_permission_user_bash_history --remediate ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Ensure User Bash History File Has Correct Permissions
Rule    xccdf_org.ssgproject.content_rule_file_permission_user_bash_history
Result  pass


--- Starting Remediation ---

root@06ddb2fcb2d4:/content/build# 
```