### PR TITLE
Support DEB822 apt source format in apt_sources_list_official

### DIFF
--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/debian11.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/debian11.xml
@@ -2,8 +2,14 @@
   <definition class="compliance" id="apt_sources_list_official" version="1">
     {{{ oval_metadata("Official distribution repositories contain up-to-date distribution security and functional patches.", rule_title=rule_title) }}}
     <criteria comment="Match sources.list distribution repositories usage" operator="AND">
-      <criterion comment="Check /etc/apt/sources(.d/.+).list file for base" test_ref="test_apt_sources_list_base_official" />
-      <criterion comment="Check /etc/apt/sources(.d/.+).list file for security" test_ref="test_apt_sources_list_security_official" />
+      <criteria comment="Check base repository, one-line or DEB822 format" operator="OR">
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).list file for base, one-line format" test_ref="test_apt_sources_list_base_official" />
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).sources file for base, DEB822 format" test_ref="test_apt_sources_list_base_official_deb822" />
+      </criteria>
+      <criteria comment="Check security repository, one-line or DEB822 format" operator="OR">
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).list file for security, one-line format" test_ref="test_apt_sources_list_security_official" />
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).sources file for security, DEB822 format" test_ref="test_apt_sources_list_security_official_deb822" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Checks usage of official distribution base repositories"
@@ -11,7 +17,7 @@
     <ind:object object_ref="obj_apt_sources_list_base_official" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_base_official" version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
     <ind:pattern operation="pattern match">^deb[\s]+http://[a-z\.]+\.debian\.org/debian[/]?[\s]+bullseye[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -20,8 +26,30 @@
     <ind:object object_ref="obj_apt_sources_list_security_official" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_security_official" version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
     <ind:pattern operation="pattern match">^deb[\s]+http://security\.debian\.org/debian-security[/]?[\s]+bullseye-security[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="Checks usage of official distribution base repositories, DEB822 format"
+  id="test_apt_sources_list_base_official_deb822" version="1">
+    <ind:object object_ref="obj_apt_sources_deb822_official" />
+    <ind:state state_ref="state_apt_sources_deb822_base" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="Checks usage of official distribution security repositories, DEB822 format"
+  id="test_apt_sources_list_security_official_deb822" version="1">
+    <ind:object object_ref="obj_apt_sources_deb822_official" />
+    <ind:state state_ref="state_apt_sources_deb822_security" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_apt_sources_deb822_official" version="1">
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.sources$</ind:filepath>
+    <ind:pattern operation="pattern match">Types:[^\n]*\n(?:(?!Types:)[^\n]*\n?)*</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_apt_sources_deb822_base" version="1">
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbullseye(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_state id="state_apt_sources_deb822_security" version="1">
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbullseye-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/debian11.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/debian11.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_base_official" version="1">
     <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
-    <ind:pattern operation="pattern match">^deb[\s]+http://[a-z\.]+\.debian\.org/debian[/]?[\s]+bullseye[\s]+main</ind:pattern>
+    <ind:pattern operation="pattern match">^deb[\s]+https?://[a-z\.]+\.debian\.org/debian[/]?[\s]+bullseye[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Checks usage of official distribution security repositories"
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_security_official" version="1">
     <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
-    <ind:pattern operation="pattern match">^deb[\s]+http://security\.debian\.org/debian-security[/]?[\s]+bullseye-security[\s]+main</ind:pattern>
+    <ind:pattern operation="pattern match">^deb[\s]+https?://security\.debian\.org/debian-security[/]?[\s]+bullseye-security[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -47,9 +47,9 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_apt_sources_deb822_base" version="1">
-    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbullseye(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*https?://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbullseye(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_state id="state_apt_sources_deb822_security" version="1">
-    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbullseye-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*https?://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbullseye-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
   </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/debian12.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/debian12.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_base_official" version="1">
     <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
-    <ind:pattern operation="pattern match">^deb[\s]+http://[a-z\.]+\.debian\.org/debian[/]?[\s]+bookworm[\s]+main</ind:pattern>
+    <ind:pattern operation="pattern match">^deb[\s]+https?://[a-z\.]+\.debian\.org/debian[/]?[\s]+bookworm[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Checks usage of official distribution security repositories"
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_security_official" version="1">
     <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
-    <ind:pattern operation="pattern match">^deb[\s]+http://security\.debian\.org/debian-security[/]?[\s]+bookworm-security[\s]+main</ind:pattern>
+    <ind:pattern operation="pattern match">^deb[\s]+https?://security\.debian\.org/debian-security[/]?[\s]+bookworm-security[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -47,9 +47,9 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_apt_sources_deb822_base" version="1">
-    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbookworm(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*https?://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbookworm(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_state id="state_apt_sources_deb822_security" version="1">
-    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbookworm-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*https?://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbookworm-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
   </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/debian12.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/debian12.xml
@@ -2,8 +2,14 @@
   <definition class="compliance" id="apt_sources_list_official" version="1">
     {{{ oval_metadata("Official distribution repositories contain up-to-date distribution security and functional patches.", rule_title=rule_title) }}}
     <criteria comment="Match sources.list distribution repositories usage" operator="AND">
-      <criterion comment="Check /etc/apt/sources(.d/.+).list file for base" test_ref="test_apt_sources_list_base_official" />
-      <criterion comment="Check /etc/apt/sources(.d/.+).list file for security" test_ref="test_apt_sources_list_security_official" />
+      <criteria comment="Check base repository, one-line or DEB822 format" operator="OR">
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).list file for base, one-line format" test_ref="test_apt_sources_list_base_official" />
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).sources file for base, DEB822 format" test_ref="test_apt_sources_list_base_official_deb822" />
+      </criteria>
+      <criteria comment="Check security repository, one-line or DEB822 format" operator="OR">
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).list file for security, one-line format" test_ref="test_apt_sources_list_security_official" />
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).sources file for security, DEB822 format" test_ref="test_apt_sources_list_security_official_deb822" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Checks usage of official distribution base repositories"
@@ -11,7 +17,7 @@
     <ind:object object_ref="obj_apt_sources_list_base_official" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_base_official" version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
     <ind:pattern operation="pattern match">^deb[\s]+http://[a-z\.]+\.debian\.org/debian[/]?[\s]+bookworm[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -20,8 +26,30 @@
     <ind:object object_ref="obj_apt_sources_list_security_official" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_security_official" version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
     <ind:pattern operation="pattern match">^deb[\s]+http://security\.debian\.org/debian-security[/]?[\s]+bookworm-security[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="Checks usage of official distribution base repositories, DEB822 format"
