### PR TITLE
nist_800_53: fix duplicate variables and ordering in sync, add missing rules

### DIFF
--- a/products/rhel10/controls/nist_800_53/ac.yml
+++ b/products/rhel10/controls/nist_800_53/ac.yml
@@ -210,6 +210,7 @@ controls:
           - package_libselinux_installed
           - package_mcstrans_removed
           - package_setroubleshoot_removed
+          - rsyslog_filecreatemode
           - rsyslog_files_groupownership
           - rsyslog_files_ownership
           - rsyslog_files_permissions

--- a/products/rhel9/controls/nist_800_53/ac.yml
+++ b/products/rhel9/controls/nist_800_53/ac.yml
@@ -203,6 +203,7 @@ controls:
           - package_libselinux_installed
           - package_mcstrans_removed
           - package_setroubleshoot_removed
+          - rsyslog_filecreatemode
           - rsyslog_files_groupownership
           - rsyslog_files_ownership
           - rsyslog_files_permissions

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/ac.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/ac.yml
@@ -90,9 +90,9 @@ controls:
       levels:
           - low
       rules:
-          - var_selinux_policy_name=targeted
-          - var_pam_wheel_group_for_su=cis
           - var_accounts_user_umask=027
+          - var_pam_wheel_group_for_su=cis
+          - var_selinux_policy_name=targeted
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs
           - accounts_umask_etc_profile
@@ -495,8 +495,8 @@ controls:
       levels:
           - low
       rules:
-          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_deny=5
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
@@ -525,8 +525,8 @@ controls:
       levels:
           - low
       rules:
-          - dconf_login_banner_text=cis_banners
           - dconf_login_banner_contents=cis_default
+          - dconf_login_banner_text=cis_banners
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
       status: automated

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/au.yml
@@ -11,10 +11,12 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_admin_space_left_action=cis_rhel10
           - var_audit_backlog_limit=8192
-          - var_auditd_space_left_action=cis_rhel10
           - var_auditd_action_mail_acct=root
+          - var_auditd_admin_space_left_action=cis_rhel10
+          - var_auditd_disk_error_action=cis_rhel10
+          - var_auditd_disk_full_action=cis_rhel10
+          - var_auditd_space_left_action=cis_rhel10
           - aide_build_database
           - aide_periodic_cron_checking
           - audit_rules_execution_chacl
@@ -59,10 +61,11 @@ controls:
       levels:
           - low
       rules:
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - var_multiple_time_servers=rhel
-          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
           - sshd_max_auth_tries_value=4
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - var_accounts_passwords_pam_faillock_dir=run
+          - var_multiple_time_servers=rhel
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -160,8 +163,8 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_disk_full_action=cis_rhel10
           - var_auditd_disk_error_action=cis_rhel10
+          - var_auditd_disk_full_action=cis_rhel10
           - auditd_data_disk_error_action
           - auditd_data_disk_full_action
       status: automated

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/cm.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/cm.yml
@@ -5,12 +5,30 @@ controls:
       levels:
           - low
       rules:
-          - var_user_initialization_files_regex=all_dotfiles
-          - var_sshd_set_maxstartups=10:30:60
           - sshd_idle_timeout_value=5_minutes
-          - var_sshd_set_keepalive=1
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
           - var_accounts_maximum_age_login_defs=365
           - var_sshd_max_sessions=10
+          - var_sshd_set_keepalive=1
+          - var_sshd_set_maxstartups=10:30:60
+          - var_user_initialization_files_regex=all_dotfiles
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - account_unique_id
@@ -61,7 +79,6 @@ controls:
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           - sysctl_net_ipv4_ip_forward
           - sysctl_net_ipv4_tcp_syncookies
-          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra
           - sysctl_net_ipv6_conf_all_accept_redirects
           - sysctl_net_ipv6_conf_all_accept_source_route
@@ -215,30 +232,30 @@ controls:
       levels:
           - low
       rules:
