### PR TITLE
Check selection lines with direct attributes in aide.conf

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -22,5 +22,12 @@
     path: /etc/aide.conf
     regexp: (^\s*{{ item }}\s*=\s*)(?!.*acl)([^\s]*)
     replace: \g<1>\g<2>+acl
-  when: find_rules_groups_results is not skipped and "'aide' in ansible_facts.packages"
+  when: "find_rules_groups_results is not skipped and 'aide' in ansible_facts.packages"
   with_items: "{{ find_rules_groups_results.stdout_lines | map('trim') | list }}"
+
+- name: Ensure the acl attribute is present on selection lines with direct attributes
+  ansible.builtin.replace:
+    path: /etc/aide.conf
+    regexp: ^(\/\S+\s+)(?!.*acl)([a-z][a-zA-Z0-9+]*)
+    replace: \g<1>\g<2>+acl
+  when: "'aide' in ansible_facts.packages"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
@@ -25,3 +25,6 @@ do
 	fi
 	sed -i "s/^$group\s*=.*/$group = $config/g" $aide_conf
 done
+
+# Add acl to selection lines that specify attributes directly (e.g., /path p+i+n+u+g)
+LC_ALL=C sed -i -E '/^\/\S+\s+[a-z]/ { /acl/! s/^(\/\S+\s+)([a-z][a-zA-Z0-9+]*)/\1\2+acl/ }' "$aide_conf"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
@@ -3,12 +3,13 @@
     {{{ oval_metadata("AIDE should be configured to verify Access Control Lists (ACLs).", rule_title=rule_title) }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
-      <criterion comment="acl is set in {{{ aide_conf_path }}}" test_ref="test_aide_verify_acls" />
+      <criterion comment="acl is set in group definitions in {{{ aide_conf_path }}}" test_ref="test_aide_verify_acls" />
+      <criterion comment="acl is set in selection lines in {{{ aide_conf_path }}}" test_ref="test_aide_verify_acls_selection_lines" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test id="test_aide_verify_acls"
-  comment="acl is set in {{{ aide_conf_path }}}" check="all"
+  comment="acl is set in group definitions in {{{ aide_conf_path }}}" check="all"
   check_existence="all_exist" version="1">
     <ind:object object_ref="object_aide_verify_acls" />
     <ind:state state_ref="state_aide_verify_acls" />
@@ -21,6 +22,19 @@
     {{% else %}}
     <ind:pattern operation="pattern match">^(?!ALLXTRAHASHES)[A-Z][a-zA-Z_]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
     {{% endif %}}
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_acls_selection_lines"
+  comment="acl is set in selection lines in {{{ aide_conf_path }}}" check="all"
+  check_existence="any_exist" version="1">
+    <ind:object object_ref="object_aide_verify_acls_selection_lines" />
+    <ind:state state_ref="state_aide_verify_acls" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_acls_selection_lines"
+  version="1">
+    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^/\S+\s+([a-z][a-zA-Z0-9\+]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
@@ -11,13 +11,16 @@ description: |-
     <pre>FIPSR = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha256</pre>
     AIDE rules can be configured in multiple ways; this is merely one example that is already
     configured by default.
+    The <tt>acl</tt> option must also be present on selection lines that specify
+    attributes directly without referencing a group. For example:
+    <pre>/bin p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha256</pre>
 
     {{% if "debian" in product %}}
     The remediation provided with this rule adds <tt>acl</tt> to the OwnerMode rule
-    in <tt>{{{ aide_conf_path }}}</tt>
+    in <tt>{{{ aide_conf_path }}}</tt> and to any selection lines that specify attributes directly.
     {{% else %}}
     The remediation provided with this rule adds <tt>acl</tt> to all rule sets available in
-    <tt>{{{ aide_conf_path }}}</tt>
+    <tt>{{{ aide_conf_path }}}</tt> and to any selection lines that specify attributes directly.
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value_inline.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value_inline.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = aide
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+
+
+cat >/etc/aide.conf <<EOL
+All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
+/bin p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+/sbin p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value_inline.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value_inline.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = aide
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+
+
+cat >/etc/aide.conf <<EOL
+All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
+/bin p+i+n+u+g+s+m+S+sha512+xattrs+selinux
+/sbin p+i+n+u+g+s+m+S+sha512+xattrs+selinux
+EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -22,5 +22,12 @@
     path: /etc/aide.conf
     regexp: (^\s*{{ item }}\s*=\s*)(?!.*xattrs)([^\s]*)
     replace: \g<1>\g<2>+xattrs
-  when: find_rules_groups_results is not skipped and "'aide' in ansible_facts.packages"
+  when: "find_rules_groups_results is not skipped and 'aide' in ansible_facts.packages"
   with_items: "{{ find_rules_groups_results.stdout_lines | map('trim') | list }}"
+
+- name: Ensure the xattrs attribute is present on selection lines with direct attributes
+  ansible.builtin.replace:
+    path: /etc/aide.conf
+    regexp: ^(\/\S+\s+)(?!.*xattrs)([a-z][a-zA-Z0-9+]*)
+    replace: \g<1>\g<2>+xattrs
+  when: "'aide' in ansible_facts.packages"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
@@ -25,3 +25,6 @@ do
 	fi
 	sed -i "s/^$group\s*=.*/$group = $config/g" $aide_conf
 done
+
+# Add xattrs to selection lines that specify attributes directly (e.g., /path p+i+n+u+g)
+LC_ALL=C sed -i -E '/^\/\S+\s+[a-z]/ { /xattrs/! s/^(\/\S+\s+)([a-z][a-zA-Z0-9+]*)/\1\2+xattrs/ }' "$aide_conf"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
@@ -3,12 +3,13 @@
     {{{ oval_metadata("AIDE should be configured to verify extended file attributes.", rule_title=rule_title) }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
-      <criterion comment="xattrs is set in {{{ aide_conf_path }}}" test_ref="test_aide_verify_ext_attributes" />
+      <criterion comment="xattrs is set in group definitions in {{{ aide_conf_path }}}" test_ref="test_aide_verify_ext_attributes" />
+      <criterion comment="xattrs is set in selection lines in {{{ aide_conf_path }}}" test_ref="test_aide_verify_ext_attributes_selection_lines" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test id="test_aide_verify_ext_attributes"
-  comment="xattrs is set in {{{ aide_conf_path }}}" check="all"
+  comment="xattrs is set in group definitions in {{{ aide_conf_path }}}" check="all"
   check_existence="all_exist" version="1">
     <ind:object object_ref="object_aide_verify_ext_attributes" />
     <ind:state state_ref="state_aide_verify_ext_attributes" />
@@ -21,6 +22,19 @@
     {{% else %}}
     <ind:pattern operation="pattern match">^(?!ALLXTRAHASHES)[A-Z][a-zA-Z_]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
     {{% endif %}}
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_ext_attributes_selection_lines"
+  comment="xattrs is set in selection lines in {{{ aide_conf_path }}}" check="all"
+  check_existence="any_exist" version="1">
+    <ind:object object_ref="object_aide_verify_ext_attributes_selection_lines" />
+    <ind:state state_ref="state_aide_verify_ext_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_ext_attributes_selection_lines"
+  version="1">
+    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^/\S+\s+([a-z][a-zA-Z0-9\+]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
@@ -11,13 +11,16 @@ description: |-
     <pre>FIPSR = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha256</pre>
     AIDE rules can be configured in multiple ways; this is merely one example that is already
     configured by default.
+    The <tt>xattrs</tt> option must also be present on selection lines that specify
+    attributes directly without referencing a group. For example:
+    <pre>/bin p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha256</pre>
 
     {{% if "debian" in product %}}
     The remediation provided with this rule adds <tt>xattrs</tt> to the InodeData rule in
-    <tt>{{{ aide_conf_path }}}</tt>
+    <tt>{{{ aide_conf_path }}}</tt> and to any selection lines that specify attributes directly.
     {{% else %}}
     The remediation provided with this rule adds <tt>xattrs</tt> to all rule sets available in
-    <tt>{{{ aide_conf_path }}}</tt>
+    <tt>{{{ aide_conf_path }}}</tt> and to any selection lines that specify attributes directly.
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value_inline.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value_inline.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = aide
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+
+
+cat >/etc/aide.conf <<EOL
+All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
+/bin p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+/sbin p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value_inline.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value_inline.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = aide
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+
+
+cat >/etc/aide.conf <<EOL
+All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
+/bin p+i+n+u+g+s+m+S+sha512+acl+selinux
+/sbin p+i+n+u+g+s+m+S+sha512+acl+selinux
+EOL


### PR DESCRIPTION
AIDE config files can contain selection lines that specify attributes directly (e.g., /bin p+i+n+u+g) instead of referencing a group. These entries were not checked for the xattrs attribute. Extend the OVAL check, bash and ansible remediations, and test scenarios to cover this case in rules aide_verify_ext_attributes and aide_verify_acls.