### PR TITLE
Fix system_with_kernel applicability on Amazon Linux 2023

### DIFF
--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -18,8 +18,10 @@
 {{{ oval_test_package_installed(package="kernel-default", test_id="inventory_test_kernel_installed") }}}
 {{{ oval_test_package_installed(package="kernel-default-base", test_id="inventory_test_kernel_default_base_installed") }}}
 {{{ oval_test_package_installed(package="kernel-azure", test_id="inventory_test_kernel_azure_installed") }}}
-{{% else %}}
+{{% elif product == "fedora" or "rhel" in product %}}
 {{{ oval_test_package_installed(package="kernel-core", test_id="inventory_test_kernel_installed") }}}
+{{% else %}}
+{{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
 {{% endif %}}
 {{% if "ol" in families %}}
 {{{ oval_test_package_installed(package="kernel-uek", test_id="inventory_test_kernel_uek_installed") }}}


### PR DESCRIPTION
The system_with_kernel CPE OVAL tested for the kernel-core package, which Amazon Linux 2023 does not provide (it ships kernel). system_with_kernel therefore evaluated false on AL2023, and every rule gated on it (the bulk of the profile) was marked not applicable.

Mirror the logic already used by the bash and ansible conditionals in system_with_kernel.yml: test kernel-core on Fedora and RHEL, and kernel elsewhere (including AL2023).