### PR TITLE
Remove rule file_sshd_50_redhat_exists from RHEL 10 STIG

### DIFF
--- a/products/rhel10/controls/stig_rhel10.yml
+++ b/products/rhel10/controls/stig_rhel10.yml
@@ -898,13 +898,9 @@ controls:
       title: RHEL 10 must be configured so that the Secure Shell (SSH) server configuration file is owned
           by "root".
       rules:
-          - file_sshd_50_redhat_exists
           - file_owner_sshd_config
           - directory_owner_sshd_config_d
           - file_owner_sshd_drop_in_config
-      notes: >
-          TODO: investigate if file_sshd_50_redhat_exists is a convenience rule or a prerequisite
-          or if it's superfluous and should be removed.
       status: automated
     - id: RHEL-10-400160
       levels:

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -58,3 +58,4 @@ selections:
     - sysctl_net_ipv4_tcp_invalid_ratelimit
     - set_password_hashing_min_rounds_logindefs
     - directory_group_ownership_var_log_audit
+    - file_sshd_50_redhat_exists

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -274,7 +274,6 @@ file_permissions_ungroupowned
 file_permissions_var_log
 file_permissions_var_log_audit
 file_permissions_var_log_messages
-file_sshd_50_redhat_exists
 firewalld-backend
 firewalld_sshd_port_enabled
 gid_passwd_group_same

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -274,7 +274,6 @@ file_permissions_ungroupowned
 file_permissions_var_log
 file_permissions_var_log_audit
 file_permissions_var_log_messages
-file_sshd_50_redhat_exists
 firewalld-backend
 firewalld_sshd_port_enabled
 gid_passwd_group_same


### PR DESCRIPTION
The STIG requirement doesn't require that the file /etc/ssh/sshd_config.d/50-redhat.conf must exist. The check only lists the file in the example output of the find command as one of the files present in the directory. But, it doesn't say anything about its mandatory existence. The requirement is about ownership and the existing rules cover all files.

