### PR TITLE
change to GVariant format

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/bash/shared.sh
@@ -5,5 +5,9 @@
 {{{ bash_enable_dconf_user_profile(profile="gdm", database="gdm") }}}
 {{% endif %}}
 
+{{% if 'ubuntu' in product %}}
+{{{ bash_dconf_settings("org/gnome/settings-daemon/plugins/media-keys", "logout", "@as []", "local.d", "00-security-settings", rule_id=rule_id) }}}
+{{%- else %}}
 {{{ bash_dconf_settings("org/gnome/settings-daemon/plugins/media-keys", "logout", "['']", "local.d", "00-security-settings", rule_id=rule_id) }}}
+{{%- endif %}}
 {{{ bash_dconf_lock("org/gnome/settings-daemon/plugins/media-keys", "logout", "local.d", "00-security-settings-lock") }}}

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
@@ -20,7 +20,7 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys\]([^\n]*\n+)+?logout[\s]*=[\s]*\[''\]$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys\]([^\n]*\n+)+?logout[\s]*=[\s]*(\[''\]|@as[\s]*\[\])$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- change to GVariant format

#### Rationale:

- Both stig ubuntu2404 v1r5 and stig ubuntu2204 v2r8 require such value
