### PR TITLE
CMP-4338: Updated the audit rules to properly handle the RHCOS4 audit system config

### DIFF
--- a/applications/openshift/logging/directory_access_var_log_kube_audit/oval/shared.xml
+++ b/applications/openshift/logging/directory_access_var_log_kube_audit/oval/shared.xml
@@ -7,13 +7,13 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit rule to record read access events to /var/log/kube-apiserver" test_ref="test_directory_acccess_var_log_kube_audit_augenrules" />
+        <criterion comment="audit rule to record read access events to /var/log/kube-apiserver" test_ref="test_directory_access_var_log_kube_audit_augenrules" />
       </criteria>
 
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit rule to record read access events to /var/log/kube-apiserver" test_ref="test_directory_acccess_var_log_kube_audit_auditctl" />
+        <criterion comment="audit rule to record read access events to /var/log/kube-apiserver" test_ref="test_directory_access_var_log_kube_audit_auditctl" />
       </criteria>
 
     </criteria>
@@ -26,10 +26,10 @@
 
   <!-- directory access /var/log/audit augenrule -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_kube_audit_augenrules" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_kube_audit_augenrules" />
+ comment="defined audit rule must exist" id="test_directory_access_var_log_kube_audit_augenrules" version="1">
+    <ind:object object_ref="object_directory_access_var_log_kube_audit_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_kube_audit_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_directory_access_var_log_kube_audit_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_kube_audit_regex" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
@@ -38,10 +38,10 @@
 
   <!-- directory access /var/log/audit auditctl -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_kube_audit_auditctl" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_kube_audit_auditctl" />
+ comment="defined audit rule must exist" id="test_directory_access_var_log_kube_audit_auditctl" version="1">
+    <ind:object object_ref="object_directory_access_var_log_kube_audit_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_kube_audit_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_directory_access_var_log_kube_audit_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_kube_audit_regex" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/applications/openshift/logging/directory_access_var_log_oauth_audit/oval/shared.xml
+++ b/applications/openshift/logging/directory_access_var_log_oauth_audit/oval/shared.xml
@@ -7,13 +7,13 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit rule to record read access events to /var/log/oauth-apiserver" test_ref="test_directory_acccess_var_log_oauth_audit_augenrules" />
+        <criterion comment="audit rule to record read access events to /var/log/oauth-apiserver" test_ref="test_directory_access_var_log_oauth_audit_augenrules" />
       </criteria>
 
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit rule to record read access events to /var/log/oauth-apiserver" test_ref="test_directory_acccess_var_log_oauth_audit_auditctl" />
+        <criterion comment="audit rule to record read access events to /var/log/oauth-apiserver" test_ref="test_directory_access_var_log_oauth_audit_auditctl" />
       </criteria>
 
     </criteria>
@@ -26,10 +26,10 @@
 
   <!-- directory access /var/log/audit augenrule -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_oauth_audit_augenrules" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_oauth_audit_augenrules" />
+ comment="defined audit rule must exist" id="test_directory_access_var_log_oauth_audit_augenrules" version="1">
+    <ind:object object_ref="object_directory_access_var_log_oauth_audit_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_oauth_audit_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_directory_access_var_log_oauth_audit_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_oauth_audit_regex" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
@@ -38,10 +38,10 @@
 
   <!-- directory access /var/log/audit auditctl -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_oauth_audit_auditctl" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_oauth_audit_auditctl" />
+ comment="defined audit rule must exist" id="test_directory_access_var_log_oauth_audit_auditctl" version="1">
+    <ind:object object_ref="object_directory_access_var_log_oauth_audit_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_oauth_audit_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_directory_access_var_log_oauth_audit_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_oauth_audit_regex" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/applications/openshift/logging/directory_access_var_log_ocp_audit/oval/shared.xml
+++ b/applications/openshift/logging/directory_access_var_log_ocp_audit/oval/shared.xml
@@ -7,13 +7,13 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit rule to record read access events to /var/log/openshift-apiserver" test_ref="test_directory_acccess_var_log_ocp_audit_augenrules" />
+        <criterion comment="audit rule to record read access events to /var/log/openshift-apiserver" test_ref="test_directory_access_var_log_ocp_audit_augenrules" />
       </criteria>
 
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit rule to record read access events to /var/log/openshift-apiserver" test_ref="test_directory_acccess_var_log_ocp_audit_auditctl" />
+        <criterion comment="audit rule to record read access events to /var/log/openshift-apiserver" test_ref="test_directory_access_var_log_ocp_audit_auditctl" />
       </criteria>
 
     </criteria>
@@ -26,10 +26,10 @@
 
   <!-- directory access /var/log/audit augenrule -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_ocp_audit_augenrules" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_ocp_audit_augenrules" />
+ comment="defined audit rule must exist" id="test_directory_access_var_log_ocp_audit_augenrules" version="1">
+    <ind:object object_ref="object_directory_access_var_log_ocp_audit_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_ocp_audit_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_directory_access_var_log_ocp_audit_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_ocp_audit_regex" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
@@ -38,10 +38,10 @@
 
   <!-- directory access /var/log/audit auditctl -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_ocp_audit_auditctl" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_ocp_audit_auditctl" />
+ comment="defined audit rule must exist" id="test_directory_access_var_log_ocp_audit_auditctl" version="1">
+    <ind:object object_ref="object_directory_access_var_log_ocp_audit_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_ocp_audit_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_directory_access_var_log_ocp_audit_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_ocp_audit_regex" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
@@ -30,7 +30,7 @@
     </criteria>
   </definition>
 
