### PR TITLE
Fix import_disa_stig.py script

### DIFF
--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -487,7 +487,7 @@ This script only updates STIG items that only have one rule assigned to them.
 
 To execute:
 ```bash
-$ ./utils/import_disa_stig.py --product rhel9 --control stig_rhel9 shared/references/disa-stig-rhel9-v1r2-xccdf-manual.xml
+$ ./utils/import_disa_stig.py --product rhel9 --control stig_rhel9 --output-file-name rhel9.yml shared/references/disa-stig-rhel9-v1r2-xccdf-manual.xml
 ```
 
 ## Profiling the Build System

--- a/utils/import_disa_stig.py
+++ b/utils/import_disa_stig.py
@@ -2,12 +2,10 @@
 
 import argparse
 import os
-import sys
 
 import ssg.build_yaml
 import ssg.controls
 import ssg.environment
-import ssg.products
 import ssg.build_stig
 from utils.srg_utils import get_rule_dir_json, fix_changed_text
 from utils.srg_utils.yaml import update_row
@@ -62,10 +60,10 @@ def _get_controls(control_name, ssg_root, env_yaml):
     return controls
 
 
-def _get_rule_obj(control, rule_dir_json):
-    rule_id = list(filter(lambda x: "=" not in x, control.rules))[0]
-    rule_obj = rule_dir_json[rule_id]
-    return rule_obj
+def _get_rule_objs(control, rule_dir_json):
+    for rule_id in filter(lambda x: "=" not in x, control.rules):
+        rule_obj = rule_dir_json[rule_id]
+        yield rule_obj
 
 
 def _get_rule(env_yaml, rule_obj):
@@ -75,14 +73,39 @@ def _get_rule(env_yaml, rule_obj):
     return rule
 
 
-def _control_has_exactly_one_rule(control) -> bool:
-    if control is None:
-        return False
-    if control.rules is None:
-        return False
-    # control.rules contains not only rules but also variable selections
-    rules = list(filter(lambda x: "=" not in x, control.rules))
-    return len(rules) == 1
+def update_rule(rule_obj, env_yaml, stig_rule, changed_name, output_filename):
+    rule = _get_rule(env_yaml, rule_obj)
+    stig_srg_requirement = stig_rule['title']
+    rule_srg_requirement = rule.policy_specific_content.get('srg_requirement')
+    if rule_srg_requirement != stig_srg_requirement:
+        changed_fixtext = fix_changed_text(stig_srg_requirement, changed_name)
+        update_row(changed_fixtext, stig_srg_requirement, rule_obj, 'srg_requirement',
+                output_filename)
+
+    stig_fix_text = stig_rule['fixtext']
+    rule_fixtext = rule.policy_specific_content.get('fixtext')
+    if rule_fixtext != stig_fix_text:
+        changed_fixtext = fix_changed_text(stig_fix_text, changed_name)
+        changed_fixtext = changed_fixtext.replace(f'auid>={env_yaml["uid_min"]}',
+                                                'auid&gt;={{{ uid_min }}}')
+        update_row(changed_fixtext, rule_fixtext, rule_obj, 'fixtext',
+                output_filename)
+
+    stig_checktext = stig_rule['check']
+    rule_checktext = rule.policy_specific_content.get('checkfix')
+    if rule_checktext != stig_checktext:
+        changed_checktext = fix_changed_text(stig_checktext, changed_name)
+        changed_checktext = changed_checktext.replace(f'auid>={env_yaml["uid_min"]}',
+                                                    'auid&gt;={{{ uid_min }}}')
+        update_row(changed_checktext, rule_checktext, rule_obj, 'checktext',
+                output_filename)
+
+    stig_vuln_discussion = stig_rule['vuln_discussion']
+    rule_vuln_discussion = rule.policy_specific_content.get('vuldiscussion')
+    if stig_vuln_discussion != rule_vuln_discussion:
+        changed_vuln_discussion = fix_changed_text(stig_vuln_discussion, changed_name)
+        update_row(changed_vuln_discussion, rule_vuln_discussion, rule_obj,
+                'vuldiscussion', output_filename)
 
 
 def main() -> int:
@@ -97,45 +120,11 @@ def main() -> int:
 
     for stig_id, stig_rule in srgs.items():
         control = controls[stig_id]
-        if not _control_has_exactly_one_rule(control):
-            print(f"Warning: Unable to update {stig_id} since it doesn't have exactly one "
-                  f"rule.", file=sys.stderr)
+        if control is None or control.rules is None:
             continue
+        for rule_obj in _get_rule_objs(control, rule_dir_json):
+            update_rule(rule_obj, env_yaml, stig_rule, changed_name, output_filename)
 