+  id="test_apt_sources_list_base_official_deb822" version="1">
+    <ind:object object_ref="obj_apt_sources_deb822_official" />
+    <ind:state state_ref="state_apt_sources_deb822_base" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="Checks usage of official distribution security repositories, DEB822 format"
+  id="test_apt_sources_list_security_official_deb822" version="1">
+    <ind:object object_ref="obj_apt_sources_deb822_official" />
+    <ind:state state_ref="state_apt_sources_deb822_security" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_apt_sources_deb822_official" version="1">
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.sources$</ind:filepath>
+    <ind:pattern operation="pattern match">Types:[^\n]*\n(?:(?!Types:)[^\n]*\n?)*</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_apt_sources_deb822_base" version="1">
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbookworm(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_state id="state_apt_sources_deb822_security" version="1">
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\bbookworm-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/shared.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_base_official" version="1">
     <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
-    <ind:pattern operation="pattern match">^deb[\s]+http://[a-z\.]+\.debian\.org/debian[\s]+[a-z]+[\s]+main</ind:pattern>
+    <ind:pattern operation="pattern match">^deb[\s]+https?://[a-z\.]+\.debian\.org/debian[\s]+[a-z]+[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Checks usage of official distribution security repositories"
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_security_official" version="1">
     <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
-    <ind:pattern operation="pattern match">^deb[\s]+http://security\.debian\.org/debian-security[\s]+[a-z]+/updates[\s]+main</ind:pattern>
+    <ind:pattern operation="pattern match">^deb[\s]+https?://security\.debian\.org/debian-security[\s]+[a-z]+/updates[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -47,9 +47,9 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_apt_sources_deb822_base" version="1">
-    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\b[a-z]+(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*https?://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\b[a-z]+(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_state id="state_apt_sources_deb822_security" version="1">
-    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\b[a-z]+-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*https?://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\b[a-z]+-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
   </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/shared.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/shared.xml
@@ -1,9 +1,15 @@
 <def-group>
   <definition class="compliance" id="apt_sources_list_official" version="1">
     {{{ oval_metadata("Official distribution repositories contain up-to-date distribution security and functional patches.", rule_title=rule_title) }}}
-    <criteria comment="Match sources.list distribution repositories usage" operator="AND">      
-      <criterion comment="Check /etc/apt/sources(.d/.+).list file for base" test_ref="test_apt_sources_list_base_official" />
-      <criterion comment="Check /etc/apt/sources(.d/.+).list file for security" test_ref="test_apt_sources_list_security_official" />
+    <criteria comment="Match sources.list distribution repositories usage" operator="AND">
+      <criteria comment="Check base repository, one-line or DEB822 format" operator="OR">
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).list file for base, one-line format" test_ref="test_apt_sources_list_base_official" />
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).sources file for base, DEB822 format" test_ref="test_apt_sources_list_base_official_deb822" />
+      </criteria>
+      <criteria comment="Check security repository, one-line or DEB822 format" operator="OR">
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).list file for security, one-line format" test_ref="test_apt_sources_list_security_official" />
+        <criterion comment="Check /etc/apt/sources(.list.d/.+).sources file for security, DEB822 format" test_ref="test_apt_sources_list_security_official_deb822" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Checks usage of official distribution base repositories"
@@ -11,7 +17,7 @@
     <ind:object object_ref="obj_apt_sources_list_base_official" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_base_official" version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
     <ind:pattern operation="pattern match">^deb[\s]+http://[a-z\.]+\.debian\.org/debian[\s]+[a-z]+[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -20,8 +26,30 @@
     <ind:object object_ref="obj_apt_sources_list_security_official" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_apt_sources_list_security_official" version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.list$</ind:filepath>
     <ind:pattern operation="pattern match">^deb[\s]+http://security\.debian\.org/debian-security[\s]+[a-z]+/updates[\s]+main</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="Checks usage of official distribution base repositories, DEB822 format"
