### PR TITLE
Fix generated bash remediation service_autofs_disabled for OL

### DIFF
--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -22,7 +22,7 @@ bash_conditional: >-
     rpm --quiet -q kernel-default-base ||
     rpm --quiet -q kernel-azure
 {{% elif "ol" in families %}}
-bash_conditional: "rpm --quiet -q kernel || rpm --quiet -q kernel-uek"
+bash_conditional: "( rpm --quiet -q kernel || rpm --quiet -q kernel-uek )"
 {{% elif product == "fedora" or "rhel" in product %}}
 bash_conditional: "rpm --quiet -q kernel-core"
 {{% else %}}


### PR DESCRIPTION
#### Description:

Add brakets in OL conditional for OL bash remediation in shared/applicability/system_with_kernel.yml to correct management of conditional

#### Rationale:

Incorrect comparison results 