### PR TITLE
Remove DoD-specific verbiage from rule.yml files

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -27,7 +27,7 @@ identifiers:
     cce@sle15: CCE-85819-1
     cce@sle16: CCE-95748-0
     cce@slmicro5: CCE-94098-1
-    cce@slmicro6: CCE-95095-6 
+    cce@slmicro6: CCE-95095-6
 
 references:
     cis-csc: 1,12,13,14,15,16,2,3,5,6,7,8,9
@@ -58,7 +58,7 @@ vuldiscussion: |-
 
     The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
 
-    DoD has defined the list of events for which the operating system will provide an audit record generation capability as the following:
+    The list of events for which the operating system must provide an audit record generation capability includes the following:
 
     1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -47,7 +47,7 @@ vuldiscussion: |-
 
     The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
 
-    DoD has defined the list of events for which the operating system will provide an audit record generation capability as the following:
+    The list of events for which the operating system must provide an audit record generation capability includes the following:
 
     1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -57,7 +57,7 @@ vuldiscussion: |-
 
     The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
 
-    DoD has defined the list of events for which the operating system will provide an audit record generation capability as the following:
+    The list of events for which the operating system must provide an audit record generation capability includes the following:
 
     1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_antivirus_scan_uploads/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_antivirus_scan_uploads/rule.yml
@@ -11,12 +11,12 @@ rationale: |-
     Remote web authors should not be able to upload files to the Document Root
     directory structure without virus checking and checking for malicious or mobile
     code. A remote web user, whose agency has a Memorandum of Agreement (MOA) with
-    the hosting agency and has submitted a DoD form 2875 (System Authorization
-    Access Request (SAAR)) or an equivalent document, will be allowed to post files
-    to a temporary location on the server. All posted files to this temporary
-    location will be scanned for viruses and content checked for malicious or mobile
-    code. Only files free of viruses and malicious or mobile code will be posted to
-    the appropriate DocumentRoot directory.
+    the hosting agency and has submitted a System Authorization Access Request
+    (SAAR) or an equivalent document, will be allowed to post files to a temporary
+    location on the server. All posted files to this temporary location will be
+    scanned for viruses and content checked for malicious or mobile code. Only
+    files free of viruses and malicious or mobile code will be posted to the
+    appropriate DocumentRoot directory.
 
 severity: medium
 

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -43,12 +43,11 @@ ocil: |-
 
 warnings:
     - general: |-
-        In DoD environments, supplemental intrusion detection and antivirus tools,
-        such as the McAfee Host-based Security System, are available to integrate with
-        existing infrastructure. Per DISA guidance, when these supplemental tools interfere
-        with proper functioning of SELinux, SELinux takes precedence. Should further
-        clarification be required, DISA contact information is published publicly at
-        https://www.cyber.mil/stigs/
+        In some environments, supplemental intrusion detection and antivirus tools
+        are deployed to integrate with existing infrastructure. When these
+        supplemental tools interfere with proper functioning of SELinux, SELinux
+        should take precedence. Consult your organization's security guidance for
+        further clarification.
 
 platform: system_with_kernel
 


### PR DESCRIPTION
#### Description:
Several rule.yml files described generic security requirements using DoD-specific phrasing, making the content appear policy-specific even when the underlying requirement applies to any organization. This PR removes that DoD-specific framing from five files.

#### Rationale:
Replace the DoD-framed audit event capability description in three SELinux audit rules (semanage, setfiles, setsebool) with generic language. Remove the named DoD form reference in httpd_antivirus_scan_uploads, and remove the named product and government contact URL from the install_hids warning block. Also fixes a pre-existing trailing whitespace on line 30 of audit_rules_execution_semanage/rule.yml, found during lint verification of the same file.

Updates #8709 (does not fully close it out; the issue covers 119 occurrences across 37 files, and this PR addresses 5 of them).

mcafee_security_software/group.yml was reviewed but excluded from this PR. Its DoD-specific content is the entire substance of the rule, not incidental wording, so generalizing it would misrepresent the rule's purpose.

#### Review Hints:
The five files changed are independent of each other; each can be reviewed individually. The trailing-whitespace fix in audit_rules_execution_semanage/rule.yml is unrelated to the DoD wording change and was included since the file was already being touched in this PR.


### Notes:
This PR covers 5 of the 119 occurrences as a first pass. I'm planning to continue with the remaining prose-only files in a follow-up PR once this one gets reviewed, to keep each PR small and easy to verify. Will hold off on the XCCDF-variable and banner-text occurrences until I can confirm the right approach with you first.