### PR TITLE
Address more security issues related to supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-        interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default: 2

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -2,6 +2,8 @@ name: Automatus CS9
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/automatus-debian12.yaml
+++ b/.github/workflows/automatus-debian12.yaml
@@ -2,6 +2,8 @@ name: Automatus Debian 12
 on:
   pull_request:
     branches: [master, 'stabilization*']
+permissions:
+  contents: read
 concurrency:
   group: >-
     ${{ github.workflow }}-${{

--- a/.github/workflows/automatus-sanity.yaml
+++ b/.github/workflows/automatus-sanity.yaml
@@ -2,6 +2,8 @@ name: Automatus Sanity
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/automatus-sle15.yaml
+++ b/.github/workflows/automatus-sle15.yaml
@@ -2,6 +2,8 @@ name: Automatus SLE15
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/automatus-ubi8.yaml
+++ b/.github/workflows/automatus-ubi8.yaml
@@ -2,6 +2,8 @@ name: Automatus UBI8
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -2,6 +2,8 @@ name: Automatus Ubuntu 22.04
 on:
   pull_request:
     branches: [master, 'stabilization*']
+permissions:
+  contents: read
 concurrency:
   group: >-
     ${{ github.workflow }}-${{

--- a/.github/workflows/automatus-ubuntu2404.yml
+++ b/.github/workflows/automatus-ubuntu2404.yml
@@ -2,6 +2,8 @@ name: Automatus Ubuntu 24.04
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/automatus-ubuntu2604.yml
+++ b/.github/workflows/automatus-ubuntu2604.yml
@@ -2,6 +2,8 @@ name: Automatus Ubuntu 26.04
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -2,6 +2,8 @@ name: Automatus Fedora
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/cis-nist-sync.yml
+++ b/.github/workflows/cis-nist-sync.yml
@@ -8,7 +8,9 @@ on:
     # Run every Sunday at 2:00 PM UTC
     - cron: '0 14 * * 0'
   workflow_dispatch: # Allow manual trigger
-
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   generate-and-validate:
     name: Generate CIS-NIST Control File and Profiles

--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -2,6 +2,8 @@ name: Gating
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+permissions:
+  contents: read
 jobs:
   content-test-filtering:
     name: Content Test Filtering on Ubuntu Latest

--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -2,6 +2,8 @@ name: Gate (AR / RHEL)
 on:
   pull_request:
     branches: [ 'master' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -6,6 +6,8 @@ on:
     branches: ['*', '!stabilization*', '!stable*', '!master' ]
   pull_request:
     branches: [ 'master', 'stabilization*', 'oscal-update-*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/gate_fedora.yml
+++ b/.github/workflows/gate_fedora.yml
@@ -6,6 +6,8 @@ on:
     branches: ['*', '!stabilization*', '!stable*', 'master' ]
   pull_request:
     branches: [ 'master', 'stabilization*', 'oscal-update-*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-fedora-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/gate_thin_ds.yml
+++ b/.github/workflows/gate_thin_ds.yml
@@ -6,6 +6,8 @@ on:
     branches: ['*', '!stabilization*', '!stable*', 'master' ]
   pull_request:
     branches: [ 'master', 'stabilization*' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-fedora-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,6 +6,8 @@ on:
     branches: ['master', 'oscal-update-*']
   merge_group:
     branches: ['master']
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -3,6 +3,8 @@ on:
     schedule:
         # Run daily at 03:00
         -   cron: "0 3 * * *"
+permissions:
+    contents: read
 jobs:
     nightly-fedora:
         name: Nightly build on Fedora Latest (Container)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@ name: Release
 on:
   push:
     tags: [ 'v*.*.*' ]
+permissions:
+  contents: write
 jobs:
   release-fedora:
     name: Release on Fedora Latest (Container)

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -6,7 +6,8 @@ on:
         branches: [ '*', '!stabilization*', '!stable*', '!master' ]
     pull_request:
         branches: [ 'master', 'stabilization*', 'oscal-update-*' ]
-
+permissions:
+    contents: read
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
     cancel-in-progress: true

--- a/.github/workflows/srg-mapping-table.yaml
+++ b/.github/workflows/srg-mapping-table.yaml
@@ -6,6 +6,8 @@ on:
     branches: [ 'master', 'stabilization*', 'oscal-update-*' ]
   merge_group:
     branches: [ 'master' ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/stabilize.yaml
+++ b/.github/workflows/stabilize.yaml
@@ -5,6 +5,8 @@ on:
   schedule:
     # Run weekly at 05:00 on Sunday
     - cron: "0 5 * * 0"
+permissions:
+  contents: read
 env:
   SCAPVAL_JAR: scapval-1.3.5.jar
   SCAPVAL_FILENAME: SCAP-Content-Validation-Tool-1.3.5

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # Global Owners
 /CODEOWNERS @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
 /.github/ @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
+/shared/references/ @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
 /ssg/ @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
 /tests/ @matusmarhefka @mab879 @vojtapolasek @jan-cerny
 /linux_os/**/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # Global Owners
 /CODEOWNERS @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
+/.github/ @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
 /ssg/ @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
 /tests/ @matusmarhefka @mab879 @vojtapolasek @jan-cerny
 /linux_os/**/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny


### PR DESCRIPTION
#### Description:

- Add explicit least-privilege `permissions:` blocks to all 21 GitHub Actions workflows that were missing them (most get `contents: read`; `release.yaml` gets `contents: write`; `cis-nist-sync.yml` gets `contents: write` and `pull-requests: write`).
- Add `/.github/` and `/shared/references/` to `CODEOWNERS`, requiring global maintainer approval for changes to CI/CD configuration and external policy XML files.
- Extend Dependabot to also monitor pip dependencies on a weekly schedule (previously only GitHub Actions were covered).

#### Rationale:

- Without explicit `permissions:` blocks, workflows inherit the repository's default token permissions (read+write across all scopes), violating the principle of least privilege. A compromised third-party action or workflow step would have far broader access than needed.
- The `.github/` directory was unprotected in `CODEOWNERS`, meaning CI/CD pipelines could be modified without mandatory review from core maintainers — a direct supply chain risk. The `shared/references/` XML files influence generated compliance content and should require the same scrutiny.
- Python dependencies had no automated update monitoring, leaving dependency confusion and malicious package update risks undetected.

#### Review Hints:

- Each concern is addressed in its own commit — reviewing commit-by-commit is the recommended approach.
- The workflow permission changes are purely additive YAML lines; the logic of each workflow is unchanged.
- To verify the CODEOWNERS entries are syntactically correct, GitHub validates them automatically when the file is updated on the default branch.
