### PR TITLE
CMP-4340: fix copy-paste variable reference in soft_nodefs_available rule

### DIFF
--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -72,4 +72,6 @@ template:
     filepath: '/var/run/compliance-operator/kubeletconfig/openscap-kubeletconfig'
     yamlpath: ".kubeletconfig.evictionSoft['nodefs.available']"
     check_existence: "all_exist"
-    xccdf_variable: var_event_record_qps
+    values:
+      - value: "^.+$"
+        operation: "pattern match"


### PR DESCRIPTION
#### Description:

- copy-paste bug was fixed in `kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml` where `xccdf_variable: var_event_record_qps` (from a different rule) was replaced with the correct values block.

- This was found while investigating CMP-4340 (kubelet eviction threshold remediation failures). During end-to-end testing of the scanner emptyDir fix ([ComplianceAsCode/compliance-operator#1255](https://github.com/ComplianceAsCode/compliance-operator/pull/1255/)), 4 of 5 soft eviction rules passed correctly on both initial scan and rescan, but `soft_nodefs_available` consistently failed despite the kubelet having the correct value. ARF analysis confirmed the scanner read `500Mi` from the kubelet config but the OVAL comparison against `var_event_record_qps` (value `0`) caused the false failure.


#### Fix:
Replace `xccdf_variable: var_event_record_qps` with the correct `values` block using pattern match, consistent with all 9 other eviction threshold rules.
