### PR TITLE
Adjust cooldown for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 2
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
-      default: 2
+      default-days: 2


### PR DESCRIPTION
#### Description:

* Add cooldown for GitHub Actions
* Fix key for pip

#### Rationale:

Be constant 

#### Review Hints:
See the docs https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown