### PR TITLE
Fixes file_permissions_sshd_private_key failing on rhel

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/oval/shared.xml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/oval/shared.xml
@@ -101,7 +101,7 @@
         {{# CoreOS doesn't list all groups in /etc/group - that's probably related to the FS immutability #}}
 	<ind:filepath>/usr/lib/group</ind:filepath>
       {{%- endif %}}
-        <ind:pattern operation="pattern match">^{{{ dedicated_ssh_groupname }}}:\w+:(\w+):.*</ind:pattern>
+        <ind:pattern operation="pattern match">^{{{ dedicated_ssh_groupname }}}:[^:]*:([0-9]+):([a-z_][a-z0-9_-]*(\$,?)?)*$</ind:pattern>
         <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

This change fixes the regular expression for checking `content_rule_file_permissions_sshd_private_key`.
Fixes:
* https://github.com/ComplianceAsCode/content/issues/10542
* https://github.com/ComplianceAsCode/content/issues/14809

#### Rationale:

RHEL and derived systems have different approach on giving permission to private keys under /etc/ssh. On those systems the group `ssh_keys` has read access to the private keys. The current regular expression doesn't match the content of `/etc/group`, thus failing the check. The new regular expression `^ssh_keys:[^:]*:([0-9]+):([a-z_][a-z0-9_-]*(\$,?)?)*$` covers all the group's file specification. The last part of the regex is kind of a overkill, since no user is expected to be included on that group, but I have decided to cover it, just in case of corner cases.

#### Review Hints:

On Ubuntu 24.04
```
root@vagrant:/vagrant# chmod o+r /etc/ssh/ssh_host_rsa_key
root@vagrant:/vagrant# ls -l /etc/ssh/ssh_host_rsa_key
-rw----r-- 1 root root 2602 Jul 28  2025 /etc/ssh/ssh_host_rsa_key
root@vagrant:/vagrant# oscap xccdf eval \
    --profile xccdf_org.ssgproject.content_profile_cis_level2_server \
    --rule xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key \
    --remediate \
    ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Verify Permissions on SSH Server Private *_key Key Files
Rule    xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
Result  fail


--- Starting Remediation ---

Title   Verify Permissions on SSH Server Private *_key Key Files
Rule    xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
Result  fixed

root@vagrant:/vagrant# ls -l /etc/ssh/ssh_host_rsa_key
-rw------- 1 root root 2602 Jul 28  2025 /etc/ssh/ssh_host_rsa_key
```
On Ubuntu 24.04 (re-checking)
```
root@vagrant:/vagrant# oscap xccdf eval     --profile xccdf_org.ssgproject.content_profile_cis_level2_server     --rule xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Verify Permissions on SSH Server Private *_key Key Files
Rule    xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
Result  pass
```

On RHEL 9
```
[root@rhel9lab ~]# chmod g+w /etc/ssh/*_key
[root@rhel9lab ~]# ls -lh /etc/ssh/*_key
-rw-rw----. 1 root ssh_keys  492 Jun  8  2025 /etc/ssh/ssh_host_ecdsa_key
-rw-rw----. 1 root ssh_keys  387 Jun  8  2025 /etc/ssh/ssh_host_ed25519_key
-rw-rw----. 1 root ssh_keys 2.6K Jun  8  2025 /etc/ssh/ssh_host_rsa_key
[root@rhel9lab ~]# oscap xccdf eval \
    --profile xccdf_org.ssgproject.content_profile_cis \
    --rule xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key \
    --remediate \
    ssg-rhel9-ds.xml
--- Starting Evaluation ---

Title   Verify Permissions on SSH Server Private *_key Key Files
Rule    xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
Ident   CCE-90820-2
Result  fail


--- Starting Remediation ---

Title   Verify Permissions on SSH Server Private *_key Key Files
Rule    xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
Ident   CCE-90820-2
Result  fixed

[root@rhel9lab ~]# ls -lh /etc/ssh/*_key
-rw-r-----. 1 root ssh_keys  492 Jun  8  2025 /etc/ssh/ssh_host_ecdsa_key
-rw-r-----. 1 root ssh_keys  387 Jun  8  2025 /etc/ssh/ssh_host_ed25519_key
-rw-r-----. 1 root ssh_keys 2.6K Jun  8  2025 /etc/ssh/ssh_host_rsa_key
```
On RHEL 9 (re-checking)
```
[root@rhel9lab ~]# oscap xccdf eval \
    --profile xccdf_org.ssgproject.content_profile_cis \
    --rule xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key \
    ssg-rhel9-ds.xml
--- Starting Evaluation ---

Title   Verify Permissions on SSH Server Private *_key Key Files
Rule    xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
Ident   CCE-90820-2
Result  pass
```