-        rule_obj = _get_rule_obj(control, rule_dir_json)
-        rule = _get_rule(env_yaml, rule_obj)
-
-        stig_srg_requirement = stig_rule['title']
-        rule_srg_requirement = rule.policy_specific_content.get('srg_requirement')
-        if rule_srg_requirement != stig_srg_requirement:
-            changed_fixtext = fix_changed_text(stig_srg_requirement, changed_name)
-            update_row(changed_fixtext, stig_srg_requirement, rule_obj, 'srg_requirement',
-                       output_filename)
-
-        stig_fix_text = stig_rule['fixtext']
-        rule_fixtext = rule.policy_specific_content.get('fixtext')
-        if rule_fixtext != stig_fix_text:
-            changed_fixtext = fix_changed_text(stig_fix_text, changed_name)
-            changed_fixtext = changed_fixtext.replace(f'auid>={env_yaml["uid_min"]}',
-                                                      'auid&gt;={{{ uid_min }}}')
-            update_row(changed_fixtext, rule_fixtext, rule_obj, 'fixtext',
-                       output_filename)
-
-        stig_checktext = stig_rule['check']
-        rule_checktext = rule.policy_specific_content.get('checkfix')
-        if rule_checktext != stig_checktext:
-            changed_checktext = fix_changed_text(stig_checktext, changed_name)
-            changed_checktext = changed_checktext.replace(f'auid>={env_yaml["uid_min"]}',
-                                                          'auid&gt;={{{ uid_min }}}')
-            update_row(changed_checktext, rule_checktext, rule_obj, 'checktext',
-                       output_filename)
-
-        stig_vuln_discussion = stig_rule['vuln_discussion']
-        rule_vuln_discussion = rule.policy_specific_content.get('vuldiscussion')
-        if stig_vuln_discussion != rule_vuln_discussion:
-            changed_vuln_discussion = fix_changed_text(stig_vuln_discussion, changed_name)
-            update_row(changed_vuln_discussion, rule_vuln_discussion, rule_obj,
-                       'vuldiscussion', output_filename)
 
     return 0
 

--- a/utils/import_disa_stig.py
+++ b/utils/import_disa_stig.py
@@ -63,7 +63,7 @@ def _get_controls(control_name, ssg_root, env_yaml):
 
 
 def _get_rule_obj(control, rule_dir_json):
-    rule_id = control.rules[0]
+    rule_id = list(filter(lambda x: "=" not in x, control.rules))[0]
     rule_obj = rule_dir_json[rule_id]
     return rule_obj
 
@@ -73,6 +73,16 @@ def _get_rule(env_yaml, rule_obj):
     rule = ssg.build_yaml.Rule.from_yaml(rule_path, env_yaml)
     rule.load_policy_specific_content(rule_path, env_yaml)
     return rule
+
+
+def _control_has_exactly_one_rule(control) -> bool:
+    if control is None:
+        return False
+    if control.rules is None:
+        return False
+    # control.rules contains not only rules but also variable selections
+    rules = list(filter(lambda x: "=" not in x, control.rules))
+    return len(rules) == 1
 
 
 def main() -> int:
@@ -87,7 +97,7 @@ def main() -> int:
 
     for stig_id, stig_rule in srgs.items():
         control = controls[stig_id]
-        if control is None or control.rules is None or len(control.rules) != 1:
+        if not _control_has_exactly_one_rule(control):
             print(f"Warning: Unable to update {stig_id} since it doesn't have exactly one "
                   f"rule.", file=sys.stderr)
             continue

--- a/utils/import_disa_stig.py
+++ b/utils/import_disa_stig.py
@@ -36,6 +36,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument('--changed-name', '-n', type=str, action="store",
                         help="The name that DISA uses for the product. Defaults to RHEL 9",
                         default="RHEL 9")
+    parser.add_argument('-o', '--output-file-name', type=str, action="store",
+                        default="shared.yml",
+                        help="Output filename for policy-specific content "
+                        "(e.g. 'rhel10.yml'). Defaults to 'shared.yml'")
     return parser.parse_args()
 
 
@@ -75,6 +79,7 @@ def main() -> int:
     args = _parse_args()
     build_config_yaml = args.build_config_yaml
     changed_name = args.changed_name
+    output_filename = args.output_file_name
     env_yaml = _get_env_yaml(args.root, args.product, build_config_yaml)
     controls = _get_controls(args.control, args.root, env_yaml)
     rule_dir_json = get_rule_dir_json(args.json)
@@ -94,7 +99,8 @@ def main() -> int:
         rule_srg_requirement = rule.policy_specific_content.get('srg_requirement')
         if rule_srg_requirement != stig_srg_requirement:
             changed_fixtext = fix_changed_text(stig_srg_requirement, changed_name)
-            update_row(changed_fixtext, stig_srg_requirement, rule_obj, 'srg_requirement')
+            update_row(changed_fixtext, stig_srg_requirement, rule_obj, 'srg_requirement',
+                       output_filename)
 
         stig_fix_text = stig_rule['fixtext']
         rule_fixtext = rule.policy_specific_content.get('fixtext')
