### PR TITLE
Fix quoted glob in sshd_lineinfile test scripts breaking test scenarios

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/tests/common.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/tests/common.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}})
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-SSHD_PATHS+=("{{{ sshd_config_dir }}}/*")
+SSHD_PATHS+=({{{ sshd_config_dir }}}/*)
 {{% endif %}}
 # clean up configurations
 sed -i '/^(Allow|Deny)(Users|Groups).*/d' "${SSHD_PATHS[@]}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_login_grace_time/tests/include.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_login_grace_time/tests/include.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}})
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-SSHD_PATHS+=("{{{ sshd_config_dir }}}/*")
+SSHD_PATHS+=({{{ sshd_config_dir }}}/*)
 {{% endif %}}
 # clean up configurations
 sed -i '/^LoginGraceTime.*/d' "${SSHD_PATHS[@]}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/include.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/include.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}})
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-SSHD_PATHS+=("{{{ sshd_config_dir }}}/*")
+SSHD_PATHS+=({{{ sshd_config_dir }}}/*)
 {{% endif %}}
 # clean up configurations
 sed -i '/^MaxAuthTries.*/d' "${SSHD_PATHS[@]}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_sessions/tests/include.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_sessions/tests/include.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}})
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-SSHD_PATHS+=("{{{ sshd_config_dir }}}/*")
+SSHD_PATHS+=({{{ sshd_config_dir }}}/*)
 {{% endif %}}
 # clean up configurations
 sed -i '/^MaxSessions.*/d' "${SSHD_PATHS[@]}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/include.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/include.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}})
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-SSHD_PATHS+=("{{{ sshd_config_dir }}}/*")
+SSHD_PATHS+=({{{ sshd_config_dir }}}/*)
 {{% endif %}}
 # clean up configurations
 sed -i '/^MaxStartups.*/d' "${SSHD_PATHS[@]}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/include.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/include.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}})
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-SSHD_PATHS+=("{{{ sshd_config_dir }}}/*")
+SSHD_PATHS+=({{{ sshd_config_dir }}}/*)
 {{% endif %}}
 # clean up configurations
 sed -i '/^KexAlgorithms.*/d' "${SSHD_PATHS[@]}"

--- a/shared/templates/sshd_lineinfile/tests/common.sh
+++ b/shared/templates/sshd_lineinfile/tests/common.sh
@@ -3,7 +3,7 @@
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 if grep -q "^\s*{{{ PARAMETER }}}" "${SSHD_PATHS[@]}" ; then
 	sed -i "s/^{{{ PARAMETER }}}.*/# {{{ PARAMETER }}} {{{ CORRECT_VALUE }}}/g" "${SSHD_PATHS[@]}"

--- a/shared/templates/sshd_lineinfile/tests/duplicated_param.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"

--- a/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
@@ -9,7 +9,7 @@ touch "{{{ sshd_config_dir }}}/nothing"
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", cce_identifiers=cce_identifiers) }}}
 {{% endif %}}
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 if grep -q "^\s*{{{ PARAMETER }}}" "${SSHD_PATHS[@]}" ; then
     sed -i "/^\s*{{{ PARAMETER }}}.*/Id" "${SSHD_PATHS[@]}"

--- a/shared/templates/sshd_lineinfile/tests/line_not_there.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/line_not_there.fail.sh
@@ -2,7 +2,7 @@
 
 SSHD_PARAM={{{ PARAMETER }}}
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 

--- a/shared/templates/sshd_lineinfile/tests/param_conflict.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict.fail.sh
@@ -8,7 +8,7 @@
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 if grep -q "^\s*{{{ PARAMETER }}}" "${SSHD_PATHS[@]}" ; then
 	sed -i "/^\s*{{{ PARAMETER }}}.*/Id" "${SSHD_PATHS[@]}"

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_directory.fail.sh
@@ -10,7 +10,7 @@
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 {{% if product in ["ol8", "ol9"] %}}
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", cce_identifiers=cce_identifiers) }}}

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_file_with_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_file_with_directory.fail.sh
@@ -9,7 +9,7 @@
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 {{% if product in ["ol8", "ol9"] %}}
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", cce_identifiers=cce_identifiers) }}}

--- a/shared/templates/sshd_lineinfile/tests/wrong_value.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/wrong_value.fail.sh
@@ -7,7 +7,7 @@
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 if grep -q "^\s*{{{ PARAMETER }}}" "${SSHD_PATHS[@]}" ; then
 	sed -i "/^\s*{{{ PARAMETER }}}.*/Id" "${SSHD_PATHS[@]}"

--- a/shared/templates/sshd_lineinfile/tests/wrong_value_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/wrong_value_directory.fail.sh
@@ -9,7 +9,7 @@
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
 
-declare -a SSHD_PATHS=("{{{ sshd_main_config_file }}}" "{{{ sshd_config_dir }}}/*")
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 {{% if product in ["ol8", "ol9"] %}}
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", cce_identifiers=cce_identifiers) }}}

--- a/tests/data/product_stability/sle16.yml
+++ b/tests/data/product_stability/sle16.yml
@@ -100,11 +100,11 @@ reference_uris:
 rsyslog_cafile: /etc/pki/tls/cert.pem
 ssh_client_config_dir: /etc/ssh/ssh_config.d
 ssh_client_main_config_file: /etc/ssh/ssh_config
-sshd_config_base_dir: /etc/ssh
+sshd_config_base_dir: /usr/etc/ssh
 sshd_config_dir: /etc/ssh/sshd_config.d
 sshd_distributed_config: 'true'
 sshd_hardening_config_basename: 00-complianceascode-hardening.conf
-sshd_main_config_file: /etc/ssh/sshd_config
+sshd_main_config_file: /usr/etc/ssh/sshd_config
 sshd_runtime_check: 'false'
 sshd_sysconfig_file: /etc/sysconfig/sshd
 sysctl_remediate_drop_in_file: 'true'


### PR DESCRIPTION
#### Description:

- PR #14439 introduced a bash glob quoting bug in `sshd_lineinfile` template test scripts when refactoring hardcoded paths to use Jinja2 variables
-   When the glob `{{{ sshd_config_dir }}}/*` is double-quoted, bash treats it as a literal path (e.g., `/etc/ssh/sshd_config.d/*`) instead of expanding it to matching files
- This causes grep and `sed` in the test setup to silently skip drop-in config files, leaving stale `sshd` parameters in place during test execution.

#### Rationale:

- This bug caused widespread test failures across RHEL 8, 9, and 10 in weekly CI
- Removing the unnecessary double quotes from the items in `SSHD_PATHS` variables should fix the issue
- Also updating values in the `sle16` reference file to match actual product config

#### Review Hints:

- run `./tests/automatus.py` with affected rules on `rhel8`, `rhel9`, `rhel10` products
