### PR TITLE
fix: correct audit_backlog_limit definition in /etc/default/grub

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2020,14 +2020,14 @@ fi
 {{%- for grub_var in grub_vars %}}
 if grep -q '^\s*{{{ grub_var }}}=.*{{{ arg_name }}}=.*\"' '/etc/default/grub' ; then
     # modify the GRUB command-line if an {{{ arg_name }}}= arg already exists
-    sed -i 's/\(^\s*{{{ grub_var }}}=".*\){{{ arg_name }}}=[^[:space:]]\+\(.*"\)/\1{{{ arg_name_value }}}\2/' '/etc/default/grub'
+    sed -i 's/\(^\s*{{{ grub_var }}}=".*\){{{ arg_name }}}=[^[:space:]]\+\(.*"\)/\1'{{{ arg_name_value }}}'\2/' '/etc/default/grub'
 # Add to already existing parameters
 elif grep -q '^\s*{{{ grub_var }}}=' '/etc/default/grub' ; then
     # no {{{ arg_name }}}=arg is present, append it
-    sed -i 's/\(^\s*{{{ grub_var }}}=".*\)"/\1 {{{ arg_name_value }}}"/' '/etc/default/grub'
+    sed -i 's/\(^\s*{{{ grub_var }}}=".*\)"/\1 '{{{ arg_name_value }}}'"/' '/etc/default/grub'
 # Add parameters line if completely missing
 else
-    echo '{{{ grub_var }}}="{{{ arg_name_value }}}"' >> '/etc/default/grub'
+    echo '{{{ grub_var }}}="'{{{ arg_name_value }}}'"' >> '/etc/default/grub'
 fi
 {{%- endfor %}}
 {{%- endmacro %}}


### PR DESCRIPTION
#### Description:
Current `xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument` remediation is writing the variable name instead of its value in `/etc/default/grub`.

```
root@ubuntu2404:~# oscap xccdf eval \
    --profile xccdf_org.ssgproject.content_profile_cis_level2_server \
    --remediate \
    --rule xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument \
    /vagrant/build/ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Extend Audit Backlog Limit for the Audit Daemon
Rule    xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
Result  fail


--- Starting Remediation ---

Title   Extend Audit Backlog Limit for the Audit Daemon
Rule    xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
W: oscap: Conversion of the string "$var_audit_backlog_limit" to an integer (64 bits) failed: Invalid argument
W: oscap: Can't compare variable 'oval:ssg-var_audit_backlog_limit:var:1' value = '8192' with collected item entity = '$var_audit_backlog_limit'
W: oscap: Conversion of the string "$var_audit_backlog_limit" to an integer (64 bits) failed: Invalid argument
W: oscap: Can't compare variable 'oval:ssg-var_audit_backlog_limit:var:1' value = '8192' with collected item entity = '$var_audit_backlog_limit'
Result  error

root@ubuntu2404:~# grep "audit_backlog_limit" /etc/default/grub
GRUB_CMDLINE_LINUX_DEFAULT="quiet splash apparmor=1 security=apparmor audit_backlog_limit=$var_audit_backlog_limit"
GRUB_CMDLINE_LINUX=" apparmor=1 security=apparmor audit_backlog_limit=$var_audit_backlog_limit"
```

#### Rationale:
The value for `audit_backlog_limit` must be `8192` instead of `$var_audit_backlog_limit`.

```
root@ubuntu2404:~# grep "audit_backlog_limit" /etc/default/grub
GRUB_CMDLINE_LINUX_DEFAULT="quiet splash audit_backlog_limit=8192"
GRUB_CMDLINE_LINUX=" audit_backlog_limit=8192"
```

#### Review Hints:
```
root@ubuntu2404:~# oscap xccdf eval \
    --profile xccdf_org.ssgproject.content_profile_cis_level2_server \
    --remediate \
    --rule xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument \
    /vagrant/build/ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Extend Audit Backlog Limit for the Audit Daemon
Rule    xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
Result  fail


--- Starting Remediation ---

Title   Extend Audit Backlog Limit for the Audit Daemon
Rule    xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
Result  fixed

root@ubuntu2404:~# grep "audit_backlog_limit" /etc/default/grub
GRUB_CMDLINE_LINUX_DEFAULT="quiet splash audit_backlog_limit=8192"
GRUB_CMDLINE_LINUX=" audit_backlog_limit=8192"

root@ubuntu2404:~# oscap xccdf eval \
    --profile xccdf_org.ssgproject.content_profile_cis_level2_server \
    --rule xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument \
    /vagrant/build/ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Extend Audit Backlog Limit for the Audit Daemon
Rule    xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
Result  pass
```