@@ -102,7 +108,8 @@ def main() -> int:
             changed_fixtext = fix_changed_text(stig_fix_text, changed_name)
             changed_fixtext = changed_fixtext.replace(f'auid>={env_yaml["uid_min"]}',
                                                       'auid&gt;={{{ uid_min }}}')
-            update_row(changed_fixtext, rule_fixtext, rule_obj, 'fixtext')
+            update_row(changed_fixtext, rule_fixtext, rule_obj, 'fixtext',
+                       output_filename)
 
         stig_checktext = stig_rule['check']
         rule_checktext = rule.policy_specific_content.get('checkfix')
@@ -110,14 +117,15 @@ def main() -> int:
             changed_checktext = fix_changed_text(stig_checktext, changed_name)
             changed_checktext = changed_checktext.replace(f'auid>={env_yaml["uid_min"]}',
                                                           'auid&gt;={{{ uid_min }}}')
-            update_row(changed_checktext, rule_checktext, rule_obj, 'checktext')
+            update_row(changed_checktext, rule_checktext, rule_obj, 'checktext',
+                       output_filename)
 
         stig_vuln_discussion = stig_rule['vuln_discussion']
         rule_vuln_discussion = rule.policy_specific_content.get('vuldiscussion')
         if stig_vuln_discussion != rule_vuln_discussion:
             changed_vuln_discussion = fix_changed_text(stig_vuln_discussion, changed_name)
             update_row(changed_vuln_discussion, rule_vuln_discussion, rule_obj,
-                       'vuldiscussion')
+                       'vuldiscussion', output_filename)
 
     return 0
 

--- a/utils/import_disa_stig.py
+++ b/utils/import_disa_stig.py
@@ -48,7 +48,11 @@ def _get_env_yaml(ssg_root: str, product: str, build_config_yaml: str) -> dict:
 
 
 def _get_controls(control_name, ssg_root, env_yaml):
-    control_manager = ssg.controls.ControlsManager([os.path.join(ssg_root, "controls")], env_yaml)
+    controls_dirs = [os.path.join(ssg_root, "controls")]
+    product_controls_dir = os.path.join(env_yaml['product_dir'], 'controls')
+    if os.path.exists(product_controls_dir):
+        controls_dirs.append(product_controls_dir)
+    control_manager = ssg.controls.ControlsManager(controls_dirs, env_yaml)
     control_manager.load()
     controls = control_manager.get_all_controls_dict(control_name)
     return controls

--- a/utils/srg_utils/yaml.py
+++ b/utils/srg_utils/yaml.py
@@ -15,8 +15,9 @@ def add_replacement_to_result(replacement, result):
     return result
 
 
-def replace_yaml_section(section: str, replacement: str, rule_dir: dict) -> None:
-    path = create_output(rule_dir['dir'])
+def replace_yaml_section(section: str, replacement: str, rule_dir: dict,
+                         output_filename: str = "shared.yml") -> None:
+    path = create_output(rule_dir['dir'], output_filename)
 
     lines = read_file_list(path)
     replacement = replacement.replace('<', '&lt;').replace('>', '&gt;')
@@ -59,17 +60,18 @@ def replace_yaml_key(key: str, replacement: str, rule_dir: dict) -> None:
             f.write(line.rstrip())
 
 
-def update_row(changed: str, current: str, rule_dir_json: dict, section: str) -> None:
+def update_row(changed: str, current: str, rule_dir_json: dict, section: str,
+               output_filename: str = "shared.yml") -> None:
     if changed != current and changed:
-        replace_yaml_section(section, changed, rule_dir_json)
+        replace_yaml_section(section, changed, rule_dir_json, output_filename)
 
 
-def create_output(rule_dir: str) -> str:
+def create_output(rule_dir: str, output_filename: str = "shared.yml") -> str:
     path_dir_parent = os.path.join(rule_dir, "policy")
     mkdir_p(path_dir_parent)
     path_dir = os.path.join(path_dir_parent, "stig")
     mkdir_p(path_dir)
-    path = os.path.join(path_dir, 'shared.yml')
+    path = os.path.join(path_dir, output_filename)
     Path(path).touch()
     return path
 


### PR DESCRIPTION
#### Description:

Multiple fixes in `import_disa_stig.py` script.

For more details read commit messages of all commits.

#### Rationale:

This change will allow us to use the script import data from manual XCCDF file from DISA STIG for RHEL 10.

#### Review Hints:

```
python utils/import_disa_stig.py -c stig_rhel10 -p rhel10 -n "RHEL 10" -o rhel10.yml shared/references/disa-stig-rhel10-v1r1-xccdf-manual.xml
```
