### PR TITLE
CMP-4340: Consolidate KubeletConfig remediations for eviction threshold rules

### DIFF
--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/kubernetes/shared.yml
@@ -1,5 +1,9 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionHard',parameter='imagefs.available', value='var_kubelet_evictionhard_imagefs_available') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionHard:
+      imagefs.available: {{.var_kubelet_evictionhard_imagefs_available}}
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/kubernetes/shared.yml
@@ -1,5 +1,9 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionHard',parameter='imagefs.inodesFree', value='var_kubelet_evictionhard_imagefs_inodesfree') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionHard:
+      imagefs.inodesFree: {{.var_kubelet_evictionhard_imagefs_inodesfree}}
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/kubernetes/shared.yml
@@ -1,5 +1,9 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionHard',parameter='memory.available', value='var_kubelet_evictionhard_memory_available') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionHard:
+      memory.available: {{.var_kubelet_evictionhard_memory_available}}
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/kubernetes/shared.yml
@@ -1,5 +1,9 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionHard',parameter='nodefs.available', value='var_kubelet_evictionhard_nodefs_available') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionHard:
+      nodefs.available: {{.var_kubelet_evictionhard_nodefs_available}}
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/kubernetes/shared.yml
@@ -1,5 +1,9 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionHard',parameter='nodefs.inodesFree', value='var_kubelet_evictionhard_nodefs_inodesfree') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionHard:
+      nodefs.inodesFree: {{.var_kubelet_evictionhard_nodefs_inodesfree}}
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/kubernetes/shared.yml
@@ -1,7 +1,11 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionSoft',parameter='imagefs.available', value='var_kubelet_evictionsoft_imagefs_available') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig.evictionSoftGracePeriod',parameter='imagefs.available', value='"1m30s"') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionSoft:
+      imagefs.available: {{.var_kubelet_evictionsoft_imagefs_available}}
+    evictionSoftGracePeriod:
+      imagefs.available: "1m30s"
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/kubernetes/shared.yml
@@ -1,7 +1,11 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionSoft',parameter='imagefs.inodesFree', value='var_kubelet_evictionsoft_imagefs_inodesfree') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig.evictionSoftGracePeriod',parameter='imagefs.inodesFree', value='"1m30s"') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionSoft:
+      imagefs.inodesFree: {{.var_kubelet_evictionsoft_imagefs_inodesfree}}
+    evictionSoftGracePeriod:
+      imagefs.inodesFree: "1m30s"
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/kubernetes/shared.yml
@@ -1,7 +1,11 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionSoft',parameter='memory.available', value='var_kubelet_evictionsoft_memory_available') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig.evictionSoftGracePeriod',parameter='memory.available', value='"1m30s"') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionSoft:
+      memory.available: {{.var_kubelet_evictionsoft_memory_available}}
+    evictionSoftGracePeriod:
+      memory.available: "1m30s"
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/kubernetes/shared.yml
@@ -1,7 +1,11 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionSoft',parameter='nodefs.available', value='var_kubelet_evictionsoft_nodefs_available') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig.evictionSoftGracePeriod',parameter='nodefs.available', value='"1m30s"') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionSoft:
+      nodefs.available: {{.var_kubelet_evictionsoft_nodefs_available}}
+    evictionSoftGracePeriod:
+      nodefs.available: "1m30s"
+    evictionPressureTransitionPeriod: 0s

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -72,4 +72,6 @@ template:
     filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['nodefs.available']"
     check_existence: "all_exist"
-    xccdf_variable: var_event_record_qps
+    values:
+    - value: "^.+$"
+      operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/kubernetes/shared.yml
@@ -1,7 +1,11 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config(path='kubeletConfig.evictionSoft',parameter='nodefs.inodesFree', value='var_kubelet_evictionsoft_nodefs_inodesfree') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig.evictionSoftGracePeriod',parameter='nodefs.inodesFree', value='"1m30s"') }}}
----
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='evictionPressureTransitionPeriod', value='0s') }}}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+spec:
+  kubeletConfig:
+    evictionSoft:
+      nodefs.inodesFree: {{.var_kubelet_evictionsoft_nodefs_inodesfree}}
+    evictionSoftGracePeriod:
+      nodefs.inodesFree: "1m30s"
+    evictionPressureTransitionPeriod: 0s


### PR DESCRIPTION
#### Description:

The fix consolidates each rule's multiple KubeletConfig objects into a single object in all 10 `kubernetes/shared.yml` files under `applications/openshift/kubelet/kubelet_eviction_thresholds_set_*/`. This produces 1 `ComplianceRemediation` per rule instead of 2-3, resulting in a single MCO rollout that completes successfully. Validated on OCP 4.22 CI / RHEL 10 with all 10 soft eviction remediations applied to both master and worker nodes -- all 6 nodes survived and all rules pass after rescan. An additional copy-paste bug was fixed in `kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml` where `xccdf_variable: var_event_record_qps` (from a different rule) was replaced with the correct values block.

