### PR TITLE
Clarify RHEL 10 STIG requirement RHEL-10-800290

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
@@ -55,3 +55,9 @@ template:
         parameter: FirewallBackend
         value: nftables
         no_quotes: 'true'
+
+warnings:
+    - general: >
+        Establish rate-limiting rules based on organization-defined types of DoS attacks on impacted network interfaces.
+        You can use firewalld rich rules or advanced per-ip limiting in nftables configuration to rate-limit incoming connections to specific services.
+        The rule doesn't configure any rate-limiting, this has to be configured individually.

--- a/products/rhel10/controls/stig_rhel10.yml
+++ b/products/rhel10/controls/stig_rhel10.yml
@@ -3344,12 +3344,11 @@ controls:
           ensuring that rate-limiting measures on impacted network interfaces are implemented.
       rules:
           - firewalld-backend
-      related_rules:
-          - sysctl_net_ipv4_tcp_invalid_ratelimit
-          - sysctl_net_ipv4_tcp_invalid_ratelimit_value=five_hundred
       notes: >
-          TODO: resolve mismatch of title and description
-      status: automated
+          Establish rate-limiting rules based on organization-defined types of DoS attacks on impacted network interfaces.
+          You can use firewalld rich rules or advanced per-ip limiting in nftables configuration to rate-limit incoming connections to specific services.
+          The selected rule doesn't configure any rate-limiting, this has to be configured individually.
+      status: partial
     - id: RHEL-10-800300
       levels:
           - medium


### PR DESCRIPTION
Add a note to the control and a warning to the rule. The notion of the STIG requirement is that system administrators need to configure rate-limiting in firewalld rules or nftables configuration manually. The selected rule `firewalld_backend` merely allows the rate-limiting configuration to be effective.

The rule `sysctl_net_ipv4_tcp_invalid_ratelimit` has been removed from related rules because it only covers the maximal rate for sending duplicate acknowledgments in response to incoming TCP packets. Based on the rule description we see that the rule doesn't fit the intent of this STIG requirement.



