### PR TITLE
Fix multiple SCE check productization issues

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/sce/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/sce/shared.sh
@@ -2,4 +2,4 @@
 # platform = multi_platform_fedora,multi_platform_rhel
 # check-import = stdout
 
-{{{ find_directories(find_parameters="-perm -0002 -uid +"~uid_min, fail_message="Found world-writable directories that are not owned by a system account") }}}
+{{{ find_directories(find_parameters="-perm -0002 -uid +"~(uid_min - 1), fail_message="Found world-writable directories that are not owned by a system account") }}}

--- a/linux_os/guide/system/permissions/files/no_files_or_dirs_ungroupowned/sce/shared.sh
+++ b/linux_os/guide/system/permissions/files/no_files_or_dirs_ungroupowned/sce/shared.sh
@@ -2,4 +2,4 @@
 # platform = multi_platform_fedora,multi_platform_rhel,Ubuntu 24.04
 # check-import = stdout
 
-{{{ find_files(find_parameters="-nogroup", fail_message="Found ungroupowned files or directories", exclude_directories="sysroot") }}}
+{{{ find_command(find_parameters="-nogroup", fail_message="Found ungroupowned files or directories", exclude_directories="sysroot", find_type="\( -type f -o -type d \)") }}}

--- a/linux_os/guide/system/permissions/files/no_files_or_dirs_unowned_by_user/sce/shared.sh
+++ b/linux_os/guide/system/permissions/files/no_files_or_dirs_unowned_by_user/sce/shared.sh
@@ -2,4 +2,4 @@
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ubuntu
 # check-import = stdout
 
-{{{ find_files(find_parameters="-nouser", fail_message="Found unowned files or directories") }}}
+{{{ find_command(find_parameters="-nouser", fail_message="Found unowned files or directories", find_type="\( -type f -o -type d \)") }}}

--- a/shared/templates/service_enabled/sce-bash.template
+++ b/shared/templates/service_enabled/sce-bash.template
@@ -1,6 +1,14 @@
 #!/bin/bash
 # check-import = stdout
-if [[ $(systemctl is-enabled {{{ DAEMONNAME }}}.service) == "enabled" ]] ; then
+state=$(systemctl is-enabled {{{ DAEMONNAME }}}.service 2>/dev/null)
+active=$(systemctl is-active {{{ DAEMONNAME }}}.service 2>/dev/null)
+if [[ ("$state" == "enabled" || "$state" == "indirect" || "$state" == "static") && "$active" == "active" ]] ; then
+    exit "$XCCDF_RESULT_PASS"
+fi
+# Also check the socket unit for socket-activated services
+state=$(systemctl is-enabled {{{ DAEMONNAME }}}.socket 2>/dev/null)
+active=$(systemctl is-active {{{ DAEMONNAME }}}.socket 2>/dev/null)
+if [[ ("$state" == "enabled" || "$state" == "indirect" || "$state" == "static") && "$active" == "active" ]] ; then
     exit "$XCCDF_RESULT_PASS"
 fi
 exit "$XCCDF_RESULT_FAIL"

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -19,17 +19,24 @@ function pass_if_set_correctly()
     local filelist="$1"
     local regex="$2"
     local expected_value="$3"
+    local value_regex="${4:-}"
     local found=0
     for files in $filelist ; do
         [[ -e "$files" ]] || continue
-        found_value=$(grep -P "$regex" $files | sed -E "s/$regex/\1/")
-        if [[ -n "$found_value" ]] ; then
-            if [[ "$found_value" == "$expected_value" ]] ; then
+        while IFS= read -r found_value; do
+            [[ -n "$found_value" ]] || continue
+            if [[ -n "$value_regex" ]] ; then
+                if echo "$found_value" | grep -qP "^($value_regex)$" ; then
+                    found=1
+                else
+                    return 1
+                fi
+            elif [[ "$found_value" == "$expected_value" ]] ; then
                 found=1
             else
                 return 1
             fi
-        fi
+        done < <(grep -P "$regex" $files | sed -E "s/$regex/\1/")
     done
     if [[ $found == 1 ]] ; then
         return 0
@@ -43,7 +50,7 @@ function pass_if_missing()
     local regex="$2"
     for files in $filelist ; do
         [[ -e "$files" ]] || continue
-        if grep -P "$regex"  $files ; then
+        if grep -qP "$regex" $files ; then
             return 1
         fi
     done