+          - cis_banner_text=cis
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_forwarding_value=disabled
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
           - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
           - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
           - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-          - cis_banner_text=cis
-          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-          - var_accounts_user_umask=027
-          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-          - var_sshd_set_login_grace_time=60
-          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
           - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
+          - var_accounts_user_umask=027
+          - var_sshd_set_login_grace_time=60
           - accounts_password_pam_modules_in_authselect_profile
           - accounts_password_pam_pwquality_password_auth
           - accounts_password_pam_pwquality_system_auth

--- a/shared/references/controls/nist_800_53_cis_reference_rhel10/ia.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel10/ia.yml
@@ -152,16 +152,16 @@ controls:
       levels:
           - low
       rules:
-          - var_password_hashing_algorithm_pam=cis_rhel10
-          - var_password_hashing_algorithm=cis_rhel10
           - var_accounts_minimum_age_login_defs=1
-          - var_password_pam_maxsequence=3
-          - var_password_pam_maxrepeat=3
           - var_accounts_password_warn_age_login_defs=7
+          - var_password_hashing_algorithm=cis_rhel10
+          - var_password_hashing_algorithm_pam=cis_rhel10
           - var_password_pam_dictcheck=1
+          - var_password_pam_difok=2
+          - var_password_pam_maxrepeat=3
+          - var_password_pam_maxsequence=3
           - var_password_pam_minclass=4
           - var_password_pam_minlen=14
-          - var_password_pam_difok=2
           - accounts_minimum_age_login_defs
           - accounts_password_all_shadowed
           - accounts_password_last_change_is_in_past
@@ -190,8 +190,8 @@ controls:
       levels:
           - low
       rules:
-          - var_password_pam_remember_control_flag=requisite_or_required
           - var_password_pam_remember=24
+          - var_password_pam_remember_control_flag=requisite_or_required
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
           - accounts_password_pam_unix_enabled

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/ac.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/ac.yml
@@ -90,8 +90,8 @@ controls:
       levels:
           - low
       rules:
-          - var_pam_wheel_group_for_su=cis
           - var_accounts_user_umask=027
+          - var_pam_wheel_group_for_su=cis
           - var_selinux_policy_name=targeted
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs
@@ -499,9 +499,9 @@ controls:
       levels:
           - low
       rules:
-          - var_accounts_passwords_pam_faillock_unlock_time=900
           - var_accounts_passwords_pam_faillock_deny=5
           - var_accounts_passwords_pam_faillock_root_unlock_time=60
+          - var_accounts_passwords_pam_faillock_unlock_time=900
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - accounts_passwords_pam_faillock_deny
@@ -529,8 +529,8 @@ controls:
       levels:
           - low
       rules:
-          - dconf_login_banner_text=cis_banners
           - dconf_login_banner_contents=cis_default
+          - dconf_login_banner_text=cis_banners
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
       status: automated
@@ -565,8 +565,8 @@ controls:
       levels:
           - moderate
       rules:
-          - var_screensaver_lock_delay=5_seconds
           - inactivity_timeout_value=15_minutes
+          - var_screensaver_lock_delay=5_seconds
           - dconf_gnome_screensaver_idle_delay
           - dconf_gnome_screensaver_lock_delay
           - dconf_gnome_screensaver_user_locks

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/au.yml
@@ -11,9 +11,11 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_admin_space_left_action=cis_rhel8
-          - var_auditd_space_left_action=cis_rhel8
           - var_audit_backlog_limit=8192
+          - var_auditd_admin_space_left_action=cis_rhel8
+          - var_auditd_disk_error_action=cis_rhel8
+          - var_auditd_disk_full_action=cis_rhel8
+          - var_auditd_space_left_action=cis_rhel8
           - aide_build_database
           - aide_periodic_cron_checking
           - audit_rules_execution_chacl
@@ -58,10 +60,11 @@ controls:
       levels:
           - low
       rules:
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
           - sshd_max_auth_tries_value=4
-          - var_multiple_time_servers=rhel
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
           - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - var_accounts_passwords_pam_faillock_dir=run
