### PR TITLE
Remove pyopenssl from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ pycompliance
 # used in utils/controleval_metrics.py
 prometheus_client
 requests
-pyopenssl>=26.3.0
 pcre2


### PR DESCRIPTION


#### Description:

Remove pyopenssl from requirements.txt
#### Rationale:

No longer needed
