### PR TITLE
Fix typo in snmpd_use_newer_protocol OVAL check and add tests

### DIFF
--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/oval/shared.xml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/oval/shared.xml
@@ -11,7 +11,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_snmp_versions" version="1">
     <ind:filepath>/etc/snmp/snmpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(com2se|rocommunity|rwcommunity)</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(com2sec|rocommunity|rwcommunity)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/com2sec.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/com2sec.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = net-snmp
+# remediation = none
+
+
+echo "com2secunix" >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/commented.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/commented.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = net-snmp
+
+
+sed -i '/.*com2sec.*/d' /etc/snmp/snmpd.conf
+sed -i '/.*rocommunity.*/d' /etc/snmp/snmpd.conf
+sed -i '/.*rwcommunity.*/d' /etc/snmp/snmpd.conf
+echo '# com2sec' >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/correct.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = net-snmp
+
+
+sed -i '/.*com2sec.*/d' /etc/snmp/snmpd.conf
+sed -i '/.*rocommunity.*/d' /etc/snmp/snmpd.conf
+sed -i '/.*rwcommunity.*/d' /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/missing.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/missing.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = net-snmp
+
+rm -f /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/rocommunity.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/rocommunity.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = net-snmp
+# remediation = none
+
+
+echo "rocommunity something" >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/rwcommunity.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/tests/rwcommunity.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = net-snmp
+# remediation = none
+
+echo "rwcommunity something" >> /etc/snmp/snmpd.conf


### PR DESCRIPTION
#### Description:

- Fix typo in OVAL check for rule `snmpd_use_newer_protocol` — the regex pattern matched `com2se` instead of `com2sec`, so SNMPv1/v2c configurations using `com2sec` directives were not detected.
- Add test scenarios covering all three SNMPv1/v2c directive types (`com2sec`, `rocommunity`, `rwcommunity`), plus passing scenarios for commented-out directives, clean config, and missing config file.

#### Rationale:

- The OVAL check was silently missing `com2sec` directives due to the typo, causing false passes on systems configured with SNMPv1/v2c community-based security.

#### Review Hints:

- Affected products: rhel8, rhel9, rhel10. Build with: `./build_product --datastream-only rhel8 rhel9 rhel10`
- Test with Automatus: `./tests/automatus.py rule --libvirt qemu:///session <vm_name> --datastream build/ssg-<product>-ds.xml snmpd_use_newer_protocol`
- The OVAL fix is a single-character change (`com2se` → `com2sec`), best reviewed in the diff view.
- The test scenarios use `# remediation = none` for the fail cases because the rule has no automated remediation — review is straightforward.