+          - var_multiple_time_servers=rhel
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -258,8 +261,8 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_max_log_file_action=keep_logs
           - var_auditd_max_log_file=8
+          - var_auditd_max_log_file_action=keep_logs
           - auditd_data_retention_max_log_file
           - auditd_data_retention_max_log_file_action
       status: automated

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/cm.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/cm.yml
@@ -6,11 +6,29 @@ controls:
           - low
       rules:
           - sshd_idle_timeout_value=5_minutes
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - var_accounts_maximum_age_login_defs=365
           - var_sshd_max_sessions=10
           - var_sshd_set_keepalive=1
           - var_sshd_set_maxstartups=10:30:60
           - var_user_initialization_files_regex=all_dotfiles
-          - var_accounts_maximum_age_login_defs=365
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - account_unique_id
@@ -61,7 +79,6 @@ controls:
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           - sysctl_net_ipv4_ip_forward
           - sysctl_net_ipv4_tcp_syncookies
-          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra
           - sysctl_net_ipv6_conf_all_accept_redirects
           - sysctl_net_ipv6_conf_all_accept_source_route
@@ -215,31 +232,31 @@ controls:
       levels:
           - low
       rules:
-          - var_sshd_set_login_grace_time=60
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
           - cis_banner_text=cis
-          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-          - var_accounts_user_umask=027
-          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-          - var_authselect_profile=sssd
-          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
           - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
           - sysctl_net_ipv4_conf_default_forwarding_value=disabled
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
           - sysctl_net_ipv4_conf_default_log_martians_value=enabled
           - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
           - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_forwarding_value=disabled
+          - var_accounts_user_umask=027
+          - var_authselect_profile=sssd
+          - var_sshd_set_login_grace_time=60
           - accounts_password_pam_modules_in_authselect_profile
           - accounts_password_pam_pwquality_password_auth
           - accounts_password_pam_pwquality_system_auth

--- a/shared/references/controls/nist_800_53_cis_reference_rhel8/ia.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel8/ia.yml
@@ -152,14 +152,14 @@ controls:
       levels:
           - low
       rules:
-          - var_password_pam_maxrepeat=3
-          - var_password_pam_minlen=14
+          - var_accounts_password_warn_age_login_defs=7
           - var_password_hashing_algorithm=cis_rhel8
           - var_password_hashing_algorithm_pam=cis_rhel8
-          - var_password_pam_maxsequence=3
-          - var_accounts_password_warn_age_login_defs=7
           - var_password_pam_dictcheck=1
           - var_password_pam_difok=2
+          - var_password_pam_maxrepeat=3
+          - var_password_pam_maxsequence=3
+          - var_password_pam_minlen=14
           - accounts_password_all_shadowed
           - accounts_password_last_change_is_in_past
           - accounts_password_pam_dictcheck
@@ -185,8 +185,8 @@ controls:
       levels:
           - low
       rules:
-          - var_password_pam_remember_control_flag=requisite_or_required
           - var_password_pam_remember=24
+          - var_password_pam_remember_control_flag=requisite_or_required
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
           - accounts_password_pam_unix_enabled

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/au.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/au.yml
@@ -11,10 +11,12 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_action_mail_acct=root
-          - var_auditd_space_left_action=cis_rhel9
-          - var_auditd_admin_space_left_action=cis_rhel9
           - var_audit_backlog_limit=8192
+          - var_auditd_action_mail_acct=root
+          - var_auditd_admin_space_left_action=cis_rhel9
+          - var_auditd_disk_error_action=cis_rhel9
+          - var_auditd_disk_full_action=cis_rhel9
+          - var_auditd_space_left_action=cis_rhel9
           - aide_build_database
           - aide_periodic_cron_checking
           - audit_rules_execution_chacl
@@ -56,10 +58,11 @@ controls:
       levels:
           - low
       rules:
+          - sshd_max_auth_tries_value=4
           - sysctl_net_ipv4_conf_all_log_martians_value=enabled
           - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - var_accounts_passwords_pam_faillock_dir=run
           - var_multiple_time_servers=rhel
