### PR TITLE
Remove some duplicate rule selections in RHEL 10 STIG control file

### DIFF
--- a/products/rhel10/controls/stig_rhel10.yml
+++ b/products/rhel10/controls/stig_rhel10.yml
@@ -2797,7 +2797,7 @@ controls:
       title: RHEL 10 must disable the ability of a user to accidentally press Ctrl-Alt-Del and cause
           a system to shut down or reboot.
       rules:
-          - disable_ctrlaltdel_reboot
+          - dconf_gnome_disable_ctrlaltdel_reboot
       status: automated
     - id: RHEL-10-700840
       levels:

--- a/products/rhel10/controls/stig_rhel10.yml
+++ b/products/rhel10/controls/stig_rhel10.yml
@@ -1334,9 +1334,7 @@ controls:
       title: RHEL 10 must take action when allocated audit record storage volume reaches 75 percent of
           the audit record storage capacity.
       rules:
-          - auditd_data_retention_space_left_action
           - auditd_data_retention_space_left_percentage
-          - var_auditd_space_left_action=email
           - var_auditd_space_left_percentage=25pc
       status: automated
     - id: RHEL-10-500045
@@ -1405,9 +1403,7 @@ controls:
           (ISSO) (at a minimum) when allocated audit record storage volume 75 percent utilization.
       rules:
           - auditd_data_retention_space_left_action
-          - auditd_data_retention_space_left_percentage
           - var_auditd_space_left_action=email
-          - var_auditd_space_left_percentage=25pc
       status: automated
     - id: RHEL-10-500210
       levels:

--- a/products/rhel10/controls/stig_rhel10.yml
+++ b/products/rhel10/controls/stig_rhel10.yml
@@ -1352,7 +1352,6 @@ controls:
           audit records.
       rules:
           - auditd_audispd_configure_sufficiently_large_partition
-          - partition_for_var_log_audit
       status: automated
     - id: RHEL-10-500105
       levels:


### PR DESCRIPTION
#### Description:

Some rules were selected in multiple controls. This change will remove these duplicate selections, the rules will be selected only in the control where they fit the best. This change doesn't modify the set of selected rules in the STIG profile.
For more details please read commit messages of every commit.