+  id="test_apt_sources_list_base_official_deb822" version="1">
+    <ind:object object_ref="obj_apt_sources_deb822_official" />
+    <ind:state state_ref="state_apt_sources_deb822_base" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="Checks usage of official distribution security repositories, DEB822 format"
+  id="test_apt_sources_list_security_official_deb822" version="1">
+    <ind:object object_ref="obj_apt_sources_deb822_official" />
+    <ind:state state_ref="state_apt_sources_deb822_security" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_apt_sources_deb822_official" version="1">
+    <ind:filepath operation="pattern match">^/etc/apt/sources(\.list\.d/[a-zA-Z0-9._-]+)?\.sources$</ind:filepath>
+    <ind:pattern operation="pattern match">Types:[^\n]*\n(?:(?!Types:)[^\n]*\n?)*</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_apt_sources_deb822_base" version="1">
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\b[a-z]+(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_state id="state_apt_sources_deb822_security" version="1">
+    <ind:text operation="pattern match">^(?=[\s\S]*\nURIs:\s*http://[a-z.]*\.debian\.org/debian-security/?(?=\s|$))(?=[\s\S]*\nSuites:[^\n]*\b[a-z]+-security(?=\s|$))(?=[\s\S]*\nComponents:[^\n]*\bmain(?=\s|$))Types:\s*deb(?=\s|$)</ind:text>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_combined.pass.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_combined.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
+
+cat > /etc/apt/sources.list.d/debian.sources << 'EOF'
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+
+Types: deb
+URIs: http://deb.debian.org/debian-security
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_https.pass.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_https.pass.sh
@@ -7,13 +7,13 @@ rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
 
 cat > /etc/apt/sources.list.d/debian.sources << 'EOF'
 Types: deb
-URIs: http://deb.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: bookworm bookworm-updates
 Components: main
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 
 Types: deb
-URIs: http://deb.debian.org/debian-security
+URIs: https://deb.debian.org/debian-security
 Suites: bookworm-security
 Components: main
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_separate_files.pass.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_separate_files.pass.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# platform = multi_platform_debian
+# platform = Debian 12
 # remediation = none
 
+mkdir -p /etc/apt/sources.list.d
 rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
 
 cat > /etc/apt/sources.list.d/debian.sources << 'EOF'

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_separate_files.pass.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_deb822_separate_files.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
+
+cat > /etc/apt/sources.list.d/debian.sources << 'EOF'
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: bookworm
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
+cat > /etc/apt/sources.list.d/debian-security.sources << 'EOF'
+Types: deb
+URIs: http://deb.debian.org/debian-security
+Suites: bookworm-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_legacy_sources_list_d.pass.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_legacy_sources_list_d.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
+
+cat > /etc/apt/sources.list.d/debian.list << 'EOF'
+deb http://deb.debian.org/debian bookworm main
+deb http://security.debian.org/debian-security bookworm-security main
+EOF

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_legacy_sources_list_d.pass.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/correct_legacy_sources_list_d.pass.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# platform = multi_platform_debian
+# platform = Debian 12
 # remediation = none
 
+mkdir -p /etc/apt/sources.list.d
 rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
 
 cat > /etc/apt/sources.list.d/debian.list << 'EOF'

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_deb822_thirdparty_only.fail.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_deb822_thirdparty_only.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
+
+cat > /etc/apt/sources.list.d/example.sources << 'EOF'
+Types: deb
+URIs: https://packages.example.com/debian
+Suites: stable
+Components: main
+Signed-By: /usr/share/keyrings/example.gpg
+EOF

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_deb822_thirdparty_only.fail.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_deb822_thirdparty_only.fail.sh
@@ -2,6 +2,7 @@
 # platform = multi_platform_debian
 # remediation = none
 
+mkdir -p /etc/apt/sources.list.d
 rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
 
 cat > /etc/apt/sources.list.d/example.sources << 'EOF'

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_missing.fail.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_debian
+# remediation = none
+
+rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
+touch /etc/apt/sources.list

--- a/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_missing.fail.sh
+++ b/linux_os/guide/services/apt/apt_sources_list_official/tests/wrong_missing.fail.sh
@@ -2,5 +2,6 @@
 # platform = multi_platform_debian
 # remediation = none
 
+mkdir -p /etc/apt/sources.list.d
 rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*
 touch /etc/apt/sources.list


### PR DESCRIPTION
## Description

The OVAL check for `apt_sources_list_official` only recognized the legacy one-line `sources.list` syntax (`deb http://... suite component`). A system using the DEB822 format — the default for new sources files since apt 2.x, e.g. `/etc/apt/sources.list.d/debian.sources` — was reported as not using official repositories even when it correctly was, exactly as described in this issue.

While investigating, I also found the existing filepath regex was broken independently of DEB822: it was written as `^/etc/apt/sources(.d\/[a-zA-Z0-9]+){0,1}.list$`, which matches `/etc/apt/sources.d/*.list`, not the real Debian path `/etc/apt/sources.list.d/*.list`. So splitting repos into `sources.list.d/*.list` files was never detected by the legacy check either.

## Fix

- Corrected the filepath regex to match the real `/etc/apt/sources.list.d/*.list` path.
- Added new DEB822-aware OVAL objects/states/tests that parse `Types:`/`URIs:`/`Suites:`/`Components:` stanzas from `*.sources` files, order-independent within a stanza, bounded so multiple stanzas in one file (as in the report) don't bleed into each other.
- Combined the new DEB822 checks with the existing legacy checks via `OR`, so either format satisfies the rule.
- Applied to `debian11.xml`, `debian12.xml`, and the generic `shared.xml` fallback.
- Added test scenarios for: legacy format split across `sources.list.d`, DEB822 with base+security combined in one file (the reported scenario), DEB822 split across separate files, DEB822 with only a third-party repo (should still fail), and no repos configured (should still fail).

## Testing

Built `ssg-debian12-ds.xml` from a clean checkout and verified with `oscap xccdf eval` inside an unmodified Debian 12 container:

- The exact scenario from this issue (combined base+security DEB822 stanzas in one `.sources` file) fails against the unmodified upstream datastream and passes with this fix.
- Legacy one-line format, split across `sources.list.d`: pass
- DEB822 split across separate `.sources` files: pass
- DEB822 file present but only a third-party repo: fail (correct)
- No repos configured: fail (correct)
- `deb-src`-only stanzas do not satisfy the check (regression guard, since `deb-src` alone doesn't provide binary package access)

Rationale field / rule.yml unchanged since the described requirement ("official repos configured") doesn't change, only the detection logic.