-          - sshd_max_auth_tries_value=4
           - audit_rules_dac_modification_chmod
           - audit_rules_dac_modification_chown
           - audit_rules_dac_modification_fchmod
@@ -154,8 +157,8 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_disk_full_action=cis_rhel9
           - var_auditd_disk_error_action=cis_rhel9
+          - var_auditd_disk_full_action=cis_rhel9
           - auditd_data_disk_error_action
           - auditd_data_disk_full_action
       status: automated
@@ -258,8 +261,8 @@ controls:
       levels:
           - low
       rules:
-          - var_auditd_max_log_file_action=keep_logs
           - var_auditd_max_log_file=6
+          - var_auditd_max_log_file_action=keep_logs
           - auditd_data_retention_max_log_file
           - auditd_data_retention_max_log_file_action
       status: automated

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/cm.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/cm.yml
@@ -5,12 +5,30 @@ controls:
       levels:
           - low
       rules:
+          - sshd_idle_timeout_value=5_minutes
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - var_accounts_maximum_age_login_defs=365
           - var_sshd_max_sessions=10
-          - var_user_initialization_files_regex=all_dotfiles
           - var_sshd_set_keepalive=1
           - var_sshd_set_maxstartups=10:30:60
-          - sshd_idle_timeout_value=5_minutes
-          - var_accounts_maximum_age_login_defs=365
+          - var_user_initialization_files_regex=all_dotfiles
           - account_password_pam_faillock_password_auth
           - account_password_pam_faillock_system_auth
           - account_unique_id
@@ -61,7 +79,6 @@ controls:
           - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
           - sysctl_net_ipv4_ip_forward
           - sysctl_net_ipv4_tcp_syncookies
-          - sysctl_net_ipv4_tcp_syncookies_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra
           - sysctl_net_ipv6_conf_all_accept_redirects
           - sysctl_net_ipv6_conf_all_accept_source_route
@@ -215,29 +232,29 @@ controls:
       levels:
           - low
       rules:
-          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-          - var_sshd_set_login_grace_time=60
-          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
           - cis_banner_text=cis
-          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-          - var_accounts_user_umask=027
-          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-          - var_authselect_profile=sssd
-          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
           - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
           - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
           - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
           - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - var_accounts_user_umask=027
+          - var_authselect_profile=sssd
+          - var_sshd_set_login_grace_time=60
           - accounts_password_pam_modules_in_authselect_profile
           - accounts_umask_etc_bashrc
           - accounts_umask_etc_login_defs

--- a/shared/references/controls/nist_800_53_cis_reference_rhel9/ia.yml
+++ b/shared/references/controls/nist_800_53_cis_reference_rhel9/ia.yml
@@ -152,16 +152,16 @@ controls:
       levels:
           - low
       rules:
-          - var_password_pam_minlen=14
-          - var_password_pam_dictcheck=1
-          - var_password_hashing_algorithm_pam=sha512
+          - var_accounts_minimum_age_login_defs=1
           - var_accounts_password_warn_age_login_defs=7
           - var_password_hashing_algorithm=SHA512
+          - var_password_hashing_algorithm_pam=sha512
+          - var_password_pam_dictcheck=1
+          - var_password_pam_difok=2
           - var_password_pam_maxrepeat=3
           - var_password_pam_maxsequence=3
           - var_password_pam_minclass=4
-          - var_password_pam_difok=2
-          - var_accounts_minimum_age_login_defs=1
+          - var_password_pam_minlen=14
           - accounts_minimum_age_login_defs
           - accounts_password_all_shadowed
           - accounts_password_last_change_is_in_past
@@ -189,8 +189,8 @@ controls:
       levels:
           - low
       rules:
-          - var_password_pam_remember_control_flag=requisite_or_required
           - var_password_pam_remember=24