@@ -54,11 +61,12 @@ function check_sysctl_configuration()
 {
     local sysctlvar="$1"
     local expected_value="$2"
+    local value_regex="${3:-}"
 
-    regex="^\s*$sysctlvar\s*=\s*(.*)\s*"
+    regex="^\s*$sysctlvar\s*=\s*(.*\S)\s*"
 
     # kernel static parameter $sysctlvar set to $sysctlvar in sysctl files not managed by packages
-    pass_if_set_correctly "${FILES_NOT_MANAGED_BY_PACKAGES[*]}" "$regex" "$expected_value"
+    pass_if_set_correctly "${FILES_NOT_MANAGED_BY_PACKAGES[*]}" "$regex" "$expected_value" "$value_regex"
     set_correctly_in_not_managed="$?"
 
     # kernel static parameter $sysctlvar missing in sysctl files not managed by packages
@@ -66,12 +74,22 @@ function check_sysctl_configuration()
     missing_in_not_managed="$?"
 
     # kernel static parameter $sysctlvar set to $sysctlval in sysctl files managed by packages
-    pass_if_set_correctly "${FILES_MANAGED_BY_PACKAGES[*]}" "$regex" "$expected_value"
+    pass_if_set_correctly "${FILES_MANAGED_BY_PACKAGES[*]}" "$regex" "$expected_value" "$value_regex"
     set_correctly_in_managed="$?"
 
+    {{% if MISSING_PARAMETER_PASS == "true" %}}
+    # kernel static parameter $sysctlvar missing or correct in sysctl files managed by packages
+    pass_if_missing "${FILES_MANAGED_BY_PACKAGES[*]}" "$regex"
+    missing_in_managed="$?"
+
+    if [[ "$set_correctly_in_not_managed" == 0 || ( "$missing_in_not_managed" == 0 && ( "$set_correctly_in_managed" == 0 || "$missing_in_managed" == 0 ) ) ]] ; then
+        return 0
+    fi
+    {{% else %}}
     if [[ "$set_correctly_in_not_managed" == 0 || ( "$missing_in_not_managed" == 0 && "$set_correctly_in_managed" == 0 ) ]] ; then
         return 0
     fi
+    {{% endif %}}
     return 1
 }
 
@@ -86,18 +104,51 @@ fi
 {{% if SYSCTLVAL is string %}}
 {{% if SYSCTLVAL == "" -%}}
 expected_value="$XCCDF_VALUE_sysctl_{{{ SYSCTLID }}}_value"
-{{%- else -%}}
-expected_value="{{{ SYSCTLVAL }}}"
-{{%- endif %}}
 check_sysctl_configuration "{{{ SYSCTLVAR }}}" "$expected_value"
 if [[ $? == 0 ]] ; then
+{{% if CHECK_RUNTIME == "true" %}}
+    runtime_value=$(sysctl -n "{{{ SYSCTLVAR }}}" 2>/dev/null)
+    if [[ "$runtime_value" == "$expected_value" ]] ; then
+        exit $XCCDF_RESULT_PASS
+    fi
+{{% else %}}
     exit $XCCDF_RESULT_PASS
+{{% endif %}}
 fi
+{{%- else %}}
+expected_value="{{{ SYSCTLVAL }}}"
+{{% if OPERATION == "pattern match" %}}
+check_sysctl_configuration "{{{ SYSCTLVAR }}}" "$expected_value" "{{{ SYSCTLVAL_REGEX }}}"
+{{% else %}}
+check_sysctl_configuration "{{{ SYSCTLVAR }}}" "$expected_value"
+{{% endif %}}
+if [[ $? == 0 ]] ; then
+{{% if CHECK_RUNTIME == "true" %}}
+    runtime_value=$(sysctl -n "{{{ SYSCTLVAR }}}" 2>/dev/null)
+{{% if OPERATION == "pattern match" %}}
+    if echo "$runtime_value" | grep -qP "^({{{ SYSCTLVAL_REGEX }}})$" ; then
+{{% else %}}
+    if [[ "$runtime_value" == "$expected_value" ]] ; then
+{{% endif %}}
+        exit $XCCDF_RESULT_PASS
+    fi
+{{% else %}}
+    exit $XCCDF_RESULT_PASS
+{{% endif %}}
+fi
+{{% endif %}}
 {{% elif SYSCTLVAL is sequence %}}
 {{% for x in SYSCTLVAL %}}
 check_sysctl_configuration "{{{ SYSCTLVAR }}}" "{{{ x }}}"
 if [[ $? == 0 ]] ; then
+{{% if CHECK_RUNTIME == "true" %}}
+    runtime_value=$(sysctl -n "{{{ SYSCTLVAR }}}" 2>/dev/null)
+    if [[ "$runtime_value" == "{{{ x }}}" ]] ; then
+        exit $XCCDF_RESULT_PASS
+    fi
+{{% else %}}
     exit $XCCDF_RESULT_PASS
+{{% endif %}}
 fi
 {{% endfor %}}
 {{% endif %}}


### PR DESCRIPTION
# Fix multiple SCE check productization issues

#### Description:

- Fixes several mismatches between SCE and OVAL checks discovered through per-rule Automatus testing. Each fix aligns the SCE check behaviour with what the OVAL check already verifies.

- **#14842** (`dir_perms_world_writable_system_owned`): The SCE used `-uid +{uid_min}` which means uid **strictly greater than** uid_min, but the OVAL check uses `operation="greater than or equal"`. On RHEL 9 where uid_min=1000, directories owned by uid 1000 were incorrectly excluded. Fixed by using `-uid +(uid_min - 1)`.

