### PR TITLE
rpm_verify: align SCE checks with OVAL by skipping ghost files

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/sce/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/sce/shared.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_rhel
 # check-import = stdout
 
-readarray -t FILES_WITH_INCORRECT_HASHES < <(rpm -Va --noconfig | grep -E '^..5' | awk '{print $NF}' )
+readarray -t FILES_WITH_INCORRECT_HASHES < <(rpm -Va --noconfig --noghost | grep -E '^..5' | awk '{print $NF}' )
 
 if (( ${#FILES_WITH_INCORRECT_HASHES[@]} > 0 )); then
     echo "Files with incorrect hashes:"

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/fresh_system.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/fresh_system.pass.sh
@@ -3,6 +3,6 @@
 
 # verify (-V) all installed (-a) packages digests,
 # if digest differs from package metadata, then attribute '5' is printed
-result=$(rpm -Va --noconfig | grep -E '^..5')
+result=$(rpm -Va --noconfig --noghost | grep -E '^..5')
 
 [ -z "$result" ]

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/sce/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/sce/shared.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_rhel
 # check-import = stdout
 
-readarray -t FILES_WITH_INCORRECT_OWNERSHIP < <(rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }')
+readarray -t FILES_WITH_INCORRECT_OWNERSHIP < <(rpm -Va --nofiledigest --noghost | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }')
 
 if (( ${#FILES_WITH_INCORRECT_OWNERSHIP[@]} > 0 )); then
     echo "Files with incorrect perms:"

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/tests/all_ownerships_ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/tests/all_ownerships_ok.pass.sh
@@ -2,7 +2,7 @@
 
 # Perform same steps as remediation
 declare -A SETOWNER_RPM_LIST
-FILES_WITH_INCORRECT_OWNERSHIP=($(rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'))
+FILES_WITH_INCORRECT_OWNERSHIP=($(rpm -Va --nofiledigest --noghost | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'))
 
 for FILE_PATH in "${FILES_WITH_INCORRECT_OWNERSHIP[@]}"; do
     RPM_PACKAGES=$(rpm -qf "$FILE_PATH")

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/sce/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/sce/shared.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_rhel
 # check-import = stdout
 
-readarray -t FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }')
+readarray -t FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest --noghost | awk '{ if (substr($0,2,1)=="M") print $NF }')
 
 if (( ${#FILES_WITH_INCORRECT_PERMS[@]} > 0 )); then
     echo "Files with incorrect perms:"

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/all_permissions_ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/all_permissions_ok.pass.sh
@@ -6,7 +6,7 @@ declare -A SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }'))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest --noghost | awk '{ if (substr($0,2,1)=="M") print $NF }'))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,


### PR DESCRIPTION


#### Description:

- rpm_verify: align SCE checks with OVAL by skipping ghost files
  - The OVAL checks for rpm_verify_permissions, rpm_verify_hashes, and rpm_verify_ownership all use noghostfiles="true", which excludes ghost files (e.g. /root/.bash_*, /etc/audit/rules.d/audit.rules) from verification. The SCE scripts and their pass test scenarios were missing the equivalent --noghost flag, causing false failures on RHEL 10 where those files are marked %ghost in their packages.

  - Add --noghost to rpm -Va in all three SCE scripts and their corresponding pass test scenarios to match OVAL behavior.

Ran some tests and got:

From:

```
10.0@x86_64	fail	/per-rule/oscap/4	sce/rpm_verify_permissions/all_permissions_ok.pass
10.0@x86_64	fail	/per-rule/oscap/4	sce/rpm_verify_permissions/bad_permissions.fail
```
to:
```
10.0	pass	/per-rule/oscap/3	sce/rpm_verify_permissions/all_permissions_ok.pass		
10.0	pass	/per-rule/oscap/3	rpm_verify_permissions/all_permissions_ok.pass		
10.0	pass	/per-rule/oscap/3	sce/rpm_verify_permissions/bad_permissions.fail		
10.0	pass	/per-rule/oscap/3	rpm_verify_permissions/bad_permissions.fail
```
