### PR TITLE
Add rules from RHEL 10 STIG to SRG GPOS

### DIFF
--- a/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
+++ b/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
@@ -12,4 +12,7 @@ controls:
             - var_password_hashing_algorithm_pam=sha512
             - set_password_hashing_min_rounds_logindefs
             - var_password_pam_unix_rounds=100000
+            - accounts_password_all_shadowed_sha512
+            - accounts_password_pam_unix_rounds_password_auth
+            - accounts_password_pam_unix_rounds_system_auth
         status: automated

--- a/controls/srg_gpos/SRG-OS-000080-GPOS-00048.yml
+++ b/controls/srg_gpos/SRG-OS-000080-GPOS-00048.yml
@@ -13,4 +13,6 @@ controls:
             - file_groupownership_audit_configuration
             - file_ownership_audit_configuration
             - file_permissions_audit_configuration
+            - require_emergency_target_auth
+            - mount_option_boot_efi_nosuid
         status: automated

--- a/controls/srg_gpos/SRG-OS-000132-GPOS-00067.yml
+++ b/controls/srg_gpos/SRG-OS-000132-GPOS-00067.yml
@@ -25,3 +25,5 @@ controls:
             {{{ full_name }}} management functionality must be executed by the administrator user, which is only accessible through the sudo command (with a proper authentication request). The sudo manpage has more information.
         status_justification:
             The UNIX permissions construct separates user and privileged user (the {{{ full_name }}} operating system accounts) access.
+        rules:
+            - sysctl_kernel_kptr_restrict

--- a/controls/srg_gpos/SRG-OS-000366-GPOS-00153.yml
+++ b/controls/srg_gpos/SRG-OS-000366-GPOS-00153.yml
@@ -25,5 +25,6 @@ controls:
             {{% if 'almalinux' in product %}}
             - ensure_almalinux_gpgkey_installed
             {{% endif %}}
+            - enable_gpgcheck_for_all_repositories
 
         status: automated

--- a/controls/srg_gpos/SRG-OS-000396-GPOS-00176.yml
+++ b/controls/srg_gpos/SRG-OS-000396-GPOS-00176.yml
@@ -12,4 +12,5 @@ controls:
             - sysctl_crypto_fips_enabled
             - enable_fips_mode
             - fips_crypto_subpolicy
+            - crypto_policy_not_overridden
         status: automated

--- a/controls/srg_gpos/SRG-OS-000420-GPOS-00186.yml
+++ b/controls/srg_gpos/SRG-OS-000420-GPOS-00186.yml
@@ -10,4 +10,6 @@ controls:
             - sysctl_net_ipv4_tcp_syncookies
             - sysctl_net_ipv4_tcp_invalid_ratelimit_value=five_hundred
             - firewalld-backend
+            - sysctl_net_ipv4_conf_all_log_martians
+            - sysctl_net_ipv4_conf_default_log_martians
         status: automated

--- a/docs/manual/developer/08_content_tests.md
+++ b/docs/manual/developer/08_content_tests.md
@@ -99,3 +99,8 @@ You should replace `0.1.76` with the latest release of the project.
 1. `./build_product rhel10 rhel8 rhel9`
 1. `cd build`
 1. `ctest -R  rule-removal --output-on-failure`
+
+## STIG rules in SRG GPOS
+
+The test `test_stig_rules_in_srg_gpos.py` ensures that all rules selected in RHEL 10 STIG profile are also selected in SRG GPOS control files.
+The test prevents data inconsistencies and verifies that the STIG profile remains based on SRG GPOS controls.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -401,3 +401,11 @@ add_test(
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${Python_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/import_srg_spreadsheet.py" "-h"
 )
 endif()
+
+if(SSG_PRODUCT_RHEL10)
+    add_test(
+        NAME "stig-rules-srg-gpos"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_stig_rules_in_srg_gpos.py"  --root "${CMAKE_SOURCE_DIR}" --product "rhel10"
+    )
+    set_tests_properties("stig-rules-srg-gpos" PROPERTIES LABELS quick)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -408,4 +408,5 @@ if(SSG_PRODUCT_RHEL10)
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_stig_rules_in_srg_gpos.py"  --root "${CMAKE_SOURCE_DIR}" --product "rhel10"
     )
     set_tests_properties("stig-rules-srg-gpos" PROPERTIES LABELS quick)
+    mypy_test("tests/test_stig_rules_in_srg_gpos.py" "normal")
 endif()

--- a/tests/test_stig_rules_in_srg_gpos.py
+++ b/tests/test_stig_rules_in_srg_gpos.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+import sys
+
+import ssg.environment
+import ssg.controls
+
+
+SSG_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _is_rule(selection: str) -> bool:
+    return "=" not in selection
+
+
+def _get_env_yaml(ssg_root: Path, product: str) -> dict:
+    return ssg.environment.open_environment(
+        str(ssg_root / "build" / "build_config.yml"),
+        str(ssg_root / "products" / product / "product.yml"),
+        str(ssg_root / "product_properties"))
+
+
+def get_rules_in_srg_gpos(ssg_root: Path, product: str) -> set:
+    env_yaml = _get_env_yaml(ssg_root, product)
+    mgr = ssg.controls.ControlsManager(
+        [str(ssg_root / "controls")], env_yaml)
+    mgr.load()
+    return {
+        rule
+        for control in mgr.get_all_controls("srg_gpos")
+        for rule in control.rules
+        if _is_rule(rule)
+    }
+
+
+def get_rules_in_stig_profile(ssg_root: Path, product: str) -> set:
+    profile_path = (
+        ssg_root / "tests" / "data" / "profile_stability" / product
+        / "stig.profile")
+    lines = profile_path.read_text().splitlines()
+    return {line.strip() for line in lines if _is_rule(line.strip())}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r", "--root", type=Path, default=SSG_ROOT,
+        help="Path to the root of the content repo")
+    parser.add_argument(
+        "-p", "--product", required=True, type=str,
+        help="Product ID")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    rules_in_stig_profile = get_rules_in_stig_profile(args.root, args.product)
+    rules_in_srg_gpos = get_rules_in_srg_gpos(args.root, args.product)
+    missing = rules_in_stig_profile - rules_in_srg_gpos
+    if missing:
+        print("These rules are part of profile but aren't part of SRG GPOS:")
+        for rule in sorted(missing):
+            print(rule)
+        sys.exit(1)


### PR DESCRIPTION
#### Description:

Some rules are part of the RHEL 10 STIG control file and profile but aren't part of SRG GPOS. This PR adds these rules to SRGs according to `shared/references/disa-stig-rhel10-v1r1-xccdf-manual.xml`.

Also, add a small CTest test ensuring that all rules in RHEL 10 STIG are also selected in SRG GPOS control files.

#### Rationale:
Improves DISA alignment. Facilitates running SRG diff and SRG export procedures. Reduces and prevents data inconsistency.

#### Review Hints:

For each added rule find the STIG ID for which is the rule selected in products/rhel10/controls/stig_rhel10.yml. Then, find the SRG for the STIG ID in `shared/references/disa-stig-rhel10-v1r1-xccdf-manual.xml` and verify that the SRG is the SRG where the rule is added.
