### PR TITLE
Fix SLE16 build failure

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
@@ -1,13 +1,3 @@
-{{%- if product == 'sle16' -%}}
-{{{ sshd_oval_check_usr(
-    parameter="Compression",
-    value="(no|delayed)",
-    missing_parameter_pass=false,
-    datatype="string",
-    rule_id=rule_id,
-    rule_title=rule_title
-) }}}
-{{%- else -%}}
 {{{ sshd_oval_check(
     parameter="Compression",
     value="(no|delayed)",
@@ -17,4 +7,3 @@
     rule_id=rule_id,
     rule_title=rule_title
 ) }}}
-{{%- endif -%}}


### PR DESCRIPTION
Addressing:
jinja2.exceptions.UndefinedError: 'sshd_oval_check_usr' is undefined

The PR https://github.com/ComplianceAsCode/content/pull/14439 merged today removed this macro sshd_oval_check_usr and all its occurrences. But, the https://github.com/ComplianceAsCode/content/pull/14831 merged yesterday added one occurrence of this macro back. And the first PR wasn't rebased after the latter was merged.