+          - var_password_pam_remember_control_flag=requisite_or_required
           - accounts_password_pam_pwhistory_remember_password_auth
           - accounts_password_pam_pwhistory_remember_system_auth
           - accounts_password_pam_unix_no_remember

--- a/utils/nist_sync/sync_nist_split.py
+++ b/utils/nist_sync/sync_nist_split.py
@@ -466,22 +466,18 @@ class NISTSplitSync:
                 # Filter rules: only include if in target product's CIS control file
                 filtered_rules = [r for r in mapped_rules if r in all_cis_items]
 
-                # Filter variables: only include the specific assignment for target product.
-                # mapped_vars may contain full assignments as keys (e.g. 'var_x=value')
-                # because cis_nist_mappings.json uses full assignments in the variables
-                # section.  all_cis_items_with_values is keyed by the stripped name
-                # ('var_x'), so we must strip before looking up.
-                filtered_vars = []
+                # Filter variables: collect into a set first to deduplicate, then sort.
+                # mapped_vars may contain both bare names ('var_x') and full assignments
+                # ('var_x=value') as separate keys; both strip to the same name, so
+                # iterating and calling extend() would add the same assignment multiple times.
+                var_assignments = set()
                 for var_name in mapped_vars:
                     stripped_name = var_name.split('=')[0] if '=' in var_name else var_name
                     if stripped_name in all_cis_items_with_values:
-                        # Get all assignments for this variable in the target product
-                        assignments = all_cis_items_with_values[stripped_name]
-                        # Add all assignments (should only be one per product)
-                        filtered_vars.extend(sorted(assignments))
+                        var_assignments.update(all_cis_items_with_values[stripped_name])
 
                 rules = sorted(filtered_rules)
-                vars = filtered_vars
+                vars = sorted(var_assignments)
             else:
                 # Legacy: include all rules/vars
                 rules = sorted(mapped_rules)


### PR DESCRIPTION
#### Description:

- This is a continuation of: https://github.com/ComplianceAsCode/content/pull/14785

- Fix duplicate variable entries and non-deterministic ordering in `utils/nist_sync/sync_nist_split.py`. When `cis_nist_mappings.json` contains both a bare key (`var_x`) and a full assignment (`var_x=value`) for the same variable, both strip to the same name and `extend()` would add the same assignment multiple times. Fixed by collecting into a `set` before sorting, ensuring stable, deduplicated output on every run.
- Add `rsyslog_filecreatemode` to the `ac-3` block in `products/rhel9/controls/nist_800_53/ac.yml` and `products/rhel10/controls/nist_800_53/ac.yml`. The rule was present in `cis_nist_mappings.json` but missing from the human-maintained product control files, causing a non-empty `CIS - CIS_NIST` diff.
- Regenerate `shared/references/controls/nist_800_53_cis_reference_{rhel8,rhel9,rhel10}/` with the fixed script to reflect both the deduplication fix and the CIS→NIST mapping additions from fab8d571a6.

#### Rationale:

- The duplicate variable bug caused the generated NIST reference files to contain repeated entries (e.g. `var_auditd_space_left_action=cis_rhel9` appearing 2–3 times in the same control block), making diffs noisy and the output non-idempotent across runs.
- The missing `rsyslog_filecreatemode` in the product control files caused the CIS-NIST workflow to report that CIS-NIST did not fully cover CIS for rhel9 and rhel10.

#### Review Hints:

- All three products (rhel8, rhel9, rhel10) pass the CIS vs CIS-NIST profile comparison with zero differences after this fix. To verify locally:
  ```bash
  ./build_product rhel8 rhel9 rhel10 --datastream-only
  cd utils/nist_sync && ./generate_cis_nist_workflow.sh --products "rhel8 rhel9 rhel10" --skip-build
  ```
- The reference file changes under `shared/references/controls/` are deduplication + sort order fixes plus the `rsyslog_filecreatemode` additions; no rules were removed.
- The `sync_nist_split.py` fix is in `generate_controls()` around line 474: replaces `extend()` on a loop over a `set` with `set.update()` + `sorted()`.