- **#14843** (`no_files_or_dirs_ungroupowned`): The SCE used `find_files()` which only searches for regular files (`-type f`). The OVAL check uses separate `file_object` entries for both files and directories. Fixed by switching to `find_command()` with `\( -type f -o -type d \)`.

- **#14844** (`no_files_or_dirs_unowned_by_user`): Same root cause and fix as #14843 — `find_files()` misses unowned directories.

- **#14845** (`service_enabled` template): The SCE only accepted `"enabled"` from `systemctl is-enabled`, but the OVAL check verifies both the unit's enabled state and that it is actively running (`ActiveState=active`). Socket-activated services like `pcscd` return `"indirect"`, and always-on units like `systemd-journald` return `"static"` — both are valid enabled states. Three fixes applied:
  - Accept `"indirect"` and `"static"` from `systemctl is-enabled` (not just `"enabled"`).
  - Add an `is-active` check to match the OVAL `ActiveState=active` requirement.
  - Check the `.socket` unit in addition to `.service` for socket-activated services.

- **#14847** (`sysctl` template): Six bugs compared to the OVAL check were fixed:
  - **Multi-line grep**: When a file contains two identical entries for the same sysctl key, `grep` returns two lines and `"1\n1" != "1"` causes a spurious failure. Fixed by reading matched values line-by-line with a `while` loop.
  - **Missing runtime check**: The SCE never called `sysctl -n` even when `CHECK_RUNTIME="true"`. The OVAL check has a separate `unix:sysctl_test` for the runtime value. Fixed by adding a `sysctl -n` check after the configuration check passes.
  - **Missing `MISSING_PARAMETER_PASS` support**: The OVAL check uses `check_existence="any_exist"` for package-managed files, meaning zero matches is a pass (the system default is acceptable). The SCE had no such logic. Fixed by also passing when the parameter is absent from both user-managed and package-managed files.
  - **`grep` stdout pollution**: `pass_if_missing()` called `grep` without `-q`, so matched lines were printed to stdout and picked up by the `# check-import = stdout` SCE mechanism, corrupting the result. Fixed by adding `-q`.
  - **Trailing-whitespace mismatch**: The OVAL extraction pattern `(.*\S)` trims trailing whitespace from config file values. The SCE used `(.*)`, so values with trailing whitespace would never compare equal. Fixed by matching OVAL's `(.*\S)` pattern.
  - **`operation: pattern match` not supported**: When a sysctl rule sets `operation: pattern match` (e.g. `net.ipv4.ip_local_port_range` with regex `32768\s*65535`), OVAL uses `SYSCTLVAL_REGEX` instead of an exact match. The SCE always did exact comparison, so the tab-separated kernel output `32768\t65535` never matched `32768 65535`. Fixed by passing `SYSCTLVAL_REGEX` to `grep -qP` for both config file and runtime checks when `OPERATION == "pattern match"`.

#### Rationale:

- SCE checks are used by the compliance-operator and oscap when running in SCE mode. Divergence from the OVAL checks causes inconsistent scan results between engines, which breaks per-rule Automatus tests and can produce incorrect compliance verdicts in production.

- Fixes #14842
- Fixes #14843
- Fixes #14844
- Fixes #14845
- Fixes #14847

#### Review Hints:

- Each fix has its own commit, making it straightforward to review them individually in sequence.

- For **#14842**, the key insight is that `find -uid +N` means uid > N (strictly), not uid >= N. The fix `+(uid_min - 1)` is equivalent to `>= uid_min`.

- For **#14843** and **#14844**, the `find_command()` macro's `find_type` parameter is passed verbatim to `find`, so `\( -type f -o -type d \)` correctly matches both files and directories.

- For **#14845**, `"indirect"` means the service is enabled via another unit (typically a socket), and `"static"` means the unit has no `[Install]` section and is always managed by systemd directly — both are valid "enabled" states from a compliance perspective. The `is-active` check is necessary because the OVAL check's `systemdunitproperty_test` explicitly verifies `ActiveState=active`; without it, a stopped socket-activated service would pass the SCE check. The socket unit check mirrors the OVAL `test_multi_user_wants_pcscd_socket` path: `systemctl is-enabled` checks whether the socket is linked into `multi-user.target.wants/`, the same condition OVAL's `systemdunitdependency_test` evaluates.

- For **#14847**, the pattern match fix is the most impactful for test coverage: `net.ipv4.ip_local_port_range` returns `32768\t65535` (tab-separated) from the kernel but the config file value is typically written as `32768 65535` (space). With `operation: pattern match` and `sysctlval_regex: '32768\s*65535'`, both forms match correctly. The OVAL check already handled this; the SCE was silently failing every test case for this rule.

- Issue **#14852** (`grub2_nousb_argument wrong_value_entries.fail`) is intentionally not fixed here: the `grub2_bootloader_argument` template has no SCE support and the test failure is a false positive caused by the `contest` test framework running SCE tests for rules that have no SCE check. The correct fix is in the test framework — see https://github.com/RHSecurityCompliance/contest/pull/636.
