### PR TITLE
Fix three RCE vectors in the build system

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1604,39 +1604,6 @@ class Group(XCCDFEntity):
         return self.id_
 
 
-def noop_rule_filterfunc(rule):
-    return True
-
-
-def rule_filter_from_def(filterdef):
-    """
-    Creates a filter function based on the provided filter definition.
-
-    Args:
-        filterdef (str or None): A string containing a Python expression that will be used
-                                 to filter rules. If None or an empty string is provided,
-                                 a no-operation filter function is returned.
-
-    Returns:
-        function: A function that takes a rule object and evaluates the filter definition against
-                  the rule's attributes. If the filter definition is None or an empty string, a
-                  no-operation filter function is returned.
-
-    Note:
-        The filter function uses `eval` to evaluate the filter definition. For security reasons,
-        only the rule's attributes are exposed to the evaluation context, and Python built-ins
-        are not available.
-    """
-    if filterdef is None or filterdef == "":
-        return noop_rule_filterfunc
-
-    def filterfunc(rule):
-        # Remove globals for security and only expose
-        # variables relevant to the rule
-        return eval(filterdef, {"__builtins__": None}, rule.__dict__)
-    return filterfunc
-
-
 class Rule(XCCDFEntity, Templatable):
     """
     Represents an XCCDF Rule entity with various attributes and methods for handling rule data,

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -3,6 +3,7 @@ import copy
 from xml.sax.saxutils import escape
 
 from ..build_cpe import CPEDoesNotExist
+from ..utils import safe_eval_filter
 
 from ..xml import ElementTree as ET
 
@@ -30,9 +31,7 @@ def rule_filter_from_def(filterdef):
         c = copy.copy(rule)
         if c.platform is None:
             c.platform = ''
-        # Remove globals for security and only expose
-        # variables relevant to the rule
-        return eval(filterdef, {"__builtins__": None}, c.__dict__)
+        return safe_eval_filter(filterdef, c.__dict__)
     return filterfunc
 
 

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import os.path
 import sys
 import jinja2
+from jinja2.sandbox import SandboxedEnvironment
 
 from urllib.parse import quote
 from shlex import quote as shell_quote
@@ -104,7 +105,7 @@ def preload_macros(env):
         _preload_macros_from_file(env, macros_file)
 
 
-class JinjaEnvironment(jinja2.Environment):
+class JinjaEnvironment(SandboxedEnvironment):
     def __init__(self, bytecode_cache=None):
         super(JinjaEnvironment, self).__init__(
             block_start_string="{{%",

--- a/ssg/rule_yaml.py
+++ b/ssg/rule_yaml.py
@@ -164,7 +164,7 @@ def parse_from_yaml(file_contents, lines):
     """
     new_file_arr = file_contents[lines.start:lines.end + 1]
     new_file = "\n".join(new_file_arr)
-    return yaml.load(new_file, Loader=yaml.Loader)
+    return yaml.load(new_file, Loader=yaml.SafeLoader)
 
 
 def get_yaml_contents(rule_obj):

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -4,6 +4,7 @@ Utils functions consumed by SSG
 
 from __future__ import absolute_import
 
+import ast
 import multiprocessing
 import os
 import re
@@ -981,3 +982,67 @@ def select_templated_tests(test_dir_config, available_scenarios_basenames):
         )
         raise ValueError(msg)
     return available_scenarios_basenames
+
+
+def _eval_filter_ast_node(node, context):
+    """Evaluate one AST node; only safe boolean/comparison/literal types are allowed."""
+    if isinstance(node, ast.BoolOp):
+        if isinstance(node.op, ast.And):
+            return all(_eval_filter_ast_node(v, context) for v in node.values)
+        elif isinstance(node.op, ast.Or):
+            return any(_eval_filter_ast_node(v, context) for v in node.values)
+        else:
+            raise ValueError(
+                "Unsupported boolean operator in filter: {}".format(
+                    type(node.op).__name__))
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not _eval_filter_ast_node(node.operand, context)
+    elif isinstance(node, ast.Compare):
+        left = _eval_filter_ast_node(node.left, context)
+        # Chained comparisons share the previous right operand as the next left.
+        for op, comparator in zip(node.ops, node.comparators):
+            right = _eval_filter_ast_node(comparator, context)
+            if isinstance(op, ast.In):
+                if left not in right:
+                    return False
+            elif isinstance(op, ast.NotIn):
+                if left in right:
+                    return False
+            elif isinstance(op, ast.Eq):
+                if left != right:
+                    return False
+            elif isinstance(op, ast.NotEq):
+                if left == right:
+                    return False
+            else:
+                raise ValueError(
+                    "Unsupported operator in filter expression: {}".format(
+                        type(op).__name__))
+            left = right
+        return True
+    elif isinstance(node, ast.Constant):
+        if isinstance(node.value, (str, int, float, bool, type(None))):
+            return node.value
+        raise ValueError(
+            "Unsupported constant type in filter expression: {}".format(
+                type(node.value).__name__))
+    elif isinstance(node, (ast.List, ast.Tuple)):
+        return [_eval_filter_ast_node(elt, context) for elt in node.elts]
+    elif isinstance(node, ast.Name):
+        try:
+            return context[node.id]
+        except KeyError as err:
+            raise ValueError(
+                "Unknown variable in filter expression: {}".format(node.id)) from err
+    raise ValueError(
+        "Unsupported expression type in filter: {}".format(type(node).__name__))
+
+
+def safe_eval_filter(filterdef, context):
+    """Evaluate a filter_rules expression against context using a safe AST whitelist."""
+    try:
+        tree = ast.parse(filterdef, mode='eval')
+    except SyntaxError as exc:
+        raise ValueError(
+            "Invalid filter expression {!r}: {}".format(filterdef, exc)) from exc
+    return _eval_filter_ast_node(tree.body, context)

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -21,11 +21,6 @@ except ImportError:
     from yaml import SafeLoader as yaml_SafeLoader  # type: ignore[assignment]
 
 try:
