### PR TITLE
Update Ubuntu 24.04 STIG profile from V1R1 to V1R5 

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -2,7 +2,7 @@
 policy: Canonical Ubuntu 24.04 LTS Security Technical Implementation Guide (STIG)
 title: Canonical Ubuntu 24.04 LTS Security Technical Implementation Guide (STIG)
 id: stig_ubuntu2404
-version: V1R1
+version: V1R5
 source: https://www.cyber.mil/stigs/downloads/
 
 levels:
@@ -65,7 +65,8 @@ controls:
       status: automated
 
     - id: UBTU-24-100110
-      title: Ubuntu 24.04 LTS must configure AIDE to preform file integrity checking on the file system.
+      title: Ubuntu 24.04 LTS must configure AIDE to perform file integrity checking on the file system
+          if installed.
       levels:
           - medium
       rules:
@@ -666,15 +667,6 @@ controls:
           - sshd_x11_use_localhost
       status: automated
 
-    - id: UBTU-24-300024
-      title: Ubuntu 24.04 LTS must display the date and time of the last successful account logon upon
-          logon.
-      levels:
-          - low
-      rules:
-          - display_login_attempts
-      status: automated
-
     - id: UBTU-24-300025
       title: Ubuntu 24.04 LTS must disable the x86 Ctrl-Alt-Delete key sequence if a graphical user interface
           is installed.
@@ -1250,7 +1242,7 @@ controls:
     - id: UBTU-24-700400
       title: Ubuntu 24.04 LTS must be a vendor-supported release.
       levels:
-          - medium
+          - high
       rules:
           - installed_OS_is_vendor_supported
       status: automated
@@ -1708,7 +1700,7 @@ controls:
       status: automated
 
     - id: UBTU-24-901250
-      title: Ubuntu 24.04 LTS must configure the audit tools to be group-owned by root.
+      title: Ubuntu 24.04 LTS must configure the audit tools to be group owned by root.
       levels:
           - medium
       rules:
@@ -1775,18 +1767,18 @@ controls:
           - directory_permissions_var_log_audit
       status: automated
 
-    - id: UBTU-24-90890
-      title: Ubuntu 24.04 LTS must use cryptographic mechanisms to protect the integrity of audit tools.
-      levels:
-          - medium
-      rules:
-          - aide_check_audit_tools
-      status: automated
-
     - id: UBTU-24-909000
       title: Ubuntu 24.04 LTS audit system must protect auditing rules from unauthorized change.
       levels:
           - medium
       rules:
           - audit_rules_immutable
+      status: automated
+
+    - id: UBTU-24-909890
+      title: Ubuntu 24.04 LTS must use cryptographic mechanisms to protect the integrity of audit tools.
+      levels:
+          - medium
+      rules:
+          - aide_check_audit_tools
       status: automated

--- a/products/ubuntu2404/profiles/stig.profile
+++ b/products/ubuntu2404/profiles/stig.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 metadata:
-    version: V1R1
+    version: V1R5
     SMEs:
         - mpurg
         - dodys
@@ -9,11 +9,11 @@ metadata:
 
 reference: https://www.cyber.mil/stigs/downloads
 
-title: 'Canonical Ubuntu 24.04 LTS Security Technical Implementation Guide (STIG) V1R1'
+title: 'Canonical Ubuntu 24.04 LTS Security Technical Implementation Guide (STIG) V1R5'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for Canonical Ubuntu 24.04 LTS V1R1.
+    DISA STIG for Canonical Ubuntu 24.04 LTS V1R5.
 
 selections:
     - stig_ubuntu2404:all


### PR DESCRIPTION
Closes #14714

`controls/stig_ubuntu2404.yml` already matched nearly all of V1R5's content despite still being labeled V1R1 -- diffed every requirement against DISA's V1R5 XCCDF (via cyber.trackr.live) to find the real remaining gap:

- Bump version metadata to V1R5 in the control file and stig.profile
- Rename UBTU-24-90890 to UBTU-24-909890 (DISA renumbered it; same rule, same title, `aide_check_audit_tools`)
- Remove UBTU-24-300024 (last successful logon display) -- DISA dropped this requirement in a later revision; `display_login_attempts` itself is untouched since other profiles still use it
- Bump UBTU-24-700400 (vendor-supported release) from medium to high severity, matching DISA's current rating
- Fix two title typos DISA corrected: "preform" -> "perform" (plus "if installed" qualifier) on UBTU-24-100110, and "group-owned" -> "group owned" on UBTU-24-901250

Verified zero remaining discrepancies (ID/severity/title) between this file and DISA's V1R5 across all 194 controls.

#### Description:

Updates the Canonical Ubuntu 24.04 LTS STIG profile (`controls/stig_ubuntu2404.yml` and `products/ubuntu2404/profiles/stig.profile`) from the stale V1R1 label to V1R5, and fixes the handful of real content drifts found along the way (one renumbered control, one dropped control, one severity bump, two title typos).

#### Rationale:

DISA has released V1R2-V1R5 of this STIG since ComplianceAsCode last touched the version label, and issue #14714 reported the mismatch. Most of the content had already been kept in sync incrementally without the version string being bumped, so the actual diff needed is small and precisely scoped -- verified control-by-control against DISA's published V1R5 data rather than assumed.

#### Review Hints:

Diff is confined to the two files above. The control-count and per-control (id/severity/title) parity against DISA's V1R5 XCCDF was verified programmatically before opening this PR.
