### PR TITLE
CMP-4341: move kubelet rule filepath to /tmp/runtime/openscap-kubeletconfig

### DIFF
--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.authentication.anonymous.enabled"
         check_existence: "all_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.authorization.mode"
         check_existence: "all_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -54,7 +54,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.authentication.x509.clientCAFile"
         check_existence: "all_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -62,7 +62,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.eventRecordQPS"
         check_existence: "all_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.tlsCipherSuites[:]"
         xccdf_variable: var_kubelet_tls_cipher_suites_regex
         regex_data: true

--- a/applications/openshift/kubelet/kubelet_configure_tls_min_version/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_min_version/rule.yml
@@ -87,7 +87,7 @@ ocil: |-
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.tlsMinVersion"
         xccdf_variable: var_kubelet_tls_min_version_regex
         regex_data: true

--- a/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
@@ -40,7 +40,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.hostname-override"
         check_existence: "none_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
@@ -46,7 +46,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.rotateCertificates"
         check_existence: "all_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -47,7 +47,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.featureGates.RotateKubeletClientCertificate"
         check_existence: "any_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -47,7 +47,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.makeIPTablesUtilChains"
         values:
          - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -106,7 +106,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.protectKernelDefaults"
         values:
          - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -44,7 +44,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.serverTLSBootstrap"
         values:
          - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -50,7 +50,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.streamingConnectionIdleTimeout"
         check_existence: "all_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionHard['imagefs.available']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionHard['imagefs.inodesFree']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionHard['memory.available']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionHard['nodefs.available']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionHard['nodefs.inodesFree']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['imagefs.available']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
@@ -69,7 +69,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['imagefs.inodesFree']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
@@ -69,7 +69,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['memory.available']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -69,7 +69,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['nodefs.available']"
     check_existence: "all_exist"
     xccdf_variable: var_event_record_qps

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
@@ -69,7 +69,7 @@ ocil: |-
 template:
   name: yamlfile_value
   vars:
-    filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+    filepath: '/tmp/runtime/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['nodefs.inodesFree']"
     check_existence: "all_exist"
     values:

--- a/applications/openshift/kubelet/kubelet_read_only_port_secured/rule.yml
+++ b/applications/openshift/kubelet/kubelet_read_only_port_secured/rule.yml
@@ -35,7 +35,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
+        filepath: '/tmp/runtime/openscap-kubeletconfig'
         yamlpath: ".kubeletconfig.readOnlyPort"
         values:
          - value: "0"


### PR DESCRIPTION
The compliance-operator delivers the runtime kubeletconfig to the scanner via a shared `emptyDir` mounted at `/host/tmp/runtime` (mirroring the runtime SSH config), instead of a host symlink under `/var/run`.

A volume mountpoint cannot be created under the read-only host `/var/run`, and the previous host `ln -s` was non-idempotent and failed `Read-only file system` on re-scans. This moves the kubelet `yamlfile_value` checks to read the config from the new path.

Updates the `filepath` in all 24 kubelet rules from `/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig` to `/tmp/runtime/openscap-kubeletconfig`.

**Pairs with compliance-operator PR ComplianceAsCode/compliance-operator#1255** (must merge together — the operator writes the new path, content reads it).

CMP-4341