-    from yaml import CLoader as yaml_Loader
-except ImportError:
-    from yaml import Loader as yaml_Loader  # type: ignore[assignment]
-
-try:
     from yaml import CDumper as yaml_Dumper
 except ImportError:
     from yaml import Dumper as yaml_Dumper  # type: ignore[assignment]
@@ -65,6 +60,23 @@ def _unicode_constructor(self, node):
 yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:bool', _bool_constructor)
 # Python2-relevant - become able to resolve "unicode strings"
 yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:python/unicode', _unicode_constructor)
+
+def _standard_bool_constructor(loader, node):
+    # Delegates to SafeConstructor to get real Python True/False (not the project's
+    # string-returning _bool_constructor registered on yaml_SafeLoader).
+    return yaml.constructor.SafeConstructor.construct_yaml_bool(loader, node)
+
+
+# Loader for ordered_load (Ansible content): safe against !!python/object tags but
+# uses standard Python bool semantics (True/False) because Ansible task files rely on
+# real booleans for keys like become:, ignore_errors:, etc.
+class _AnsibleSafeLoader(yaml_SafeLoader):
+    pass
+
+_AnsibleSafeLoader.add_constructor(
+    u'tag:yaml.org,2002:bool',
+    _standard_bool_constructor
+)
 
 
 class DocumentationNotComplete(Exception):
@@ -240,7 +252,7 @@ def open_raw(yaml_file):
     return yaml_contents
 
 
-def ordered_load(stream, Loader=yaml_Loader, object_pairs_hook=OrderedDict):
+def ordered_load(stream, Loader=_AnsibleSafeLoader, object_pairs_hook=OrderedDict):
     """
     Load a YAML stream while preserving the order of dictionaries.
 
@@ -249,7 +261,7 @@ def ordered_load(stream, Loader=yaml_Loader, object_pairs_hook=OrderedDict):
 
     Args:
         stream (str): The YAML stream to load.
-        Loader (yaml.Loader, optional): The YAML loader class to use. Defaults to `yaml_Loader`.
+        Loader (yaml.Loader, optional): The YAML loader class to use. Defaults to `_AnsibleSafeLoader`.
         object_pairs_hook (callable, optional): A callable that will be used to construct
                                                 ordered mappings. Defaults to `OrderedDict`.
 


### PR DESCRIPTION
#### Description:

- Fix three RCE vectors in the build system
  - `ssg/jinja.py`: switch `JinjaEnvironment` base from `jinja2.Environment` to `jinja2.sandbox.SandboxedEnvironment`, blocking SSTI class-hierarchy traversal in contributed rule/remediation templates
  - `ssg/rule_yaml.py`, `ssg/yaml.py`: replace `yaml.Loader` / `yaml_Loader` with `SafeLoader` in all call sites, preventing `!!python/object/apply:` payloads in YAML content from executing during the build
  - `ssg/utils.py`: add `safe_eval_filter()`, an AST-based evaluator that only permits boolean/comparison expressions on rule attributes; replaces `eval()` with `{"__builtins__": None}` (bypassable sandbox) used for profile `filter_rules` in `ssg/build_yaml.py` and `ssg/entities/profile_base.py`

#### Rationale:

- Fixes three RCE vectors in the build system exploitable by any contributor whose PR triggers a CI build: unsandboxed Jinja2 (SSTI via `__class__.__mro__` traversal), unsafe YAML deserialization (`yaml.Loader` accepting `!!python/object/apply:` tags), and a bypassable `eval()` sandbox for profile `filter_rules` expressions (`{"__builtins__": None}` is a well-known ineffective restriction).

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- All changes are in one commit and best reviewed file-by-file.

- **`ssg/jinja.py`**: `JinjaEnvironment` base class changed from `jinja2.Environment` to `jinja2.sandbox.SandboxedEnvironment`. No behaviour change for legitimate templates; blocks dunder/class-hierarchy traversal.

- **`ssg/rule_yaml.py`**: single-line change, `yaml.Loader` → `yaml.SafeLoader`.

- **`ssg/yaml.py`**: `ordered_load` (used for Ansible snippet parsing) needed a safe loader that still returns Python `True`/`False` for YAML booleans — the project's `yaml_SafeLoader` has a custom `_bool_constructor` that returns raw strings instead, which would break Ansible `become:`, `ignore_errors:`, etc. The fix introduces `_AnsibleSafeLoader`, a `yaml_SafeLoader` subclass that re-registers the standard `construct_yaml_bool` constructor.

- **`ssg/utils.py` + callers**: `eval()` is replaced by `safe_eval_filter()`, an AST-based whitelist evaluator. Allowed node types: `BoolOp`, `UnaryOp/Not`, `Compare` (`in`/`not in`/`==`/`!=`), `Constant`, `Name`, `List`, `Tuple`. Everything else raises `ValueError`. All existing `filter_rules` expressions in the repo (`"ocp4-node" in platform`, etc.) continue to work. The duplicate `rule_filter_from_def` in `build_yaml.py` (dead code, no callers) is removed.

- Quick smoke test: `python3 -c "from ssg.utils import safe_eval_filter; print(safe_eval_filter('\"ocp4-node\" in platform', {'platform': 'ocp4-node'}))"` → `True`.
