### PR TITLE
Remove autrace from some products

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -24,18 +24,9 @@
 - name: Set "{{{ rule_title }}} - audit_tools fact"
   ansible.builtin.set_fact:
     audit_tools:
-      {{% if aide_also_checks_audispd == "yes" -%}}
-      - /usr/sbin/audispd
-      {{%- endif %}}
-      - /usr/sbin/auditctl
-      - /usr/sbin/auditd
-      - /usr/sbin/augenrules
-      - /usr/sbin/aureport
-      - /usr/sbin/ausearch
-      - /usr/sbin/autrace
-      {{% if aide_also_checks_rsyslog == "yes" -%}}
-      - /usr/sbin/rsyslogd
-      {{%- endif %}}
+      {{% for audit_tool in aide_audit_binaries %}}
+      - /usr/sbin/{{{ audit_tool }}}
+      {{%- endfor %}}
 
 - name: "{{{ rule_title }}} - Ensure Existing AIDE Configuration for Audit Tools are Correct"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
@@ -6,23 +6,7 @@
 
 {{{ bash_package_install("aide") }}}
 
-{{% set auditfiles = [
-      "auditctl",
-      "auditd",
-      "ausearch",
-      "aureport",
-      "autrace",
-      "augenrules" ] %}}
-
-{{% if aide_also_checks_audispd == "yes" %}}
-{{% set auditfiles = auditfiles + ["audispd"] %}}
-{{% endif %}}
-
-{{% if aide_also_checks_rsyslog == "yes" %}}
-{{% set auditfiles = auditfiles + ["rsyslogd"] %}}
-{{% endif %}}
-
-{{% for file in auditfiles %}}
+{{% for file in aide_audit_binaries %}}
 if grep -i -E '^.*(/usr)?/sbin/{{{file}}}.*$' {{{ aide_conf_path }}}; then
 sed -i -r "s#.*(/usr)?/sbin/{{{file}}}.*#/usr/sbin/{{{file}}} {{{ aide_string() }}}#" {{{ aide_conf_path }}}
 else

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -3,18 +3,9 @@
     {{{ oval_metadata("The " ~ full_name ~ " operating system file integrity tool must be configured to protect the integrity of the audit tools.", title="Configure AIDE to Verify the Audit Tools", rule_title=rule_title) }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
-      <criterion comment="auditctl is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_auditctl" />
-      <criterion comment="auditd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_auditd" />
-      <criterion comment="ausearch is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_ausearch" />
-      <criterion comment="aureport is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_aureport" />
-      <criterion comment="autrace is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_autrace" />
-      {{% if aide_also_checks_audispd == "yes" %}}
-      <criterion comment="audispd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_audispd" />
-      {{% endif %}}
-      {{% if aide_also_checks_rsyslog == "yes" %}}
-      <criterion comment="rsyslogd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_rsyslogd" />
-      {{% endif %}}
-      <criterion comment="augenrules is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_augenrules" />
+      {{% for audit_tool in aide_audit_binaries -%}}
+      <criterion comment="{{{ audit_tool }}} is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_{{{ audit_tool }}}" />
+      {{% endfor %}}
     </criteria>
   </definition>
 
@@ -26,8 +17,7 @@
     {{% endif %}}
   </ind:textfilecontent54_state>
 
-  {{%- set audit_tools_list = ['auditctl', 'auditd', 'ausearch', 'aureport', 'autrace', 'audispd', 'rsyslogd', 'augenrules'] -%}}
-  {{%- for audit_tool in audit_tools_list -%}}
+  {{% for audit_tool in aide_audit_binaries %}}
     {{{ oval_test_aide_audit_tools(audit_tool) }}}
   {{%- endfor %}}
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -52,7 +52,7 @@ ocil: |-
 
     <pre># sudo cat {{{ aide_conf_path }}} | grep /usr/sbin/au
 
-    {{{ aide_files() }}}
+    {{{ aide_config_file_lines() }}}
     </pre>
     If AIDE is configured properly to protect the integrity of the audit tools,
     all lines listed above will be returned from the command.
@@ -63,7 +63,7 @@ fixtext: |-
     Add or update the following lines to {{{ aide_conf_path }}}, to protect the integrity of the audit tools.
 
     <pre>
-    {{{ aide_files() }}}
+    {{{ aide_config_file_lines() }}}
     </pre>
 
 srg_requirement:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
@@ -5,7 +5,11 @@
 aide --init
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
+bins=(
+{{% for audit_tool in aide_audit_binaries %}}
+"/usr/sbin/{{{ audit_tool }}}"
+{{% endfor %}}
+)
 
 echo >> {{{ aide_conf_path }}}
 for theFile in "${bins[@]}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
@@ -3,7 +3,11 @@
 # packages = aide
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
+bins=(
+{{% for audit_tool in aide_audit_binaries %}}
+"/usr/sbin/{{{ audit_tool }}}"
+{{% endfor %}}
+)
 
 echo >> {{{ aide_conf_path }}}
 for theFile in "${bins[@]}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/expect_sbin_path.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/expect_sbin_path.pass.sh
@@ -3,7 +3,11 @@
 # packages = aide
 
 declare -a bins
-bins=('/sbin/auditctl' '/sbin/auditd' '/sbin/augenrules' '/sbin/aureport' '/sbin/ausearch' '/sbin/autrace' '/sbin/rsyslogd' '/sbin/audispd')
+bins=(
+{{% for audit_tool in aide_audit_binaries %}}
+"/sbin/{{{ audit_tool }}}"
+{{% endfor %}}
+)
 
 echo >> {{{ aide_conf_path }}}
 for theFile in "${bins[@]}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/extra_suffix.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/extra_suffix.fail.sh
@@ -3,7 +3,11 @@
 # packages = aide
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
+bins=(
+{{% for audit_tool in aide_audit_binaries %}}
+"/usr/sbin/{{{ audit_tool }}}"
+{{% endfor %}}
+)
 
 for theFile in "${bins[@]}"
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
@@ -5,7 +5,11 @@
 aide --init
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
+bins=(
+{{% for audit_tool in aide_audit_binaries %}}
+"/usr/sbin/{{{ audit_tool }}}"
+{{% endfor %}}
+)
 
 for theFile in "${bins[@]}"
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
@@ -33,7 +33,7 @@ ocil: |-
 
     Check the group-owner of each audit tool by running the following command:
 
-    {{% if product in ['rhel10', 'fedora'] %}}
+    {{% if product in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     $ sudo stat -c "%G %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/auditd /sbin/rsyslogd /sbin/augenrules
     {{% else %}}
     $ sudo stat -c "%G %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules
@@ -42,7 +42,7 @@ ocil: |-
     root /sbin/auditctl
     root /sbin/aureport
     root /sbin/ausearch
-    {{% if product not in ['rhel10', 'fedora'] %}}
+    {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     root /sbin/autrace
     {{% endif %}}
     root /sbin/auditd
@@ -65,7 +65,7 @@ template:
             - /sbin/auditctl
             - /sbin/aureport
             - /sbin/ausearch
-            {{% if product not in ['rhel10', 'fedora'] %}}
+            {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
             - /sbin/autrace
             {{% endif %}}
             - /sbin/auditd

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
@@ -33,12 +33,18 @@ ocil: |-
 
     Check the group-owner of each audit tool by running the following command:
 
+    {{% if product in ['rhel10', 'fedora'] %}}
+    $ sudo stat -c "%G %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/auditd /sbin/rsyslogd /sbin/augenrules
+    {{% else %}}
     $ sudo stat -c "%G %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules
+    {{% endif %}}
 
     root /sbin/auditctl
     root /sbin/aureport
     root /sbin/ausearch
+    {{% if product not in ['rhel10', 'fedora'] %}}
     root /sbin/autrace
+    {{% endif %}}
     root /sbin/auditd
     root /sbin/rsyslogd
     root /sbin/augenrules
@@ -59,7 +65,9 @@ template:
             - /sbin/auditctl
             - /sbin/aureport
             - /sbin/ausearch
+            {{% if product not in ['rhel10', 'fedora'] %}}
             - /sbin/autrace
+            {{% endif %}}
             - /sbin/auditd
             - /sbin/rsyslogd
             - /sbin/augenrules

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_ownership/rule.yml
@@ -33,7 +33,7 @@ ocil: |-
 
     Check the owner of each audit tool by running the following command:
 
-    {{% if product in ['rhel10', 'fedora'] %}}
+    {{% if product in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/auditd /sbin/rsyslogd /sbin/augenrules
     {{% else %}}
     $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules
@@ -42,7 +42,7 @@ ocil: |-
     root /sbin/auditctl
     root /sbin/aureport
     root /sbin/ausearch
-    {{% if product not in ['rhel10', 'fedora'] %}}
+    {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     root /sbin/autrace
     {{% endif %}}
     root /sbin/auditd
@@ -65,7 +65,7 @@ template:
             - /sbin/auditctl
             - /sbin/aureport
             - /sbin/ausearch
-            {{% if product not in ['rhel10', 'fedora'] %}}
+            {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
             - /sbin/autrace
             {{% endif %}}
             - /sbin/auditd

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_ownership/rule.yml
@@ -33,12 +33,18 @@ ocil: |-
 
     Check the owner of each audit tool by running the following command:
 
+    {{% if product in ['rhel10', 'fedora'] %}}
+    $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/auditd /sbin/rsyslogd /sbin/augenrules
+    {{% else %}}
     $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules
+    {{% endif %}}
 
     root /sbin/auditctl
     root /sbin/aureport
     root /sbin/ausearch
+    {{% if product not in ['rhel10', 'fedora'] %}}
     root /sbin/autrace
+    {{% endif %}}
     root /sbin/auditd
     root /sbin/rsyslogd
     root /sbin/augenrules
@@ -59,7 +65,9 @@ template:
             - /sbin/auditctl
             - /sbin/aureport
             - /sbin/ausearch
+            {{% if product not in ['rhel10', 'fedora'] %}}
             - /sbin/autrace
+            {{% endif %}}
             - /sbin/auditd
             - /sbin/rsyslogd
             - /sbin/augenrules

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_permissions/rule.yml
@@ -33,7 +33,11 @@ ocil: |-
 
     Check the octal permission of each audit tool by running the following command:
 
+    {{% if product in ['rhel10', 'fedora'] %}}
+    $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/auditd /sbin/rsyslogd /sbin/augenrules
+    {{% else %}}
     $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules
+    {{% endif %}}
 
 fixtext: |-
     Configure the audit tools to be owned by "root", by running the following command:
@@ -51,7 +55,9 @@ template:
             - /sbin/auditctl
             - /sbin/aureport
             - /sbin/ausearch
+            {{% if product not in ['rhel10', 'fedora'] %}}
             - /sbin/autrace
+            {{% endif %}}
             - /sbin/auditd
             - /sbin/rsyslogd
             - /sbin/augenrules

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_permissions/rule.yml
@@ -33,7 +33,7 @@ ocil: |-
 
     Check the octal permission of each audit tool by running the following command:
 
-    {{% if product in ['rhel10', 'fedora'] %}}
+    {{% if product in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/auditd /sbin/rsyslogd /sbin/augenrules
     {{% else %}}
     $ sudo stat -c "%U %n" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules
@@ -55,7 +55,7 @@ template:
             - /sbin/auditctl
             - /sbin/aureport
             - /sbin/ausearch
-            {{% if product not in ['rhel10', 'fedora'] %}}
+            {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
             - /sbin/autrace
             {{% endif %}}
             - /sbin/auditd

--- a/product_properties/10-aide-audit.yml
+++ b/product_properties/10-aide-audit.yml
@@ -4,7 +4,7 @@ default:
     - "auditd"
     - "ausearch"
     - "aureport"
-    {{% if product not in ['rhel10', 'sle16', 'fedora'] %}}
+    {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     - "autrace"
     {{% endif %}}
     {{% if 'rhel' not in product and 'ol' not in families and 'debian' not in families and 'ubuntu' not in families %}}

--- a/product_properties/10-aide-audit.yml
+++ b/product_properties/10-aide-audit.yml
@@ -1,24 +1,16 @@
 default:
-  aide_also_checks_rsyslog: "yes"
-  aide_also_checks_audispd: "no"
-
-overrides:
-{{% if "debian-like" in families %}}
-  aide_also_checks_rsyslog: "no"
-  {{% if "debian" in families %}}
-    {{% if major_version_ordinal <= 10 %}}
-  aide_also_checks_audispd: "yes"
-    {{% else %}}
-  aide_also_checks_audispd: "no"
+  aide_audit_binaries:
+    - "auditctl"
+    - "auditd"
+    - "ausearch"
+    - "aureport"
+    {{% if product not in ['rhel10', 'sle16', 'fedora'] %}}
+    - "autrace"
     {{% endif %}}
-  {{% elif "ubuntu" in families %}}
-    {{% if major_version_ordinal <= 2004 %}}
-  aide_also_checks_audispd: "yes"
-    {{% else %}}
-  aide_also_checks_audispd: "no"
+    {{% if 'rhel' not in product and 'ol' not in families and 'debian' not in families and 'ubuntu' not in families %}}
+    - "audispd"
     {{% endif %}}
-  {{% endif %}}
-{{% elif "rhel-like" not in families %}}
-  aide_also_checks_rsyslog: "no"
-  aide_also_checks_audispd: "yes"
-{{% endif %}}
+    {{% if 'ol' in families %}}
+    - "rsyslogd"
+    {{% endif %}}
+    - "augenrules"

--- a/product_properties/10-audit-binaries.yml
+++ b/product_properties/10-audit-binaries.yml
@@ -3,7 +3,7 @@ default:
     - /sbin/auditctl
     - /sbin/aureport
     - /sbin/ausearch
-    {{% if product not in ['rhel10', 'sle16'] %}}
+    {{% if product not in ['rhel10', 'sle16', 'fedora'] %}}
     - /sbin/autrace
     {{% endif %}}
     - /sbin/auditd

--- a/product_properties/10-audit-binaries.yml
+++ b/product_properties/10-audit-binaries.yml
@@ -3,7 +3,7 @@ default:
     - /sbin/auditctl
     - /sbin/aureport
     - /sbin/ausearch
-    {{% if product not in ['rhel10', 'sle16', 'fedora'] %}}
+    {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     - /sbin/autrace
     {{% endif %}}
     - /sbin/auditd

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1261,15 +1261,10 @@ p+i+n+u+g+s+b+acl+xattrs+sha512
     Lists the files need for the rule aide_check_audit_tools with the AIDE string
 
 #}}
-{{%- macro aide_files() -%}}
-    /usr/sbin/auditctl {{{ aide_string() }}}
-    /usr/sbin/auditd {{{ aide_string() }}}
-    /usr/sbin/ausearch {{{ aide_string() }}}
-    /usr/sbin/aureport {{{ aide_string() }}}
-    /usr/sbin/autrace {{{ aide_string() }}}
-    {{% if 'rhel' not in product and 'ol' not in families %}}/usr/sbin/audispd {{{ aide_string() }}}{{% endif %}}
-    {{% if 'ol' in families %}}/usr/sbin/rsyslogd {{{ aide_string() }}}{{% endif %}}
-    /usr/sbin/augenrules {{{ aide_string() }}}
+{{%- macro aide_config_file_lines() -%}}
+    {{% for binary in aide_audit_binaries -%}}
+    /usr/sbin/{{{ binary }}} {{{ aide_string() }}}
+    {{% endfor %}}
 {{% endmacro %}}
 
 

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/anolis23.yml
+++ b/tests/data/product_stability/anolis23.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -1,7 +1,12 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -1,7 +1,12 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/debian13.yml
+++ b/tests/data/product_stability/debian13.yml
@@ -1,7 +1,12 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -1,13 +1,17 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl
   - /sbin/aureport
   - /sbin/ausearch
-  - /sbin/autrace
   - /sbin/auditd
   - /sbin/audispd
   - /sbin/augenrules

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ol10.yml
+++ b/tests/data/product_stability/ol10.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - rsyslogd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ol10.yml
+++ b/tests/data/product_stability/ol10.yml
@@ -5,7 +5,6 @@ aide_audit_binaries:
   - auditd
   - ausearch
   - aureport
-  - autrace
   - rsyslogd
   - augenrules
 audisp_conf_path: /etc/audit
@@ -13,7 +12,6 @@ audit_binaries:
   - /sbin/auditctl
   - /sbin/aureport
   - /sbin/ausearch
-  - /sbin/autrace
   - /sbin/auditd
   - /sbin/augenrules
 audit_watches_style: legacy

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'yes'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - rsyslogd
+  - augenrules
 audisp_conf_path: /etc/audisp
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'yes'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - rsyslogd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'yes'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - rsyslogd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/rhel10.yml
+++ b/tests/data/product_stability/rhel10.yml
@@ -1,7 +1,11 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'yes'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -1,7 +1,12 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'yes'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -1,7 +1,12 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'yes'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: "yes"
-aide_also_checks_rsyslog: "no"
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /usr/sbin/auditctl

--- a/tests/data/product_stability/sle16.yml
+++ b/tests/data/product_stability/sle16.yml
@@ -1,7 +1,12 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/slmicro5.yml
+++ b/tests/data/product_stability/slmicro5.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/slmicro6.yml
+++ b/tests/data/product_stability/slmicro6.yml
@@ -1,7 +1,13 @@
-aide_also_checks_audispd: 'yes'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide.conf
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - audispd
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -1,8 +1,13 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide/aide.conf
 aide_default_path: /etc/default/aide
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -1,8 +1,13 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide/aide.conf
 aide_default_path: /etc/default/aide
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl

--- a/tests/data/product_stability/ubuntu2604.yml
+++ b/tests/data/product_stability/ubuntu2604.yml
@@ -1,8 +1,13 @@
-aide_also_checks_audispd: 'no'
-aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide/aide.conf
 aide_default_path: /etc/default/aide
+aide_audit_binaries:
+  - auditctl
+  - auditd
+  - ausearch
+  - aureport
+  - autrace
+  - augenrules
 audisp_conf_path: /etc/audit
 audit_binaries:
   - /sbin/auditctl


### PR DESCRIPTION
The autrace binary has been removed in audit 4.x. Therefore, autrace isn't available in distros that ship audit 4.0 or newer, which is: RHEL 10, OL 10, SLES 16 and all currently supported Fedora versions. Rules used in these products shouldn't contain autrace at all. The code has been refactored to centralize the definition of the list of binaries checked by aide as a product property.