-{{% macro test_directory_acccess_var_log_audit(audit_tool, filepath, bits) %}}
+{{% macro test_directory_access_var_log_audit(audit_tool, filepath, bits) %}}
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit {{{ audit_tool }}} {{{ NAME }}}" id="test_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
     <ind:object object_ref="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" />
   </ind:textfilecontent54_test>
@@ -41,9 +41,9 @@
   </ind:textfilecontent54_object>
 {{% endmacro %}}
 
-{{{ test_directory_acccess_var_log_audit("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "32") }}}
-{{{ test_directory_acccess_var_log_audit("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "64") }}}
-{{{ test_directory_acccess_var_log_audit("auditctl", "/etc/audit/audit.rules", "32") }}}
-{{{ test_directory_acccess_var_log_audit("auditctl", "/etc/audit/audit.rules", "64") }}}
+{{{ test_directory_access_var_log_audit("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "32") }}}
+{{{ test_directory_access_var_log_audit("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "64") }}}
+{{{ test_directory_access_var_log_audit("auditctl", "/etc/audit/audit.rules", "32") }}}
+{{{ test_directory_access_var_log_audit("auditctl", "/etc/audit/audit.rules", "64") }}}
 
 </def-group>

--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -8,7 +8,7 @@
       <description>Test if auditctl is in use for audit rules.</description>
     </metadata>
 
-{{% if product in ['ocp4', 'rhcos4'] %}}
+{{% if product in ['rhcos4', 'ocp4'] %}}
     <criteria operator="OR">
       <criterion comment="audit auditctl via audit-rules.service" test_ref="test_audit_rules_auditctl_service" />
       <criterion comment="audit auditctl via auditd.service" test_ref="test_audit_rules_auditctl" />
@@ -20,7 +20,7 @@
 {{% endif %}}
   </definition>
 
-{{% if product in ['ocp4', 'rhcos4'] %}}
+{{% if product in ['rhcos4', 'ocp4'] %}}
   <!-- RHCOS on RHEL 10+: auditctl runs via a separate audit-rules.service -->
   <ind:textfilecontent54_test check="all" comment="audit auditctl via audit-rules.service" id="test_audit_rules_auditctl_service" version="1">
     <ind:object object_ref="object_audit_rules_auditctl_service" />

--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -8,10 +8,29 @@
       <description>Test if auditctl is in use for audit rules.</description>
     </metadata>
 
+{{% if product in ['ocp4', 'rhcos4'] %}}
+    <criteria operator="OR">
+      <criterion comment="audit auditctl via audit-rules.service" test_ref="test_audit_rules_auditctl_service" />
+      <criterion comment="audit auditctl via auditd.service" test_ref="test_audit_rules_auditctl" />
+    </criteria>
+{{% else %}}
     <criteria>
       <criterion comment="audit auditctl" test_ref="test_audit_rules_auditctl" />
     </criteria>
+{{% endif %}}
   </definition>
+
+{{% if product in ['ocp4', 'rhcos4'] %}}
+  <!-- RHCOS on RHEL 10+: auditctl runs via a separate audit-rules.service -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl via audit-rules.service" id="test_audit_rules_auditctl_service" version="1">
+    <ind:object object_ref="object_audit_rules_auditctl_service" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_auditctl_service" version="1">
+    <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStart=\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
 
   <!-- Test the auditctl case -->
   <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_audit_rules_auditctl" version="1">

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -8,10 +8,29 @@
       <description>Test if augenrules is enabled for audit rules.</description>
     </metadata>
 
+{{% if product in ['ocp4', 'rhcos4'] %}}
+    <criteria operator="OR">
+      <criterion comment="audit augenrules via audit-rules.service" test_ref="test_audit_rules_augenrules_service" />
+      <criterion comment="audit augenrules via auditd.service" test_ref="test_audit_rules_augenrules" />
+    </criteria>
+{{% else %}}
     <criteria>
       <criterion comment="audit augenrules" test_ref="test_audit_rules_augenrules" />
     </criteria>
+{{% endif %}}
   </definition>
+
+{{% if product in ['ocp4', 'rhcos4'] %}}
+  <!-- RHCOS on RHEL 10+: augenrules runs via a separate audit-rules.service -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules via audit-rules.service" id="test_audit_rules_augenrules_service" version="1">
+    <ind:object object_ref="object_audit_rules_augenrules_service" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_augenrules_service" version="1">
+    <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStart=(\/usr|)?\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
 
   <!-- Test the augenrules case -->
   <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_audit_rules_augenrules" version="1">

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -8,7 +8,7 @@
       <description>Test if augenrules is enabled for audit rules.</description>
     </metadata>
 
-{{% if product in ['ocp4', 'rhcos4'] %}}
+{{% if product in ['rhcos4', 'ocp4'] %}}
     <criteria operator="OR">
       <criterion comment="audit augenrules via audit-rules.service" test_ref="test_audit_rules_augenrules_service" />
       <criterion comment="audit augenrules via auditd.service" test_ref="test_audit_rules_augenrules" />
@@ -20,7 +20,7 @@
 {{% endif %}}
   </definition>
 
-{{% if product in ['ocp4', 'rhcos4'] %}}
+{{% if product in ['rhcos4', 'ocp4'] %}}
   <!-- RHCOS on RHEL 10+: augenrules runs via a separate audit-rules.service -->
   <ind:textfilecontent54_test check="all" comment="audit augenrules via audit-rules.service" id="test_audit_rules_augenrules_service" version="1">
     <ind:object object_ref="object_audit_rules_augenrules_service" />


### PR DESCRIPTION
#### Description:

Updated the audit rules to properly handle the RHCOS4 audit system configuration (which supports rhel8 - rhel10).
More information related to the ticket can be found here: https://redhat.atlassian.net/browse/CMP-4338

