### PR TITLE
NIST-800-53: Nest enhancements under the main controls (e.g. AC-1.1 is now under AC-1)

### DIFF
--- a/products/rhel10/controls/nist_800_53/ac.yml
+++ b/products/rhel10/controls/nist_800_53/ac.yml
@@ -12,80 +12,91 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ac-2.1
-      title: Automated System Account Management
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.2
-      title: Automated Temporary and Emergency Account Management
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.3
-      title: Disable Accounts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.4
-      title: Automated Audit Actions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.5
-      title: Inactivity Logout
-      levels:
-          - moderate
-      rules:
-          - accounts_tmout
-          - no_invalid_shell_accounts_unlocked
-          - no_password_auth_for_systemaccounts
-          - no_shelllogin_for_systemaccounts
-          - inactivity_timeout_value=15_minutes
-          - var_accounts_tmout=15_min
-      status: automated
-    - id: ac-2.6
-      title: Dynamic Privilege Management
-      rules: []
-      status: pending
-    - id: ac-2.7
-      title: Privileged User Accounts
-      rules: []
-      status: pending
-    - id: ac-2.8
-      title: Dynamic Account Management
-      rules: []
-      status: pending
-    - id: ac-2.9
-      title: Restrictions on Use of Shared and Group Accounts
-      rules: []
-      status: pending
-    - id: ac-2.10
-      title: Shared and Group Account Credential Change
-      rules: []
-      status: pending
-    - id: ac-2.11
-      title: Usage Conditions
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-2.12
-      title: Account Monitoring for Atypical Usage
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-2.13
-      title: Disable Accounts for High-risk Individuals
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-2.1
+            title: Automated System Account Management
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.2
+            title: Automated Temporary and Emergency Account Management
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.3
+            title: Disable Accounts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.4
+            title: Automated Audit Actions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.5
+            title: Inactivity Logout
+            levels:
+                - moderate
+            rules:
+                - accounts_tmout
+                - no_invalid_shell_accounts_unlocked
+                - no_password_auth_for_systemaccounts
+                - no_shelllogin_for_systemaccounts
+                - inactivity_timeout_value=15_minutes
+                - var_accounts_tmout=15_min
+            status: automated
+          - id: ac-2.6
+            title: Dynamic Privilege Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.7
+            title: Privileged User Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.8
+            title: Dynamic Account Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.9
+            title: Restrictions on Use of Shared and Group Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.10
+            title: Shared and Group Account Credential Change
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.11
+            title: Usage Conditions
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-2.12
+            title: Account Monitoring for Atypical Usage
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-2.13
+            title: Disable Accounts for High-risk Individuals
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-3
       title: Access Enforcement
       levels:
@@ -224,202 +235,296 @@ controls:
           - var_pam_wheel_group_for_su=cis
           - var_selinux_policy_name=targeted
       status: automated
-    - id: ac-3.1
-      title: Restricted Access to Privileged Functions
-      rules: []
-      status: pending
-    - id: ac-3.2
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: ac-3.3
-      title: Mandatory Access Control
-      rules: []
-      status: pending
-    - id: ac-3.4
-      title: Discretionary Access Control
-      rules: []
-      status: pending
-    - id: ac-3.5
-      title: Security-relevant Information
-      rules: []
-      status: pending
-    - id: ac-3.6
-      title: Protection of User and System Information
-      rules: []
-      status: pending
-    - id: ac-3.7
-      title: Role-based Access Control
-      rules: []
-      status: pending
-    - id: ac-3.8
-      title: Revocation of Access Authorizations
-      rules: []
-      status: pending
-    - id: ac-3.9
-      title: Controlled Release
-      rules: []
-      status: pending
-    - id: ac-3.10
-      title: Audited Override of Access Control Mechanisms
-      rules: []
-      status: pending
-    - id: ac-3.11
-      title: Restrict Access to Specific Information Types
-      rules: []
-      status: pending
-    - id: ac-3.12
-      title: Assert and Enforce Application Access
-      rules: []
-      status: pending
-    - id: ac-3.13
-      title: Attribute-based Access Control
-      rules: []
-      status: pending
-    - id: ac-3.14
-      title: Individual Access
-      rules: []
-      status: pending
-    - id: ac-3.15
-      title: Discretionary and Mandatory Access Control
-      rules: []
-      status: pending
+      controls:
+          - id: ac-3.1
+            title: Restricted Access to Privileged Functions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.2
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.3
+            title: Mandatory Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.4
+            title: Discretionary Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.5
+            title: Security-relevant Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.6
+            title: Protection of User and System Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.7
+            title: Role-based Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.8
+            title: Revocation of Access Authorizations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.9
+            title: Controlled Release
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.10
+            title: Audited Override of Access Control Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.11
+            title: Restrict Access to Specific Information Types
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.12
+            title: Assert and Enforce Application Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.13
+            title: Attribute-based Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.14
+            title: Individual Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.15
+            title: Discretionary and Mandatory Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-4
       title: Information Flow Enforcement
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-4.1
-      title: Object Security and Privacy Attributes
-      rules: []
-      status: pending
-    - id: ac-4.2
-      title: Processing Domains
-      rules: []
-      status: pending
-    - id: ac-4.3
-      title: Dynamic Information Flow Control
-      rules: []
-      status: pending
-    - id: ac-4.4
-      title: Flow Control of Encrypted Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-4.5
-      title: Embedded Data Types
-      rules: []
-      status: pending
-    - id: ac-4.6
-      title: Metadata
-      rules: []
-      status: pending
-    - id: ac-4.7
-      title: One-way Flow Mechanisms
-      rules: []
-      status: pending
-    - id: ac-4.8
-      title: Security and Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.9
-      title: Human Reviews
-      rules: []
-      status: pending
-    - id: ac-4.10
-      title: Enable and Disable Security or Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.11
-      title: Configuration of Security or Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.12
-      title: Data Type Identifiers
-      rules: []
-      status: pending
-    - id: ac-4.13
-      title: Decomposition into Policy-relevant Subcomponents
-      rules: []
-      status: pending
-    - id: ac-4.14
-      title: Security or Privacy Policy Filter Constraints
-      rules: []
-      status: pending
-    - id: ac-4.15
-      title: Detection of Unsanctioned Information
-      rules: []
-      status: pending
-    - id: ac-4.16
-      title: Information Transfers on Interconnected Systems
-      rules: []
-      status: pending
-    - id: ac-4.17
-      title: Domain Authentication
-      rules: []
-      status: pending
-    - id: ac-4.18
-      title: Security Attribute Binding
-      rules: []
-      status: pending
-    - id: ac-4.19
-      title: Validation of Metadata
-      rules: []
-      status: pending
-    - id: ac-4.20
-      title: Approved Solutions
-      rules: []
-      status: pending
-    - id: ac-4.21
-      title: Physical or Logical Separation of Information Flows
-      rules: []
-      status: pending
-    - id: ac-4.22
-      title: Access Only
-      rules: []
-      status: pending
-    - id: ac-4.23
-      title: Modify Non-releasable Information
-      rules: []
-      status: pending
-    - id: ac-4.24
-      title: Internal Normalized Format
-      rules: []
-      status: pending
-    - id: ac-4.25
-      title: Data Sanitization
-      rules: []
-      status: pending
-    - id: ac-4.26
-      title: Audit Filtering Actions
-      rules: []
-      status: pending
-    - id: ac-4.27
-      title: Redundant/Independent Filtering Mechanisms
-      rules: []
-      status: pending
-    - id: ac-4.28
-      title: Linear Filter Pipelines
-      rules: []
-      status: pending
-    - id: ac-4.29
-      title: Filter Orchestration Engines
-      rules: []
-      status: pending
-    - id: ac-4.30
-      title: Filter Mechanisms Using Multiple Processes
-      rules: []
-      status: pending
-    - id: ac-4.31
-      title: Failed Content Transfer Prevention
-      rules: []
-      status: pending
-    - id: ac-4.32
-      title: Process Requirements for Information Transfer
-      rules: []
-      status: pending
+      controls:
+          - id: ac-4.1
+            title: Object Security and Privacy Attributes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.2
+            title: Processing Domains
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.3
+            title: Dynamic Information Flow Control
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.4
+            title: Flow Control of Encrypted Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-4.5
+            title: Embedded Data Types
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.6
+            title: Metadata
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.7
+            title: One-way Flow Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.8
+            title: Security and Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.9
+            title: Human Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.10
+            title: Enable and Disable Security or Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.11
+            title: Configuration of Security or Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.12
+            title: Data Type Identifiers
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.13
+            title: Decomposition into Policy-relevant Subcomponents
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.14
+            title: Security or Privacy Policy Filter Constraints
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.15
+            title: Detection of Unsanctioned Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.16
+            title: Information Transfers on Interconnected Systems
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.17
+            title: Domain Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.18
+            title: Security Attribute Binding
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.19
+            title: Validation of Metadata
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.20
+            title: Approved Solutions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.21
+            title: Physical or Logical Separation of Information Flows
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.22
+            title: Access Only
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.23
+            title: Modify Non-releasable Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.24
+            title: Internal Normalized Format
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.25
+            title: Data Sanitization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.26
+            title: Audit Filtering Actions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.27
+            title: Redundant/Independent Filtering Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.28
+            title: Linear Filter Pipelines
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.29
+            title: Filter Orchestration Engines
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.30
+            title: Filter Mechanisms Using Multiple Processes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.31
+            title: Failed Content Transfer Prevention
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.32
+            title: Process Requirements for Information Transfer
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-5
       title: Separation of Duties
       levels:
@@ -436,61 +541,69 @@ controls:
           - sudo_remove_no_authenticate
           - sudo_remove_nopasswd
       status: automated
-    - id: ac-6.1
-      title: Authorize Access to Security Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.2
-      title: Non-privileged Access for Nonsecurity Functions
-      levels:
-          - moderate
-      rules:
-          - package_sudo_installed
-      status: automated
-    - id: ac-6.3
-      title: Network Access to Privileged Commands
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-6.4
-      title: Separate Processing Domains
-      rules: []
-      status: pending
-    - id: ac-6.5
-      title: Privileged Accounts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.6
-      title: Privileged Access by Non-organizational Users
-      rules: []
-      status: pending
-    - id: ac-6.7
-      title: Review of User Privileges
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.8
-      title: Privilege Levels for Code Execution
-      rules: []
-      status: pending
-    - id: ac-6.9
-      title: Log Use of Privileged Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.10
-      title: Prohibit Non-privileged Users from Executing Privileged Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-6.1
+            title: Authorize Access to Security Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.2
+            title: Non-privileged Access for Nonsecurity Functions
+            levels:
+                - moderate
+            rules:
+                - package_sudo_installed
+            status: automated
+          - id: ac-6.3
+            title: Network Access to Privileged Commands
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-6.4
+            title: Separate Processing Domains
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.5
+            title: Privileged Accounts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.6
+            title: Privileged Access by Non-organizational Users
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.7
+            title: Review of User Privileges
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.8
+            title: Privilege Levels for Code Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.9
+            title: Log Use of Privileged Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.10
+            title: Prohibit Non-privileged Users from Executing Privileged
+                Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-7
       title: Unsuccessful Logon Attempts
       levels:
@@ -506,22 +619,31 @@ controls:
           - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
       status: automated
-    - id: ac-7.1
-      title: Automatic Account Lock
-      rules: []
-      status: pending
-    - id: ac-7.2
-      title: Purge or Wipe Mobile Device
-      rules: []
-      status: pending
-    - id: ac-7.3
-      title: Biometric Attempt Limiting
-      rules: []
-      status: pending
-    - id: ac-7.4
-      title: Use of Alternate Authentication Factor
-      rules: []
-      status: pending
+      controls:
+          - id: ac-7.1
+            title: Automatic Account Lock
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.2
+            title: Purge or Wipe Mobile Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.3
+            title: Biometric Attempt Limiting
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.4
+            title: Use of Alternate Authentication Factor
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-8
       title: System Use Notification
       levels:
@@ -534,22 +656,23 @@ controls:
       title: Previous Logon Notification
       rules: []
       status: pending
-    - id: ac-9.1
-      title: Unsuccessful Logons
-      rules: []
-      status: pending
-    - id: ac-9.2
-      title: Successful and Unsuccessful Logons
-      rules: []
-      status: pending
-    - id: ac-9.3
-      title: Notification of Account Changes
-      rules: []
-      status: pending
-    - id: ac-9.4
-      title: Additional Logon Information
-      rules: []
-      status: pending
+      controls:
+          - id: ac-9.1
+            title: Unsuccessful Logons
+            rules: []
+            status: pending
+          - id: ac-9.2
+            title: Successful and Unsuccessful Logons
+            rules: []
+            status: pending
+          - id: ac-9.3
+            title: Notification of Account Changes
+            rules: []
+            status: pending
+          - id: ac-9.4
+            title: Additional Logon Information
+            rules: []
+            status: pending
     - id: ac-10
       title: Concurrent Session Control
       levels:
@@ -567,30 +690,38 @@ controls:
           - dconf_gnome_session_idle_user_locks
           - var_screensaver_lock_delay=5_seconds
       status: automated
-    - id: ac-11.1
-      title: Pattern-hiding Displays
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-11.1
+            title: Pattern-hiding Displays
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-12
       title: Session Termination
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-12.1
-      title: User-initiated Logouts
-      rules: []
-      status: pending
-    - id: ac-12.2
-      title: Termination Message
-      rules: []
-      status: pending
-    - id: ac-12.3
-      title: Timeout Warning Message
-      rules: []
-      status: pending
+      controls:
+          - id: ac-12.1
+            title: User-initiated Logouts
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-12.2
+            title: Termination Message
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-12.3
+            title: Timeout Warning Message
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-13
       title: Supervision and Review — Access Control
       rules: []
@@ -601,10 +732,13 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ac-14.1
-      title: Necessary Uses
-      rules: []
-      status: pending
+      controls:
+          - id: ac-14.1
+            title: Necessary Uses
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-15
       title: Automated Marking
       rules: []
@@ -613,46 +747,47 @@ controls:
       title: Security and Privacy Attributes
       rules: []
       status: pending
-    - id: ac-16.1
-      title: Dynamic Attribute Association
-      rules: []
-      status: pending
-    - id: ac-16.2
-      title: Attribute Value Changes by Authorized Individuals
-      rules: []
-      status: pending
-    - id: ac-16.3
-      title: Maintenance of Attribute Associations by System
-      rules: []
-      status: pending
-    - id: ac-16.4
-      title: Association of Attributes by Authorized Individuals
-      rules: []
-      status: pending
-    - id: ac-16.5
-      title: Attribute Displays on Objects to Be Output
-      rules: []
-      status: pending
-    - id: ac-16.6
-      title: Maintenance of Attribute Association
-      rules: []
-      status: pending
-    - id: ac-16.7
-      title: Consistent Attribute Interpretation
-      rules: []
-      status: pending
-    - id: ac-16.8
-      title: Association Techniques and Technologies
-      rules: []
-      status: pending
-    - id: ac-16.9
-      title: Attribute Reassignment — Regrading Mechanisms
-      rules: []
-      status: pending
-    - id: ac-16.10
-      title: Attribute Configuration by Authorized Individuals
-      rules: []
-      status: pending
+      controls:
+          - id: ac-16.1
+            title: Dynamic Attribute Association
+            rules: []
+            status: pending
+          - id: ac-16.2
+            title: Attribute Value Changes by Authorized Individuals
+            rules: []
+            status: pending
+          - id: ac-16.3
+            title: Maintenance of Attribute Associations by System
+            rules: []
+            status: pending
+          - id: ac-16.4
+            title: Association of Attributes by Authorized Individuals
+            rules: []
+            status: pending
+          - id: ac-16.5
+            title: Attribute Displays on Objects to Be Output
+            rules: []
+            status: pending
+          - id: ac-16.6
+            title: Maintenance of Attribute Association
+            rules: []
+            status: pending
+          - id: ac-16.7
+            title: Consistent Attribute Interpretation
+            rules: []
+            status: pending
+          - id: ac-16.8
+            title: Association Techniques and Technologies
+            rules: []
+            status: pending
+          - id: ac-16.9
+            title: Attribute Reassignment — Regrading Mechanisms
+            rules: []
+            status: pending
+          - id: ac-16.10
+            title: Attribute Configuration by Authorized Individuals
+            rules: []
+            status: pending
     - id: ac-17
       title: Remote Access
       levels:
@@ -660,54 +795,67 @@ controls:
       rules:
           - configure_custom_crypto_policy_cis
       status: automated
-    - id: ac-17.1
-      title: Monitoring and Control
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.2
-      title: Protection of Confidentiality and Integrity Using Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.3
-      title: Managed Access Control Points
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.4
-      title: Privileged Commands and Access
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.5
-      title: Monitoring for Unauthorized Connections
-      rules: []
-      status: pending
-    - id: ac-17.6
-      title: Protection of Mechanism Information
-      rules: []
-      status: pending
-    - id: ac-17.7
-      title: Additional Protection for Security Function Access
-      rules: []
-      status: pending
-    - id: ac-17.8
-      title: Disable Nonsecure Network Protocols
-      rules: []
-      status: pending
-    - id: ac-17.9
-      title: Disconnect or Disable Access
-      rules: []
-      status: pending
-    - id: ac-17.10
-      title: Authenticate Remote Commands
-      rules: []
-      status: pending
+      controls:
+          - id: ac-17.1
+            title: Monitoring and Control
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.2
+            title: Protection of Confidentiality and Integrity Using Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.3
+            title: Managed Access Control Points
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.4
+            title: Privileged Commands and Access
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.5
+            title: Monitoring for Unauthorized Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.6
+            title: Protection of Mechanism Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.7
+            title: Additional Protection for Security Function Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.8
+            title: Disable Nonsecure Network Protocols
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.9
+            title: Disconnect or Disable Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.10
+            title: Authenticate Remote Commands
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-18
       title: Wireless Access
       levels:
@@ -715,106 +863,130 @@ controls:
       rules:
           - wireless_disable_interfaces
       status: automated
-    - id: ac-18.1
-      title: Authentication and Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-18.2
-      title: Monitoring Unauthorized Connections
-      rules: []
-      status: pending
-    - id: ac-18.3
-      title: Disable Wireless Networking
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-18.4
-      title: Restrict Configurations by Users
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-18.5
-      title: Antennas and Transmission Power Levels
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ac-18.1
+            title: Authentication and Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-18.2
+            title: Monitoring Unauthorized Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-18.3
+            title: Disable Wireless Networking
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-18.4
+            title: Restrict Configurations by Users
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-18.5
+            title: Antennas and Transmission Power Levels
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ac-19
       title: Access Control for Mobile Devices
       levels:
           - low
       rules: []
       status: pending
-    - id: ac-19.1
-      title: Use of Writable and Portable Storage Devices
-      rules: []
-      status: pending
-    - id: ac-19.2
-      title: Use of Personally Owned Portable Storage Devices
-      rules: []
-      status: pending
-    - id: ac-19.3
-      title: Use of Portable Storage Devices with No Identifiable Owner
-      rules: []
-      status: pending
-    - id: ac-19.4
-      title: Restrictions for Classified Information
-      rules: []
-      status: pending
-    - id: ac-19.5
-      title: Full Device or Container-based Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-19.1
+            title: Use of Writable and Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.2
+            title: Use of Personally Owned Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.3
+            title: Use of Portable Storage Devices with No Identifiable Owner
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.4
+            title: Restrictions for Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.5
+            title: Full Device or Container-based Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-20
       title: Use of External Systems
       levels:
           - low
       rules: []
       status: pending
-    - id: ac-20.1
-      title: Limits on Authorized Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-20.2
-      title: Portable Storage Devices — Restricted Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-20.3
-      title: Non-organizationally Owned Systems — Restricted Use
-      rules: []
-      status: pending
-    - id: ac-20.4
-      title: Network Accessible Storage Devices — Prohibited Use
-      rules: []
-      status: pending
-    - id: ac-20.5
-      title: Portable Storage Devices — Prohibited Use
-      rules: []
-      status: pending
+      controls:
+          - id: ac-20.1
+            title: Limits on Authorized Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-20.2
+            title: Portable Storage Devices — Restricted Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-20.3
+            title: Non-organizationally Owned Systems — Restricted Use
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-20.4
+            title: Network Accessible Storage Devices — Prohibited Use
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-20.5
+            title: Portable Storage Devices — Prohibited Use
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-21
       title: Information Sharing
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-21.1
-      title: Automated Decision Support
-      rules: []
-      status: pending
-    - id: ac-21.2
-      title: Information Search and Retrieval
-      rules: []
-      status: pending
+      controls:
+          - id: ac-21.1
+            title: Automated Decision Support
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-21.2
+            title: Information Search and Retrieval
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-22
       title: Publicly Accessible Content
       levels:
@@ -829,14 +1001,15 @@ controls:
       title: Access Control Decisions
       rules: []
       status: pending
-    - id: ac-24.1
-      title: Transmit Access Authorization Information
-      rules: []
-      status: pending
-    - id: ac-24.2
-      title: No User or Process Identity
-      rules: []
-      status: pending
+      controls:
+          - id: ac-24.1
+            title: Transmit Access Authorization Information
+            rules: []
+            status: pending
+          - id: ac-24.2
+            title: No User or Process Identity
+            rules: []
+            status: pending
     - id: ac-25
       title: Reference Monitor
       rules: []

--- a/products/rhel10/controls/nist_800_53/at.yml
+++ b/products/rhel10/controls/nist_800_53/at.yml
@@ -12,60 +12,80 @@ controls:
           - low
       rules: []
       status: pending
-    - id: at-2.1
-      title: Practical Exercises
-      rules: []
-      status: pending
-    - id: at-2.2
-      title: Insider Threat
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: at-2.3
-      title: Social Engineering and Mining
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: at-2.4
-      title: Suspicious Communications and Anomalous System Behavior
-      rules: []
-      status: pending
-    - id: at-2.5
-      title: Advanced Persistent Threat
-      rules: []
-      status: pending
-    - id: at-2.6
-      title: Cyber Threat Environment
-      rules: []
-      status: pending
+      controls:
+          - id: at-2.1
+            title: Practical Exercises
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.2
+            title: Insider Threat
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: at-2.3
+            title: Social Engineering and Mining
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: at-2.4
+            title: Suspicious Communications and Anomalous System Behavior
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.5
+            title: Advanced Persistent Threat
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.6
+            title: Cyber Threat Environment
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: at-3
       title: Role-based Training
       levels:
           - low
       rules: []
       status: pending
-    - id: at-3.1
-      title: Environmental Controls
-      rules: []
-      status: pending
-    - id: at-3.2
-      title: Physical Security Controls
-      rules: []
-      status: pending
-    - id: at-3.3
-      title: Practical Exercises
-      rules: []
-      status: pending
-    - id: at-3.4
-      title: Suspicious Communications and Anomalous System Behavior
-      rules: []
-      status: pending
-    - id: at-3.5
-      title: Processing Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: at-3.1
+            title: Environmental Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.2
+            title: Physical Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.3
+            title: Practical Exercises
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.4
+            title: Suspicious Communications and Anomalous System Behavior
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.5
+            title: Processing Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: at-4
       title: Training Records
       levels:

--- a/products/rhel10/controls/nist_800_53/au.yml
+++ b/products/rhel10/controls/nist_800_53/au.yml
@@ -38,22 +38,31 @@ controls:
           - var_auditd_admin_space_left_action=cis_rhel10
           - var_auditd_space_left_action=cis_rhel10
       status: automated
-    - id: au-2.1
-      title: Compilation of Audit Records from Multiple Sources
-      rules: []
-      status: pending
-    - id: au-2.2
-      title: Selection of Audit Events by Component
-      rules: []
-      status: pending
-    - id: au-2.3
-      title: Reviews and Updates
-      rules: []
-      status: pending
-    - id: au-2.4
-      title: Privileged Functions
-      rules: []
-      status: pending
+      controls:
+          - id: au-2.1
+            title: Compilation of Audit Records from Multiple Sources
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.2
+            title: Selection of Audit Events by Component
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.3
+            title: Reviews and Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.4
+            title: Privileged Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-3
       title: Content of Audit Records
       levels:
@@ -128,20 +137,25 @@ controls:
           - sshd_max_auth_tries_value=4
           - var_multiple_time_servers=rhel
       status: automated
-    - id: au-3.1
-      title: Additional Audit Information
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-3.2
-      title: Centralized Management of Planned Audit Record Content
-      rules: []
-      status: pending
-    - id: au-3.3
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
+      controls:
+          - id: au-3.1
+            title: Additional Audit Information
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-3.2
+            title: Centralized Management of Planned Audit Record Content
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-3.3
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-4
       title: Audit Log Storage Capacity
       levels:
@@ -149,10 +163,13 @@ controls:
       rules:
           - journald_compress
       status: automated
-    - id: au-4.1
-      title: Transfer to Alternate Storage
-      rules: []
-      status: pending
+      controls:
+          - id: au-4.1
+            title: Transfer to Alternate Storage
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-5
       title: Response to Audit Logging Process Failures
       levels:
@@ -163,100 +180,123 @@ controls:
           - var_auditd_disk_error_action=cis_rhel10
           - var_auditd_disk_full_action=cis_rhel10
       status: automated
-    - id: au-5.1
-      title: Storage Capacity Warning
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-5.2
-      title: Real-time Alerts
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-5.3
-      title: Configurable Traffic Volume Thresholds
-      rules: []
-      status: pending
-    - id: au-5.4
-      title: Shutdown on Failure
-      rules: []
-      status: pending
-    - id: au-5.5
-      title: Alternate Audit Logging Capability
-      rules: []
-      status: pending
+      controls:
+          - id: au-5.1
+            title: Storage Capacity Warning
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-5.2
+            title: Real-time Alerts
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-5.3
+            title: Configurable Traffic Volume Thresholds
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-5.4
+            title: Shutdown on Failure
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-5.5
+            title: Alternate Audit Logging Capability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-6
       title: Audit Record Review, Analysis, and Reporting
       levels:
           - low
       rules: []
       status: pending
-    - id: au-6.1
-      title: Automated Process Integration
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-6.2
-      title: Automated Security Alerts
-      rules: []
-      status: pending
-    - id: au-6.3
-      title: Correlate Audit Record Repositories
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-6.4
-      title: Central Review and Analysis
-      rules: []
-      status: pending
-    - id: au-6.5
-      title: Integrated Analysis of Audit Records
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-6.6
-      title: Correlation with Physical Monitoring
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-6.7
-      title: Permitted Actions
-      rules: []
-      status: pending
-    - id: au-6.8
-      title: Full Text Analysis of Privileged Commands
-      rules: []
-      status: pending
-    - id: au-6.9
-      title: Correlation with Information from Nontechnical Sources
-      rules: []
-      status: pending
-    - id: au-6.10
-      title: Audit Level Adjustment
-      rules: []
-      status: pending
+      controls:
+          - id: au-6.1
+            title: Automated Process Integration
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-6.2
+            title: Automated Security Alerts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.3
+            title: Correlate Audit Record Repositories
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-6.4
+            title: Central Review and Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.5
+            title: Integrated Analysis of Audit Records
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-6.6
+            title: Correlation with Physical Monitoring
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-6.7
+            title: Permitted Actions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.8
+            title: Full Text Analysis of Privileged Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.9
+            title: Correlation with Information from Nontechnical Sources
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.10
+            title: Audit Level Adjustment
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-7
       title: Audit Record Reduction and Report Generation
       levels:
           - moderate
       rules: []
       status: pending
-    - id: au-7.1
-      title: Automatic Processing
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-7.2
-      title: Automatic Sort and Search
-      rules: []
-      status: pending
+      controls:
+          - id: au-7.1
+            title: Automatic Processing
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-7.2
+            title: Automatic Sort and Search
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: au-8
       title: Time Stamps
       levels:
@@ -267,14 +307,19 @@ controls:
           - var_auditd_max_log_file=8
           - var_auditd_max_log_file_action=keep_logs
       status: automated
-    - id: au-8.1
-      title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
-    - id: au-8.2
-      title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      controls:
+          - id: au-8.1
+            title: Synchronization with Authoritative Time Source
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-8.2
+            title: Secondary Authoritative Time Source
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-9
       title: Protection of Audit Information
       levels:
@@ -285,79 +330,102 @@ controls:
           - file_ownership_audit_binaries
           - file_ownership_audit_configuration
       status: automated
-    - id: au-9.1
-      title: Hardware Write-once Media
-      rules: []
-      status: pending
-    - id: au-9.2
-      title: Store on Separate Physical Systems or Components
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-9.3
-      title: Cryptographic Protection
-      levels:
-          - high
-      rules:
-          - aide_check_audit_tools
-      status: automated
-    - id: au-9.4
-      title: Access by Subset of Privileged Users
-      levels:
-          - moderate
-      rules:
-          - file_group_ownership_var_log_audit
-          - file_permissions_var_log_audit
-      status: automated
-    - id: au-9.5
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: au-9.6
-      title: Read-only Access
-      rules: []
-      status: pending
-    - id: au-9.7
-      title: Store on Component with Different Operating System
-      rules: []
-      status: pending
+      controls:
+          - id: au-9.1
+            title: Hardware Write-once Media
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.2
+            title: Store on Separate Physical Systems or Components
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-9.3
+            title: Cryptographic Protection
+            levels:
+                - high
+            rules:
+                - aide_check_audit_tools
+            status: automated
+          - id: au-9.4
+            title: Access by Subset of Privileged Users
+            levels:
+                - moderate
+            rules:
+                - file_group_ownership_var_log_audit
+                - file_permissions_var_log_audit
+            status: automated
+          - id: au-9.5
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.6
+            title: Read-only Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.7
+            title: Store on Component with Different Operating System
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-10
       title: Non-repudiation
       levels:
           - high
       rules: []
       status: pending
-    - id: au-10.1
-      title: Association of Identities
-      rules: []
-      status: pending
-    - id: au-10.2
-      title: Validate Binding of Information Producer Identity
-      rules: []
-      status: pending
-    - id: au-10.3
-      title: Chain of Custody
-      rules: []
-      status: pending
-    - id: au-10.4
-      title: Validate Binding of Information Reviewer Identity
-      rules: []
-      status: pending
-    - id: au-10.5
-      title: Digital Signatures
-      rules: []
-      status: pending
+      controls:
+          - id: au-10.1
+            title: Association of Identities
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.2
+            title: Validate Binding of Information Producer Identity
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.3
+            title: Chain of Custody
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.4
+            title: Validate Binding of Information Reviewer Identity
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.5
+            title: Digital Signatures
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: au-11
       title: Audit Record Retention
       levels:
           - low
       rules: []
       status: pending
-    - id: au-11.1
-      title: Long-term Retrieval Capability
-      rules: []
-      status: pending
+      controls:
+          - id: au-11.1
+            title: Long-term Retrieval Capability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-12
       title: Audit Record Generation
       levels:
@@ -412,58 +480,65 @@ controls:
           - grub2_audit_argument
           - service_auditd_enabled
       status: automated
-    - id: au-12.1
-      title: System-wide and Time-correlated Audit Trail
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-12.2
-      title: Standardized Formats
-      rules: []
-      status: pending
-    - id: au-12.3
-      title: Changes by Authorized Individuals
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-12.4
-      title: Query Parameter Audits of Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: au-12.1
+            title: System-wide and Time-correlated Audit Trail
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-12.2
+            title: Standardized Formats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-12.3
+            title: Changes by Authorized Individuals
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-12.4
+            title: Query Parameter Audits of Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-13
       title: Monitoring for Information Disclosure
       rules: []
       status: pending
-    - id: au-13.1
-      title: Use of Automated Tools
-      rules: []
-      status: pending
-    - id: au-13.2
-      title: Review of Monitored Sites
-      rules: []
-      status: pending
-    - id: au-13.3
-      title: Unauthorized Replication of Information
-      rules: []
-      status: pending
+      controls:
+          - id: au-13.1
+            title: Use of Automated Tools
+            rules: []
+            status: pending
+          - id: au-13.2
+            title: Review of Monitored Sites
+            rules: []
+            status: pending
+          - id: au-13.3
+            title: Unauthorized Replication of Information
+            rules: []
+            status: pending
     - id: au-14
       title: Session Audit
       rules: []
       status: pending
-    - id: au-14.1
-      title: System Start-up
-      rules: []
-      status: pending
-    - id: au-14.2
-      title: Capture and Record Content
-      rules: []
-      status: pending
-    - id: au-14.3
-      title: Remote Viewing and Listening
-      rules: []
-      status: pending
+      controls:
+          - id: au-14.1
+            title: System Start-up
+            rules: []
+            status: pending
+          - id: au-14.2
+            title: Capture and Record Content
+            rules: []
+            status: pending
+          - id: au-14.3
+            title: Remote Viewing and Listening
+            rules: []
+            status: pending
     - id: au-15
       title: Alternate Audit Logging Capability
       rules: []
@@ -472,15 +547,16 @@ controls:
       title: Cross-organizational Audit Logging
       rules: []
       status: pending
-    - id: au-16.1
-      title: Identity Preservation
-      rules: []
-      status: pending
-    - id: au-16.2
-      title: Sharing of Audit Information
-      rules: []
-      status: pending
-    - id: au-16.3
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: au-16.1
+            title: Identity Preservation
+            rules: []
+            status: pending
+          - id: au-16.2
+            title: Sharing of Audit Information
+            rules: []
+            status: pending
+          - id: au-16.3
+            title: Disassociability
+            rules: []
+            status: pending

--- a/products/rhel10/controls/nist_800_53/ca.yml
+++ b/products/rhel10/controls/nist_800_53/ca.yml
@@ -12,58 +12,74 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ca-2.1
-      title: Independent Assessors
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ca-2.2
-      title: Specialized Assessments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-2.3
-      title: Leveraging Results from External Organizations
-      rules: []
-      status: pending
+      controls:
+          - id: ca-2.1
+            title: Independent Assessors
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ca-2.2
+            title: Specialized Assessments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-2.3
+            title: Leveraging Results from External Organizations
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-3
       title: Information Exchange
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-3.1
-      title: Unclassified National Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.2
-      title: Classified National Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.3
-      title: Unclassified Non-national Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.4
-      title: Connections to Public Networks
-      rules: []
-      status: pending
-    - id: ca-3.5
-      title: Restrictions on External System Connections
-      rules: []
-      status: pending
-    - id: ca-3.6
-      title: Transfer Authorizations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-3.7
-      title: Transitive Information Exchanges
-      rules: []
-      status: pending
+      controls:
+          - id: ca-3.1
+            title: Unclassified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.2
+            title: Classified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.3
+            title: Unclassified Non-national Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.4
+            title: Connections to Public Networks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.5
+            title: Restrictions on External System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.6
+            title: Transfer Authorizations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-3.7
+            title: Transitive Information Exchanges
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-4
       title: Security Certification
       rules: []
@@ -74,78 +90,100 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ca-5.1
-      title: Automation Support for Accuracy and Currency
-      rules: []
-      status: pending
+      controls:
+          - id: ca-5.1
+            title: Automation Support for Accuracy and Currency
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-6
       title: Authorization
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-6.1
-      title: Joint Authorization — Intra-organization
-      rules: []
-      status: pending
-    - id: ca-6.2
-      title: Joint Authorization — Inter-organization
-      rules: []
-      status: pending
+      controls:
+          - id: ca-6.1
+            title: Joint Authorization — Intra-organization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-6.2
+            title: Joint Authorization — Inter-organization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-7
       title: Continuous Monitoring
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-7.1
-      title: Independent Assessment
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ca-7.2
-      title: Types of Assessments
-      rules: []
-      status: pending
-    - id: ca-7.3
-      title: Trend Analyses
-      rules: []
-      status: pending
-    - id: ca-7.4
-      title: Risk Monitoring
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ca-7.5
-      title: Consistency Analysis
-      rules: []
-      status: pending
-    - id: ca-7.6
-      title: Automation Support for Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: ca-7.1
+            title: Independent Assessment
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ca-7.2
+            title: Types of Assessments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.3
+            title: Trend Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.4
+            title: Risk Monitoring
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ca-7.5
+            title: Consistency Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.6
+            title: Automation Support for Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-8
       title: Penetration Testing
       levels:
           - high
       rules: []
       status: pending
-    - id: ca-8.1
-      title: Independent Penetration Testing Agent or Team
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-8.2
-      title: Red Team Exercises
-      rules: []
-      status: pending
-    - id: ca-8.3
-      title: Facility Penetration Testing
-      rules: []
-      status: pending
+      controls:
+          - id: ca-8.1
+            title: Independent Penetration Testing Agent or Team
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-8.2
+            title: Red Team Exercises
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: ca-8.3
+            title: Facility Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: ca-9
       title: Internal System Connections
       levels:
@@ -155,7 +193,10 @@ controls:
           - firewalld_loopback_traffic_trusted
           - package_firewalld_installed
       status: automated
-    - id: ca-9.1
-      title: Compliance Checks
-      rules: []
-      status: pending
+      controls:
+          - id: ca-9.1
+            title: Compliance Checks
+            rules: []
+            status: pending
+            levels:
+                - low

--- a/products/rhel10/controls/nist_800_53/cm.yml
+++ b/products/rhel10/controls/nist_800_53/cm.yml
@@ -76,140 +76,173 @@ controls:
           - low
       rules: []
       status: pending
-    - id: cm-2.1
-      title: Reviews and Updates
-      rules: []
-      status: pending
-    - id: cm-2.2
-      title: Automation Support for Accuracy and Currency
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-2.3
-      title: Retention of Previous Configurations
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-2.4
-      title: Unauthorized Software
-      rules: []
-      status: pending
-    - id: cm-2.5
-      title: Authorized Software
-      rules: []
-      status: pending
-    - id: cm-2.6
-      title: Development and Test Environments
-      rules: []
-      status: pending
-    - id: cm-2.7
-      title: Configure Systems and Components for High-risk Areas
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-2.1
+            title: Reviews and Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.2
+            title: Automation Support for Accuracy and Currency
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-2.3
+            title: Retention of Previous Configurations
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-2.4
+            title: Unauthorized Software
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.5
+            title: Authorized Software
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.6
+            title: Development and Test Environments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.7
+            title: Configure Systems and Components for High-risk Areas
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-3
       title: Configuration Change Control
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-3.1
-      title: Automated Documentation, Notification, and Prohibition of Changes
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-3.2
-      title: Testing, Validation, and Documentation of Changes
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-3.3
-      title: Automated Change Implementation
-      rules: []
-      status: pending
-    - id: cm-3.4
-      title: Security and Privacy Representatives
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-3.5
-      title: Automated Security Response
-      rules: []
-      status: pending
-    - id: cm-3.6
-      title: Cryptography Management
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-3.7
-      title: Review System Changes
-      rules: []
-      status: pending
-    - id: cm-3.8
-      title: Prevent or Restrict Configuration Changes
-      rules: []
-      status: pending
+      controls:
+          - id: cm-3.1
+            title: Automated Documentation, Notification, and Prohibition of
+                Changes
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-3.2
+            title: Testing, Validation, and Documentation of Changes
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-3.3
+            title: Automated Change Implementation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.4
+            title: Security and Privacy Representatives
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-3.5
+            title: Automated Security Response
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.6
+            title: Cryptography Management
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-3.7
+            title: Review System Changes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.8
+            title: Prevent or Restrict Configuration Changes
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cm-4
       title: Impact Analyses
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-4.1
-      title: Separate Test Environments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-4.2
-      title: Verification of Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-4.1
+            title: Separate Test Environments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-4.2
+            title: Verification of Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-5
       title: Access Restrictions for Change
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-5.1
-      title: Automated Access Enforcement and Audit Records
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-5.2
-      title: Review System Changes
-      rules: []
-      status: pending
-    - id: cm-5.3
-      title: Signed Components
-      rules: []
-      status: pending
-    - id: cm-5.4
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: cm-5.5
-      title: Privilege Limitation for Production and Operation
-      rules: []
-      status: pending
-    - id: cm-5.6
-      title: Limit Library Privileges
-      rules: []
-      status: pending
-    - id: cm-5.7
-      title: Automatic Implementation of Security Safeguards
-      rules: []
-      status: pending
+      controls:
+          - id: cm-5.1
+            title: Automated Access Enforcement and Audit Records
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-5.2
+            title: Review System Changes
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.3
+            title: Signed Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.4
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.5
+            title: Privilege Limitation for Production and Operation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.6
+            title: Limit Library Privileges
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.7
+            title: Automatic Implementation of Security Safeguards
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-6
       title: Configuration Settings
       levels:
@@ -312,26 +345,31 @@ controls:
           - var_accounts_user_umask=027
           - var_sshd_set_login_grace_time=60
       status: automated
-    - id: cm-6.1
-      title: Automated Management, Application, and Verification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-6.2
-      title: Respond to Unauthorized Changes
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-6.3
-      title: Unauthorized Change Detection
-      rules: []
-      status: pending
-    - id: cm-6.4
-      title: Conformance Demonstration
-      rules: []
-      status: pending
+      controls:
+          - id: cm-6.1
+            title: Automated Management, Application, and Verification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-6.2
+            title: Respond to Unauthorized Changes
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-6.3
+            title: Unauthorized Change Detection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-6.4
+            title: Conformance Demonstration
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-7
       title: Least Functionality
       levels:
@@ -396,118 +434,148 @@ controls:
           - xwayland_disabled
           - var_postfix_inet_interfaces=loopback-only
       status: automated
-    - id: cm-7.1
-      title: Periodic Review
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.2
-      title: Prevent Program Execution
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.3
-      title: Registration Compliance
-      rules: []
-      status: pending
-    - id: cm-7.4
-      title: Unauthorized Software — Deny-by-exception
-      rules: []
-      status: pending
-    - id: cm-7.5
-      title: Authorized Software — Allow-by-exception
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.6
-      title: Confined Environments with Limited Privileges
-      rules: []
-      status: pending
-    - id: cm-7.7
-      title: Code Execution in Protected Environments
-      rules: []
-      status: pending
-    - id: cm-7.8
-      title: Binary or Machine Executable Code
-      rules: []
-      status: pending
-    - id: cm-7.9
-      title: Prohibiting The Use of Unauthorized Hardware
-      rules: []
-      status: pending
+      controls:
+          - id: cm-7.1
+            title: Periodic Review
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.2
+            title: Prevent Program Execution
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.3
+            title: Registration Compliance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.4
+            title: Unauthorized Software — Deny-by-exception
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.5
+            title: Authorized Software — Allow-by-exception
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.6
+            title: Confined Environments with Limited Privileges
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.7
+            title: Code Execution in Protected Environments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.8
+            title: Binary or Machine Executable Code
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.9
+            title: Prohibiting The Use of Unauthorized Hardware
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-8
       title: System Component Inventory
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-8.1
-      title: Updates During Installation and Removal
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-8.2
-      title: Automated Maintenance
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-8.3
-      title: Automated Unauthorized Component Detection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-8.4
-      title: Accountability Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-8.5
-      title: No Duplicate Accounting of Components
-      rules: []
-      status: pending
-    - id: cm-8.6
-      title: Assessed Configurations and Approved Deviations
-      rules: []
-      status: pending
-    - id: cm-8.7
-      title: Centralized Repository
-      rules: []
-      status: pending
-    - id: cm-8.8
-      title: Automated Location Tracking
-      rules: []
-      status: pending
-    - id: cm-8.9
-      title: Assignment of Components to Systems
-      rules: []
-      status: pending
+      controls:
+          - id: cm-8.1
+            title: Updates During Installation and Removal
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-8.2
+            title: Automated Maintenance
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-8.3
+            title: Automated Unauthorized Component Detection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-8.4
+            title: Accountability Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-8.5
+            title: No Duplicate Accounting of Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.6
+            title: Assessed Configurations and Approved Deviations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.7
+            title: Centralized Repository
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.8
+            title: Automated Location Tracking
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.9
+            title: Assignment of Components to Systems
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-9
       title: Configuration Management Plan
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-9.1
-      title: Assignment of Responsibility
-      rules: []
-      status: pending
+      controls:
+          - id: cm-9.1
+            title: Assignment of Responsibility
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cm-10
       title: Software Usage Restrictions
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-10.1
-      title: Open-source Software
-      rules: []
-      status: pending
+      controls:
+          - id: cm-10.1
+            title: Open-source Software
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-11
       title: User-installed Software
       levels:
@@ -515,30 +583,38 @@ controls:
       rules:
           - package_xorg-x11-server-Xwayland_removed
       status: automated
-    - id: cm-11.1
-      title: Alerts for Unauthorized Installations
-      rules: []
-      status: pending
-    - id: cm-11.2
-      title: Software Installation with Privileged Status
-      rules: []
-      status: pending
-    - id: cm-11.3
-      title: Automated Enforcement and Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: cm-11.1
+            title: Alerts for Unauthorized Installations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-11.2
+            title: Software Installation with Privileged Status
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-11.3
+            title: Automated Enforcement and Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-12
       title: Information Location
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-12.1
-      title: Automated Tools to Support Information Location
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-12.1
+            title: Automated Tools to Support Information Location
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-13
       title: Data Action Mapping
       rules: []

--- a/products/rhel10/controls/nist_800_53/cp.yml
+++ b/products/rhel10/controls/nist_800_53/cp.yml
@@ -12,94 +12,111 @@ controls:
           - low
       rules: []
       status: pending
-    - id: cp-2.1
-      title: Coordinate with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-2.2
-      title: Capacity Planning
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-2.3
-      title: Resume Mission and Business Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-2.4
-      title: Resume All Mission and Business Functions
-      rules: []
-      status: pending
-    - id: cp-2.5
-      title: Continue Mission and Business Functions
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-2.6
-      title: Alternate Processing and Storage Sites
-      rules: []
-      status: pending
-    - id: cp-2.7
-      title: Coordinate with External Service Providers
-      rules: []
-      status: pending
-    - id: cp-2.8
-      title: Identify Critical Assets
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-2.1
+            title: Coordinate with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-2.2
+            title: Capacity Planning
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-2.3
+            title: Resume Mission and Business Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-2.4
+            title: Resume All Mission and Business Functions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.5
+            title: Continue Mission and Business Functions
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-2.6
+            title: Alternate Processing and Storage Sites
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.7
+            title: Coordinate with External Service Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.8
+            title: Identify Critical Assets
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-3
       title: Contingency Training
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-3.1
-      title: Simulated Events
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-3.2
-      title: Mechanisms Used in Training Environments
-      rules: []
-      status: pending
+      controls:
+          - id: cp-3.1
+            title: Simulated Events
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-3.2
+            title: Mechanisms Used in Training Environments
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-4
       title: Contingency Plan Testing
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-4.1
-      title: Coordinate with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-4.2
-      title: Alternate Processing Site
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-4.3
-      title: Automated Testing
-      rules: []
-      status: pending
-    - id: cp-4.4
-      title: Full Recovery and Reconstitution
-      rules: []
-      status: pending
-    - id: cp-4.5
-      title: Self-challenge
-      rules: []
-      status: pending
+      controls:
+          - id: cp-4.1
+            title: Coordinate with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-4.2
+            title: Alternate Processing Site
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-4.3
+            title: Automated Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-4.4
+            title: Full Recovery and Reconstitution
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-4.5
+            title: Self-challenge
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-5
       title: Contingency Plan Update
       rules: []
@@ -110,178 +127,203 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: cp-6.1
-      title: Separation from Primary Site
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-6.2
-      title: Recovery Time and Recovery Point Objectives
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-6.3
-      title: Accessibility
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-6.1
+            title: Separation from Primary Site
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-6.2
+            title: Recovery Time and Recovery Point Objectives
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-6.3
+            title: Accessibility
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-7
       title: Alternate Processing Site
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cp-7.1
-      title: Separation from Primary Site
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.2
-      title: Accessibility
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.3
-      title: Priority of Service
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.4
-      title: Preparation for Use
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-7.5
-      title: Equivalent Information Security Safeguards
-      rules: []
-      status: pending
-    - id: cp-7.6
-      title: Inability to Return to Primary Site
-      rules: []
-      status: pending
+      controls:
+          - id: cp-7.1
+            title: Separation from Primary Site
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.2
+            title: Accessibility
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.3
+            title: Priority of Service
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.4
+            title: Preparation for Use
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-7.5
+            title: Equivalent Information Security Safeguards
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cp-7.6
+            title: Inability to Return to Primary Site
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cp-8
       title: Telecommunications Services
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cp-8.1
-      title: Priority of Service Provisions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-8.2
-      title: Single Points of Failure
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-8.3
-      title: Separation of Primary and Alternate Providers
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-8.4
-      title: Provider Contingency Plan
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-8.5
-      title: Alternate Telecommunication Service Testing
-      rules: []
-      status: pending
+      controls:
+          - id: cp-8.1
+            title: Priority of Service Provisions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-8.2
+            title: Single Points of Failure
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-8.3
+            title: Separation of Primary and Alternate Providers
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-8.4
+            title: Provider Contingency Plan
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-8.5
+            title: Alternate Telecommunication Service Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cp-9
       title: System Backup
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-9.1
-      title: Testing for Reliability and Integrity
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-9.2
-      title: Test Restoration Using Sampling
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.3
-      title: Separate Storage for Critical Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.4
-      title: Protection from Unauthorized Modification
-      rules: []
-      status: pending
-    - id: cp-9.5
-      title: Transfer to Alternate Storage Site
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.6
-      title: Redundant Secondary System
-      rules: []
-      status: pending
-    - id: cp-9.7
-      title: Dual Authorization for Deletion or Destruction
-      rules: []
-      status: pending
-    - id: cp-9.8
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-9.1
+            title: Testing for Reliability and Integrity
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-9.2
+            title: Test Restoration Using Sampling
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.3
+            title: Separate Storage for Critical Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.4
+            title: Protection from Unauthorized Modification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.5
+            title: Transfer to Alternate Storage Site
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.6
+            title: Redundant Secondary System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.7
+            title: Dual Authorization for Deletion or Destruction
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.8
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-10
       title: System Recovery and Reconstitution
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-10.1
-      title: Contingency Plan Testing
-      rules: []
-      status: pending
-    - id: cp-10.2
-      title: Transaction Recovery
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-10.3
-      title: Compensating Security Controls
-      rules: []
-      status: pending
-    - id: cp-10.4
-      title: Restore Within Time Period
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-10.5
-      title: Failover Capability
-      rules: []
-      status: pending
-    - id: cp-10.6
-      title: Component Protection
-      rules: []
-      status: pending
+      controls:
+          - id: cp-10.1
+            title: Contingency Plan Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.2
+            title: Transaction Recovery
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-10.3
+            title: Compensating Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.4
+            title: Restore Within Time Period
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-10.5
+            title: Failover Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.6
+            title: Component Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-11
       title: Alternate Communications Protocols
       rules: []

--- a/products/rhel10/controls/nist_800_53/ia.yml
+++ b/products/rhel10/controls/nist_800_53/ia.yml
@@ -13,68 +13,85 @@ controls:
       rules:
           - account_unique_id
       status: automated
-    - id: ia-2.1
-      title: Multi-factor Authentication to Privileged Accounts
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.2
-      title: Multi-factor Authentication to Non-privileged Accounts
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.3
-      title: Local Access to Privileged Accounts
-      rules: []
-      status: pending
-    - id: ia-2.4
-      title: Local Access to Non-privileged Accounts
-      rules: []
-      status: pending
-    - id: ia-2.5
-      title: Individual Authentication with Group Authentication
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ia-2.6
-      title: Access to Accounts —separate Device
-      rules: []
-      status: pending
-    - id: ia-2.7
-      title: Network Access to Non-privileged Accounts — Separate Device
-      rules: []
-      status: pending
-    - id: ia-2.8
-      title: Access to Accounts — Replay Resistant
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.9
-      title: Network Access to Non-privileged Accounts — Replay Resistant
-      rules: []
-      status: pending
-    - id: ia-2.10
-      title: Single Sign-on
-      rules: []
-      status: pending
-    - id: ia-2.11
-      title: Remote Access — Separate Device
-      rules: []
-      status: pending
-    - id: ia-2.12
-      title: Acceptance of PIV Credentials
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.13
-      title: Out-of-band Authentication
-      rules: []
-      status: pending
+      controls:
+          - id: ia-2.1
+            title: Multi-factor Authentication to Privileged Accounts
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.2
+            title: Multi-factor Authentication to Non-privileged Accounts
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.3
+            title: Local Access to Privileged Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.4
+            title: Local Access to Non-privileged Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.5
+            title: Individual Authentication with Group Authentication
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ia-2.6
+            title: Access to Accounts —separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.7
+            title: Network Access to Non-privileged Accounts — Separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.8
+            title: Access to Accounts — Replay Resistant
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.9
+            title: Network Access to Non-privileged Accounts — Replay Resistant
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.10
+            title: Single Sign-on
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.11
+            title: Remote Access — Separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.12
+            title: Acceptance of PIV Credentials
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.13
+            title: Out-of-band Authentication
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-3
       title: Device Identification and Authentication
       levels:
@@ -84,22 +101,31 @@ controls:
           - dconf_gnome_disable_automount_open
           - kernel_module_usb-storage_disabled
       status: automated
-    - id: ia-3.1
-      title: Cryptographic Bidirectional Authentication
-      rules: []
-      status: pending
-    - id: ia-3.2
-      title: Cryptographic Bidirectional Network Authentication
-      rules: []
-      status: pending
-    - id: ia-3.3
-      title: Dynamic Address Allocation
-      rules: []
-      status: pending
-    - id: ia-3.4
-      title: Device Attestation
-      rules: []
-      status: pending
+      controls:
+          - id: ia-3.1
+            title: Cryptographic Bidirectional Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.2
+            title: Cryptographic Bidirectional Network Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.3
+            title: Dynamic Address Allocation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.4
+            title: Device Attestation
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ia-4
       title: Identifier Management
       levels:
@@ -109,44 +135,61 @@ controls:
           - accounts_set_post_pw_existing
           - var_account_disable_post_pw_expiration=45
       status: automated
-    - id: ia-4.1
-      title: Prohibit Account Identifiers as Public Identifiers
-      rules: []
-      status: pending
-    - id: ia-4.2
-      title: Supervisor Authorization
-      rules: []
-      status: pending
-    - id: ia-4.3
-      title: Multiple Forms of Certification
-      rules: []
-      status: pending
-    - id: ia-4.4
-      title: Identify User Status
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-4.5
-      title: Dynamic Management
-      rules: []
-      status: pending
-    - id: ia-4.6
-      title: Cross-organization Management
-      rules: []
-      status: pending
-    - id: ia-4.7
-      title: In-person Registration
-      rules: []
-      status: pending
-    - id: ia-4.8
-      title: Pairwise Pseudonymous Identifiers
-      rules: []
-      status: pending
-    - id: ia-4.9
-      title: Attribute Maintenance and Protection
-      rules: []
-      status: pending
+      controls:
+          - id: ia-4.1
+            title: Prohibit Account Identifiers as Public Identifiers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.2
+            title: Supervisor Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.3
+            title: Multiple Forms of Certification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.4
+            title: Identify User Status
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-4.5
+            title: Dynamic Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.6
+            title: Cross-organization Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.7
+            title: In-person Registration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.8
+            title: Pairwise Pseudonymous Identifiers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.9
+            title: Attribute Maintenance and Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-5
       title: Authenticator Management
       levels:
@@ -185,90 +228,121 @@ controls:
           - var_password_pam_minclass=4
           - var_password_pam_minlen=14
       status: automated
-    - id: ia-5.1
-      title: Password-based Authentication
-      levels:
-          - low
-      rules:
-          - accounts_password_pam_pwhistory_remember_password_auth
-          - accounts_password_pam_pwhistory_remember_system_auth
-          - accounts_password_pam_unix_enabled
-          - accounts_password_pam_unix_no_remember
-          - var_password_pam_remember=24
-          - var_password_pam_remember_control_flag=requisite_or_required
-      status: automated
-    - id: ia-5.2
-      title: Public Key-based Authentication
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-5.3
-      title: In-person or Trusted External Party Registration
-      rules: []
-      status: pending
-    - id: ia-5.4
-      title: Automated Support for Password Strength Determination
-      rules: []
-      status: pending
-    - id: ia-5.5
-      title: Change Authenticators Prior to Delivery
-      rules: []
-      status: pending
-    - id: ia-5.6
-      title: Protection of Authenticators
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-5.7
-      title: No Embedded Unencrypted Static Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.8
-      title: Multiple System Accounts
-      rules: []
-      status: pending
-    - id: ia-5.9
-      title: Federated Credential Management
-      rules: []
-      status: pending
-    - id: ia-5.10
-      title: Dynamic Credential Binding
-      rules: []
-      status: pending
-    - id: ia-5.11
-      title: Hardware Token-based Authentication
-      rules: []
-      status: pending
-    - id: ia-5.12
-      title: Biometric Authentication Performance
-      rules: []
-      status: pending
-    - id: ia-5.13
-      title: Expiration of Cached Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.14
-      title: Managing Content of PKI Trust Stores
-      rules: []
-      status: pending
-    - id: ia-5.15
-      title: GSA-approved Products and Services
-      rules: []
-      status: pending
-    - id: ia-5.16
-      title: In-person or Trusted External Party Authenticator Issuance
-      rules: []
-      status: pending
-    - id: ia-5.17
-      title: Presentation Attack Detection for Biometric Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.18
-      title: Password Managers
-      rules: []
-      status: pending
+      controls:
+          - id: ia-5.1
+            title: Password-based Authentication
+            levels:
+                - low
+            rules:
+                - accounts_password_pam_pwhistory_remember_password_auth
+                - accounts_password_pam_pwhistory_remember_system_auth
+                - accounts_password_pam_unix_enabled
+                - accounts_password_pam_unix_no_remember
+                - var_password_pam_remember=24
+                - var_password_pam_remember_control_flag=requisite_or_required
+            status: automated
+          - id: ia-5.2
+            title: Public Key-based Authentication
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-5.3
+            title: In-person or Trusted External Party Registration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.4
+            title: Automated Support for Password Strength Determination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.5
+            title: Change Authenticators Prior to Delivery
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.6
+            title: Protection of Authenticators
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-5.7
+            title: No Embedded Unencrypted Static Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.8
+            title: Multiple System Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.9
+            title: Federated Credential Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.10
+            title: Dynamic Credential Binding
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.11
+            title: Hardware Token-based Authentication
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.12
+            title: Biometric Authentication Performance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.13
+            title: Expiration of Cached Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.14
+            title: Managing Content of PKI Trust Stores
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.15
+            title: GSA-approved Products and Services
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.16
+            title: In-person or Trusted External Party Authenticator Issuance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.17
+            title: Presentation Attack Detection for Biometric Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.18
+            title: Password Managers
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-6
       title: Authentication Feedback
       levels:
@@ -287,48 +361,56 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ia-8.1
-      title: Acceptance of PIV Credentials from Other Agencies
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.2
-      title: Acceptance of External Authenticators
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.3
-      title: Use of FICAM-approved Products
-      rules: []
-      status: pending
-    - id: ia-8.4
-      title: Use of Defined Profiles
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.5
-      title: Acceptance of PIV-I Credentials
-      rules: []
-      status: pending
-    - id: ia-8.6
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: ia-8.1
+            title: Acceptance of PIV Credentials from Other Agencies
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.2
+            title: Acceptance of External Authenticators
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.3
+            title: Use of FICAM-approved Products
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-8.4
+            title: Use of Defined Profiles
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.5
+            title: Acceptance of PIV-I Credentials
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-8.6
+            title: Disassociability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-9
       title: Service Identification and Authentication
       rules: []
       status: pending
-    - id: ia-9.1
-      title: Information Exchange
-      rules: []
-      status: pending
-    - id: ia-9.2
-      title: Transmission of Decisions
-      rules: []
-      status: pending
+      controls:
+          - id: ia-9.1
+            title: Information Exchange
+            rules: []
+            status: pending
+          - id: ia-9.2
+            title: Transmission of Decisions
+            rules: []
+            status: pending
     - id: ia-10
       title: Adaptive Authentication
       rules: []
@@ -347,51 +429,57 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: ia-12.1
-      title: Supervisor Authorization
-      rules: []
-      status: pending
-    - id: ia-12.2
-      title: Identity Evidence
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.3
-      title: Identity Evidence Validation and Verification
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.4
-      title: In-person Validation and Verification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ia-12.5
-      title: Address Confirmation
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.6
-      title: Accept Externally-proofed Identities
-      rules: []
-      status: pending
+      controls:
+          - id: ia-12.1
+            title: Supervisor Authorization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-12.2
+            title: Identity Evidence
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.3
+            title: Identity Evidence Validation and Verification
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.4
+            title: In-person Validation and Verification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ia-12.5
+            title: Address Confirmation
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.6
+            title: Accept Externally-proofed Identities
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ia-13
       title: Identity Providers and Authorization Servers
       rules: []
       status: pending
-    - id: ia-13.1
-      title: Protection of Cryptographic Keys
-      rules: []
-      status: pending
-    - id: ia-13.2
-      title: Verification of Identity Assertions and Access Tokens
-      rules: []
-      status: pending
-    - id: ia-13.3
-      title: Token Management
-      rules: []
-      status: pending
+      controls:
+          - id: ia-13.1
+            title: Protection of Cryptographic Keys
+            rules: []
+            status: pending
+          - id: ia-13.2
+            title: Verification of Identity Assertions and Access Tokens
+            rules: []
+            status: pending
+          - id: ia-13.3
+            title: Token Management
+            rules: []
+            status: pending

--- a/products/rhel10/controls/nist_800_53/ir.yml
+++ b/products/rhel10/controls/nist_800_53/ir.yml
@@ -12,194 +12,239 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ir-2.1
-      title: Simulated Events
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-2.2
-      title: Automated Training Environments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-2.3
-      title: Breach
-      rules: []
-      status: pending
+      controls:
+          - id: ir-2.1
+            title: Simulated Events
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-2.2
+            title: Automated Training Environments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-2.3
+            title: Breach
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-3
       title: Incident Response Testing
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ir-3.1
-      title: Automated Testing
-      rules: []
-      status: pending
-    - id: ir-3.2
-      title: Coordination with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-3.3
-      title: Continuous Improvement
-      rules: []
-      status: pending
+      controls:
+          - id: ir-3.1
+            title: Automated Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ir-3.2
+            title: Coordination with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-3.3
+            title: Continuous Improvement
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ir-4
       title: Incident Handling
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-4.1
-      title: Automated Incident Handling Processes
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-4.2
-      title: Dynamic Reconfiguration
-      rules: []
-      status: pending
-    - id: ir-4.3
-      title: Continuity of Operations
-      rules: []
-      status: pending
-    - id: ir-4.4
-      title: Information Correlation
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-4.5
-      title: Automatic Disabling of System
-      rules: []
-      status: pending
-    - id: ir-4.6
-      title: Insider Threats
-      rules: []
-      status: pending
-    - id: ir-4.7
-      title: Insider Threats — Intra-organization Coordination
-      rules: []
-      status: pending
-    - id: ir-4.8
-      title: Correlation with External Organizations
-      rules: []
-      status: pending
-    - id: ir-4.9
-      title: Dynamic Response Capability
-      rules: []
-      status: pending
-    - id: ir-4.10
-      title: Supply Chain Coordination
-      rules: []
-      status: pending
-    - id: ir-4.11
-      title: Integrated Incident Response Team
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-4.12
-      title: Malicious Code and Forensic Analysis
-      rules: []
-      status: pending
-    - id: ir-4.13
-      title: Behavior Analysis
-      rules: []
-      status: pending
-    - id: ir-4.14
-      title: Security Operations Center
-      rules: []
-      status: pending
-    - id: ir-4.15
-      title: Public Relations and Reputation Repair
-      rules: []
-      status: pending
+      controls:
+          - id: ir-4.1
+            title: Automated Incident Handling Processes
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-4.2
+            title: Dynamic Reconfiguration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.3
+            title: Continuity of Operations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.4
+            title: Information Correlation
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-4.5
+            title: Automatic Disabling of System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.6
+            title: Insider Threats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.7
+            title: Insider Threats — Intra-organization Coordination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.8
+            title: Correlation with External Organizations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.9
+            title: Dynamic Response Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.10
+            title: Supply Chain Coordination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.11
+            title: Integrated Incident Response Team
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-4.12
+            title: Malicious Code and Forensic Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.13
+            title: Behavior Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.14
+            title: Security Operations Center
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.15
+            title: Public Relations and Reputation Repair
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-5
       title: Incident Monitoring
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-5.1
-      title: Automated Tracking, Data Collection, and Analysis
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ir-5.1
+            title: Automated Tracking, Data Collection, and Analysis
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ir-6
       title: Incident Reporting
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-6.1
-      title: Automated Reporting
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-6.2
-      title: Vulnerabilities Related to Incidents
-      rules: []
-      status: pending
-    - id: ir-6.3
-      title: Supply Chain Coordination
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ir-6.1
+            title: Automated Reporting
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-6.2
+            title: Vulnerabilities Related to Incidents
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-6.3
+            title: Supply Chain Coordination
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ir-7
       title: Incident Response Assistance
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-7.1
-      title: Automation Support for Availability of Information and Support
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-7.2
-      title: Coordination with External Providers
-      rules: []
-      status: pending
+      controls:
+          - id: ir-7.1
+            title: Automation Support for Availability of Information and
+                Support
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-7.2
+            title: Coordination with External Providers
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-8
       title: Incident Response Plan
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-8.1
-      title: Breaches
-      rules: []
-      status: pending
+      controls:
+          - id: ir-8.1
+            title: Breaches
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-9
       title: Information Spillage Response
       rules: []
       status: pending
-    - id: ir-9.1
-      title: Responsible Personnel
-      rules: []
-      status: pending
-    - id: ir-9.2
-      title: Training
-      rules: []
-      status: pending
-    - id: ir-9.3
-      title: Post-spill Operations
-      rules: []
-      status: pending
-    - id: ir-9.4
-      title: Exposure to Unauthorized Personnel
-      rules: []
-      status: pending
+      controls:
+          - id: ir-9.1
+            title: Responsible Personnel
+            rules: []
+            status: pending
+          - id: ir-9.2
+            title: Training
+            rules: []
+            status: pending
+          - id: ir-9.3
+            title: Post-spill Operations
+            rules: []
+            status: pending
+          - id: ir-9.4
+            title: Exposure to Unauthorized Personnel
+            rules: []
+            status: pending
     - id: ir-10
       title: Integrated Information Security Analysis Team
       rules: []

--- a/products/rhel10/controls/nist_800_53/ma.yml
+++ b/products/rhel10/controls/nist_800_53/ma.yml
@@ -12,134 +12,173 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ma-2.1
-      title: Record Content
-      rules: []
-      status: pending
-    - id: ma-2.2
-      title: Automated Maintenance Activities
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ma-2.1
+            title: Record Content
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-2.2
+            title: Automated Maintenance Activities
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ma-3
       title: Maintenance Tools
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ma-3.1
-      title: Inspect Tools
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.2
-      title: Inspect Media
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.3
-      title: Prevent Unauthorized Removal
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.4
-      title: Restricted Tool Use
-      rules: []
-      status: pending
-    - id: ma-3.5
-      title: Execution with Privilege
-      rules: []
-      status: pending
-    - id: ma-3.6
-      title: Software Updates and Patches
-      rules: []
-      status: pending
+      controls:
+          - id: ma-3.1
+            title: Inspect Tools
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.2
+            title: Inspect Media
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.3
+            title: Prevent Unauthorized Removal
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.4
+            title: Restricted Tool Use
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-3.5
+            title: Execution with Privilege
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-3.6
+            title: Software Updates and Patches
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ma-4
       title: Nonlocal Maintenance
       levels:
           - low
       rules: []
       status: pending
-    - id: ma-4.1
-      title: Logging and Review
-      rules: []
-      status: pending
-    - id: ma-4.2
-      title: Document Nonlocal Maintenance
-      rules: []
-      status: pending
-    - id: ma-4.3
-      title: Comparable Security and Sanitization
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ma-4.4
-      title: Authentication and Separation of Maintenance Sessions
-      rules: []
-      status: pending
-    - id: ma-4.5
-      title: Approvals and Notifications
-      rules: []
-      status: pending
-    - id: ma-4.6
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: ma-4.7
-      title: Disconnect Verification
-      rules: []
-      status: pending
+      controls:
+          - id: ma-4.1
+            title: Logging and Review
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.2
+            title: Document Nonlocal Maintenance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.3
+            title: Comparable Security and Sanitization
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ma-4.4
+            title: Authentication and Separation of Maintenance Sessions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.5
+            title: Approvals and Notifications
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.6
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.7
+            title: Disconnect Verification
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ma-5
       title: Maintenance Personnel
       levels:
           - low
       rules: []
       status: pending
-    - id: ma-5.1
-      title: Individuals Without Appropriate Access
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ma-5.2
-      title: Security Clearances for Classified Systems
-      rules: []
-      status: pending
-    - id: ma-5.3
-      title: Citizenship Requirements for Classified Systems
-      rules: []
-      status: pending
-    - id: ma-5.4
-      title: Foreign Nationals
-      rules: []
-      status: pending
-    - id: ma-5.5
-      title: Non-system Maintenance
-      rules: []
-      status: pending
+      controls:
+          - id: ma-5.1
+            title: Individuals Without Appropriate Access
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ma-5.2
+            title: Security Clearances for Classified Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.3
+            title: Citizenship Requirements for Classified Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.4
+            title: Foreign Nationals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.5
+            title: Non-system Maintenance
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ma-6
       title: Timely Maintenance
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ma-6.1
-      title: Preventive Maintenance
-      rules: []
-      status: pending
-    - id: ma-6.2
-      title: Predictive Maintenance
-      rules: []
-      status: pending
-    - id: ma-6.3
-      title: Automated Support for Predictive Maintenance
-      rules: []
-      status: pending
+      controls:
+          - id: ma-6.1
+            title: Preventive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-6.2
+            title: Predictive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-6.3
+            title: Automated Support for Predictive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ma-7
       title: Field Maintenance
       rules: []

--- a/products/rhel10/controls/nist_800_53/mp.yml
+++ b/products/rhel10/controls/nist_800_53/mp.yml
@@ -12,14 +12,19 @@ controls:
           - low
       rules: []
       status: pending
-    - id: mp-2.1
-      title: Automated Restricted Access
-      rules: []
-      status: pending
-    - id: mp-2.2
-      title: Cryptographic Protection
-      rules: []
-      status: pending
+      controls:
+          - id: mp-2.1
+            title: Automated Restricted Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-2.2
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-3
       title: Media Marking
       levels:
@@ -32,111 +37,142 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: mp-4.1
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: mp-4.2
-      title: Automated Restricted Access
-      rules: []
-      status: pending
+      controls:
+          - id: mp-4.1
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-4.2
+            title: Automated Restricted Access
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: mp-5
       title: Media Transport
       levels:
           - moderate
       rules: []
       status: pending
-    - id: mp-5.1
-      title: Protection Outside of Controlled Areas
-      rules: []
-      status: pending
-    - id: mp-5.2
-      title: Documentation of Activities
-      rules: []
-      status: pending
-    - id: mp-5.3
-      title: Custodians
-      rules: []
-      status: pending
-    - id: mp-5.4
-      title: Cryptographic Protection
-      rules: []
-      status: pending
+      controls:
+          - id: mp-5.1
+            title: Protection Outside of Controlled Areas
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.2
+            title: Documentation of Activities
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.3
+            title: Custodians
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.4
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: mp-6
       title: Media Sanitization
       levels:
           - low
       rules: []
       status: pending
-    - id: mp-6.1
-      title: Review, Approve, Track, Document, and Verify
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.2
-      title: Equipment Testing
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.3
-      title: Nondestructive Techniques
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.4
-      title: Controlled Unclassified Information
-      rules: []
-      status: pending
-    - id: mp-6.5
-      title: Classified Information
-      rules: []
-      status: pending
-    - id: mp-6.6
-      title: Media Destruction
-      rules: []
-      status: pending
-    - id: mp-6.7
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: mp-6.8
-      title: Remote Purging or Wiping of Information
-      rules: []
-      status: pending
+      controls:
+          - id: mp-6.1
+            title: Review, Approve, Track, Document, and Verify
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.2
+            title: Equipment Testing
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.3
+            title: Nondestructive Techniques
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.4
+            title: Controlled Unclassified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.5
+            title: Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.6
+            title: Media Destruction
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.7
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.8
+            title: Remote Purging or Wiping of Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-7
       title: Media Use
       levels:
           - low
       rules: []
       status: pending
-    - id: mp-7.1
-      title: Prohibit Use Without Owner
-      rules: []
-      status: pending
-    - id: mp-7.2
-      title: Prohibit Use of Sanitization-resistant Media
-      rules: []
-      status: pending
+      controls:
+          - id: mp-7.1
+            title: Prohibit Use Without Owner
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-7.2
+            title: Prohibit Use of Sanitization-resistant Media
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-8
       title: Media Downgrading
       rules: []
       status: pending
-    - id: mp-8.1
-      title: Documentation of Process
-      rules: []
-      status: pending
-    - id: mp-8.2
-      title: Equipment Testing
-      rules: []
-      status: pending
-    - id: mp-8.3
-      title: Controlled Unclassified Information
-      rules: []
-      status: pending
-    - id: mp-8.4
-      title: Classified Information
-      rules: []
-      status: pending
+      controls:
+          - id: mp-8.1
+            title: Documentation of Process
+            rules: []
+            status: pending
+          - id: mp-8.2
+            title: Equipment Testing
+            rules: []
+            status: pending
+          - id: mp-8.3
+            title: Controlled Unclassified Information
+            rules: []
+            status: pending
+          - id: mp-8.4
+            title: Classified Information
+            rules: []
+            status: pending

--- a/products/rhel10/controls/nist_800_53/pe.yml
+++ b/products/rhel10/controls/nist_800_53/pe.yml
@@ -12,58 +12,80 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pe-2.1
-      title: Access by Position or Role
-      rules: []
-      status: pending
-    - id: pe-2.2
-      title: Two Forms of Identification
-      rules: []
-      status: pending
-    - id: pe-2.3
-      title: Restrict Unescorted Access
-      rules: []
-      status: pending
+      controls:
+          - id: pe-2.1
+            title: Access by Position or Role
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-2.2
+            title: Two Forms of Identification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-2.3
+            title: Restrict Unescorted Access
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-3
       title: Physical Access Control
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-3.1
-      title: System Access
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-3.2
-      title: Facility and Systems
-      rules: []
-      status: pending
-    - id: pe-3.3
-      title: Continuous Guards
-      rules: []
-      status: pending
-    - id: pe-3.4
-      title: Lockable Casings
-      rules: []
-      status: pending
-    - id: pe-3.5
-      title: Tamper Protection
-      rules: []
-      status: pending
-    - id: pe-3.6
-      title: Facility Penetration Testing
-      rules: []
-      status: pending
-    - id: pe-3.7
-      title: Physical Barriers
-      rules: []
-      status: pending
-    - id: pe-3.8
-      title: Access Control Vestibules
-      rules: []
-      status: pending
+      controls:
+          - id: pe-3.1
+            title: System Access
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-3.2
+            title: Facility and Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.3
+            title: Continuous Guards
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.4
+            title: Lockable Casings
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.5
+            title: Tamper Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.6
+            title: Facility Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.7
+            title: Physical Barriers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.8
+            title: Access Control Vestibules
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-4
       title: Access Control for Transmission
       levels:
@@ -76,44 +98,56 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: pe-5.1
-      title: Access to Output by Authorized Individuals
-      rules: []
-      status: pending
-    - id: pe-5.2
-      title: Link to Individual Identity
-      rules: []
-      status: pending
-    - id: pe-5.3
-      title: Marking Output Devices
-      rules: []
-      status: pending
+      controls:
+          - id: pe-5.1
+            title: Access to Output by Authorized Individuals
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-5.2
+            title: Link to Individual Identity
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-5.3
+            title: Marking Output Devices
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-6
       title: Monitoring Physical Access
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-6.1
-      title: Intrusion Alarms and Surveillance Equipment
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: pe-6.2
-      title: Automated Intrusion Recognition and Responses
-      rules: []
-      status: pending
-    - id: pe-6.3
-      title: Video Surveillance
-      rules: []
-      status: pending
-    - id: pe-6.4
-      title: Monitoring Physical Access to Systems
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: pe-6.1
+            title: Intrusion Alarms and Surveillance Equipment
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: pe-6.2
+            title: Automated Intrusion Recognition and Responses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-6.3
+            title: Video Surveillance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-6.4
+            title: Monitoring Physical Access to Systems
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: pe-7
       title: Visitor Control
       rules: []
@@ -124,122 +158,152 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pe-8.1
-      title: Automated Records Maintenance and Review
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-8.2
-      title: Physical Access Records
-      rules: []
-      status: pending
-    - id: pe-8.3
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
+      controls:
+          - id: pe-8.1
+            title: Automated Records Maintenance and Review
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-8.2
+            title: Physical Access Records
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-8.3
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-9
       title: Power Equipment and Cabling
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-9.1
-      title: Redundant Cabling
-      rules: []
-      status: pending
-    - id: pe-9.2
-      title: Automatic Voltage Controls
-      rules: []
-      status: pending
+      controls:
+          - id: pe-9.1
+            title: Redundant Cabling
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-9.2
+            title: Automatic Voltage Controls
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-10
       title: Emergency Shutoff
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-10.1
-      title: Accidental and Unauthorized Activation
-      rules: []
-      status: pending
+      controls:
+          - id: pe-10.1
+            title: Accidental and Unauthorized Activation
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-11
       title: Emergency Power
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-11.1
-      title: Alternate Power Supply — Minimal Operational Capability
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-11.2
-      title: Alternate Power Supply — Self-contained
-      rules: []
-      status: pending
+      controls:
+          - id: pe-11.1
+            title: Alternate Power Supply — Minimal Operational Capability
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-11.2
+            title: Alternate Power Supply — Self-contained
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-12
       title: Emergency Lighting
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-12.1
-      title: Essential Mission and Business Functions
-      rules: []
-      status: pending
+      controls:
+          - id: pe-12.1
+            title: Essential Mission and Business Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-13
       title: Fire Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-13.1
-      title: Detection Systems — Automatic Activation and Notification
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: pe-13.2
-      title: Suppression Systems — Automatic Activation and Notification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-13.3
-      title: Automatic Fire Suppression
-      rules: []
-      status: pending
-    - id: pe-13.4
-      title: Inspections
-      rules: []
-      status: pending
+      controls:
+          - id: pe-13.1
+            title: Detection Systems — Automatic Activation and Notification
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: pe-13.2
+            title: Suppression Systems — Automatic Activation and Notification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-13.3
+            title: Automatic Fire Suppression
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-13.4
+            title: Inspections
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-14
       title: Environmental Controls
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-14.1
-      title: Automatic Controls
-      rules: []
-      status: pending
-    - id: pe-14.2
-      title: Monitoring with Alarms and Notifications
-      rules: []
-      status: pending
+      controls:
+          - id: pe-14.1
+            title: Automatic Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-14.2
+            title: Monitoring with Alarms and Notifications
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-15
       title: Water Damage Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-15.1
-      title: Automation Support
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: pe-15.1
+            title: Automation Support
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: pe-16
       title: Delivery and Removal
       levels:
@@ -258,18 +322,22 @@ controls:
           - high
       rules: []
       status: pending
-    - id: pe-18.1
-      title: Facility Site
-      rules: []
-      status: pending
+      controls:
+          - id: pe-18.1
+            title: Facility Site
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: pe-19
       title: Information Leakage
       rules: []
       status: pending
-    - id: pe-19.1
-      title: National Emissions Policies and Procedures
-      rules: []
-      status: pending
+      controls:
+          - id: pe-19.1
+            title: National Emissions Policies and Procedures
+            rules: []
+            status: pending
     - id: pe-20
       title: Asset Monitoring and Tracking
       rules: []

--- a/products/rhel10/controls/nist_800_53/pl.yml
+++ b/products/rhel10/controls/nist_800_53/pl.yml
@@ -12,18 +12,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pl-2.1
-      title: Concept of Operations
-      rules: []
-      status: pending
-    - id: pl-2.2
-      title: Functional Architecture
-      rules: []
-      status: pending
-    - id: pl-2.3
-      title: Plan and Coordinate with Other Organizational Entities
-      rules: []
-      status: pending
+      controls:
+          - id: pl-2.1
+            title: Concept of Operations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pl-2.2
+            title: Functional Architecture
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pl-2.3
+            title: Plan and Coordinate with Other Organizational Entities
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pl-3
       title: System Security Plan Update
       rules: []
@@ -34,12 +41,13 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pl-4.1
-      title: Social Media and External Site/Application Usage Restrictions
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: pl-4.1
+            title: Social Media and External Site/Application Usage Restrictions
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: pl-5
       title: Privacy Impact Assessment
       rules: []
@@ -58,14 +66,19 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: pl-8.1
-      title: Defense in Depth
-      rules: []
-      status: pending
-    - id: pl-8.2
-      title: Supplier Diversity
-      rules: []
-      status: pending
+      controls:
+          - id: pl-8.1
+            title: Defense in Depth
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pl-8.2
+            title: Supplier Diversity
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pl-9
       title: Central Management
       rules: []

--- a/products/rhel10/controls/nist_800_53/pm.yml
+++ b/products/rhel10/controls/nist_800_53/pm.yml
@@ -20,10 +20,11 @@ controls:
       title: System Inventory
       rules: []
       status: pending
-    - id: pm-5.1
-      title: Inventory of Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: pm-5.1
+            title: Inventory of Personally Identifiable Information
+            rules: []
+            status: pending
     - id: pm-6
       title: Measures of Performance
       rules: []
@@ -32,10 +33,11 @@ controls:
       title: Enterprise Architecture
       rules: []
       status: pending
-    - id: pm-7.1
-      title: Offloading
-      rules: []
-      status: pending
+      controls:
+          - id: pm-7.1
+            title: Offloading
+            rules: []
+            status: pending
     - id: pm-8
       title: Critical Infrastructure Plan
       rules: []
@@ -72,10 +74,11 @@ controls:
       title: Threat Awareness Program
       rules: []
       status: pending
-    - id: pm-16.1
-      title: Automated Means for Sharing Threat Intelligence
-      rules: []
-      status: pending
+      controls:
+          - id: pm-16.1
+            title: Automated Means for Sharing Threat Intelligence
+            rules: []
+            status: pending
     - id: pm-17
       title: Protecting Controlled Unclassified Information on External Systems
       rules: []
@@ -92,10 +95,12 @@ controls:
       title: Dissemination of Privacy Program Information
       rules: []
       status: pending
-    - id: pm-20.1
-      title: Privacy Policies on Websites, Applications, and Digital Services
-      rules: []
-      status: pending
+      controls:
+          - id: pm-20.1
+            title: Privacy Policies on Websites, Applications, and Digital
+                Services
+            rules: []
+            status: pending
     - id: pm-21
       title: Accounting of Disclosures
       rules: []
@@ -113,8 +118,8 @@ controls:
       rules: []
       status: pending
     - id: pm-25
-      title: Minimization of Personally Identifiable Information Used in Testing, Training, and
-          Research
+      title: Minimization of Personally Identifiable Information Used in
+          Testing, Training, and Research
       rules: []
       status: pending
     - id: pm-26
@@ -137,10 +142,11 @@ controls:
       title: Supply Chain Risk Management Strategy
       rules: []
       status: pending
-    - id: pm-30.1
-      title: Suppliers of Critical or Mission-essential Items
-      rules: []
-      status: pending
+      controls:
+          - id: pm-30.1
+            title: Suppliers of Critical or Mission-essential Items
+            rules: []
+            status: pending
     - id: pm-31
       title: Continuous Monitoring Strategy
       rules: []

--- a/products/rhel10/controls/nist_800_53/ps.yml
+++ b/products/rhel10/controls/nist_800_53/ps.yml
@@ -18,38 +18,50 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ps-3.1
-      title: Classified Information
-      rules: []
-      status: pending
-    - id: ps-3.2
-      title: Formal Indoctrination
-      rules: []
-      status: pending
-    - id: ps-3.3
-      title: Information Requiring Special Protective Measures
-      rules: []
-      status: pending
-    - id: ps-3.4
-      title: Citizenship Requirements
-      rules: []
-      status: pending
+      controls:
+          - id: ps-3.1
+            title: Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.2
+            title: Formal Indoctrination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.3
+            title: Information Requiring Special Protective Measures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.4
+            title: Citizenship Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ps-4
       title: Personnel Termination
       levels:
           - low
       rules: []
       status: pending
-    - id: ps-4.1
-      title: Post-employment Requirements
-      rules: []
-      status: pending
-    - id: ps-4.2
-      title: Automated Actions
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ps-4.1
+            title: Post-employment Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-4.2
+            title: Automated Actions
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ps-5
       title: Personnel Transfer
       levels:
@@ -62,18 +74,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ps-6.1
-      title: Information Requiring Special Protection
-      rules: []
-      status: pending
-    - id: ps-6.2
-      title: Classified Information Requiring Special Protection
-      rules: []
-      status: pending
-    - id: ps-6.3
-      title: Post-employment Requirements
-      rules: []
-      status: pending
+      controls:
+          - id: ps-6.1
+            title: Information Requiring Special Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-6.2
+            title: Classified Information Requiring Special Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-6.3
+            title: Post-employment Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ps-7
       title: External Personnel Security
       levels:

--- a/products/rhel10/controls/nist_800_53/pt.yml
+++ b/products/rhel10/controls/nist_800_53/pt.yml
@@ -8,78 +8,84 @@ controls:
       title: Authority to Process Personally Identifiable Information
       rules: []
       status: pending
-    - id: pt-2.1
-      title: Data Tagging
-      rules: []
-      status: pending
-    - id: pt-2.2
-      title: Automation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-2.1
+            title: Data Tagging
+            rules: []
+            status: pending
+          - id: pt-2.2
+            title: Automation
+            rules: []
+            status: pending
     - id: pt-3
       title: Personally Identifiable Information Processing Purposes
       rules: []
       status: pending
-    - id: pt-3.1
-      title: Data Tagging
-      rules: []
-      status: pending
-    - id: pt-3.2
-      title: Automation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-3.1
+            title: Data Tagging
+            rules: []
+            status: pending
+          - id: pt-3.2
+            title: Automation
+            rules: []
+            status: pending
     - id: pt-4
       title: Consent
       rules: []
       status: pending
-    - id: pt-4.1
-      title: Tailored Consent
-      rules: []
-      status: pending
-    - id: pt-4.2
-      title: Just-in-time Consent
-      rules: []
-      status: pending
-    - id: pt-4.3
-      title: Revocation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-4.1
+            title: Tailored Consent
+            rules: []
+            status: pending
+          - id: pt-4.2
+            title: Just-in-time Consent
+            rules: []
+            status: pending
+          - id: pt-4.3
+            title: Revocation
+            rules: []
+            status: pending
     - id: pt-5
       title: Privacy Notice
       rules: []
       status: pending
-    - id: pt-5.1
-      title: Just-in-time Notice
-      rules: []
-      status: pending
-    - id: pt-5.2
-      title: Privacy Act Statements
-      rules: []
-      status: pending
+      controls:
+          - id: pt-5.1
+            title: Just-in-time Notice
+            rules: []
+            status: pending
+          - id: pt-5.2
+            title: Privacy Act Statements
+            rules: []
+            status: pending
     - id: pt-6
       title: System of Records Notice
       rules: []
       status: pending
-    - id: pt-6.1
-      title: Routine Uses
-      rules: []
-      status: pending
-    - id: pt-6.2
-      title: Exemption Rules
-      rules: []
-      status: pending
+      controls:
+          - id: pt-6.1
+            title: Routine Uses
+            rules: []
+            status: pending
+          - id: pt-6.2
+            title: Exemption Rules
+            rules: []
+            status: pending
     - id: pt-7
       title: Specific Categories of Personally Identifiable Information
       rules: []
       status: pending
-    - id: pt-7.1
-      title: Social Security Numbers
-      rules: []
-      status: pending
-    - id: pt-7.2
-      title: First Amendment Information
-      rules: []
-      status: pending
+      controls:
+          - id: pt-7.1
+            title: Social Security Numbers
+            rules: []
+            status: pending
+          - id: pt-7.2
+            title: First Amendment Information
+            rules: []
+            status: pending
     - id: pt-8
       title: Computer Matching Requirements
       rules: []

--- a/products/rhel10/controls/nist_800_53/ra.yml
+++ b/products/rhel10/controls/nist_800_53/ra.yml
@@ -12,34 +12,44 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ra-2.1
-      title: Impact-level Prioritization
-      rules: []
-      status: pending
+      controls:
+          - id: ra-2.1
+            title: Impact-level Prioritization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ra-3
       title: Risk Assessment
       levels:
           - low
       rules: []
       status: pending
-    - id: ra-3.1
-      title: Supply Chain Risk Assessment
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ra-3.2
-      title: Use of All-source Intelligence
-      rules: []
-      status: pending
-    - id: ra-3.3
-      title: Dynamic Threat Awareness
-      rules: []
-      status: pending
-    - id: ra-3.4
-      title: Predictive Cyber Analytics
-      rules: []
-      status: pending
+      controls:
+          - id: ra-3.1
+            title: Supply Chain Risk Assessment
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ra-3.2
+            title: Use of All-source Intelligence
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-3.3
+            title: Dynamic Threat Awareness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-3.4
+            title: Predictive Cyber Analytics
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ra-4
       title: Risk Assessment Update
       rules: []
@@ -50,58 +60,74 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ra-5.1
-      title: Update Tool Capability
-      rules: []
-      status: pending
-    - id: ra-5.2
-      title: Update Vulnerabilities to Be Scanned
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ra-5.3
-      title: Breadth and Depth of Coverage
-      rules: []
-      status: pending
-    - id: ra-5.4
-      title: Discoverable Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ra-5.5
-      title: Privileged Access
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ra-5.6
-      title: Automated Trend Analyses
-      rules: []
-      status: pending
-    - id: ra-5.7
-      title: Automated Detection and Notification of Unauthorized Components
-      rules: []
-      status: pending
-    - id: ra-5.8
-      title: Review Historic Audit Logs
-      rules: []
-      status: pending
-    - id: ra-5.9
-      title: Penetration Testing and Analyses
-      rules: []
-      status: pending
-    - id: ra-5.10
-      title: Correlate Scanning Information
-      rules: []
-      status: pending
-    - id: ra-5.11
-      title: Public Disclosure Program
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: ra-5.1
+            title: Update Tool Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.2
+            title: Update Vulnerabilities to Be Scanned
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ra-5.3
+            title: Breadth and Depth of Coverage
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.4
+            title: Discoverable Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ra-5.5
+            title: Privileged Access
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ra-5.6
+            title: Automated Trend Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.7
+            title: Automated Detection and Notification of Unauthorized
+                Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.8
+            title: Review Historic Audit Logs
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.9
+            title: Penetration Testing and Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.10
+            title: Correlate Scanning Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.11
+            title: Public Disclosure Program
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: ra-6
       title: Technical Surveillance Countermeasures Survey
       rules: []

--- a/products/rhel10/controls/nist_800_53/sa.yml
+++ b/products/rhel10/controls/nist_800_53/sa.yml
@@ -18,108 +18,141 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sa-3.1
-      title: Manage Preproduction Environment
-      rules: []
-      status: pending
-    - id: sa-3.2
-      title: Use of Live or Operational Data
-      rules: []
-      status: pending
-    - id: sa-3.3
-      title: Technology Refresh
-      rules: []
-      status: pending
+      controls:
+          - id: sa-3.1
+            title: Manage Preproduction Environment
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-3.2
+            title: Use of Live or Operational Data
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-3.3
+            title: Technology Refresh
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-4
       title: Acquisition Process
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-4.1
-      title: Functional Properties of Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.2
-      title: Design and Implementation Information for Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.3
-      title: Development Methods, Techniques, and Practices
-      rules: []
-      status: pending
-    - id: sa-4.4
-      title: Assignment of Components to Systems
-      rules: []
-      status: pending
-    - id: sa-4.5
-      title: System, Component, and Service Configurations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sa-4.6
-      title: Use of Information Assurance Products
-      rules: []
-      status: pending
-    - id: sa-4.7
-      title: 'NIAP-approved Protection Profiles '
-      rules: []
-      status: pending
-    - id: sa-4.8
-      title: Continuous Monitoring Plan for Controls
-      rules: []
-      status: pending
-    - id: sa-4.9
-      title: Functions, Ports, Protocols, and Services in Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.10
-      title: Use of Approved PIV Products
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sa-4.11
-      title: System of Records
-      rules: []
-      status: pending
-    - id: sa-4.12
-      title: Data Ownership
-      rules: []
-      status: pending
+      controls:
+          - id: sa-4.1
+            title: Functional Properties of Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.2
+            title: Design and Implementation Information for Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.3
+            title: Development Methods, Techniques, and Practices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.4
+            title: Assignment of Components to Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.5
+            title: System, Component, and Service Configurations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sa-4.6
+            title: Use of Information Assurance Products
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.7
+            title: 'NIAP-approved Protection Profiles '
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.8
+            title: Continuous Monitoring Plan for Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.9
+            title: Functions, Ports, Protocols, and Services in Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.10
+            title: Use of Approved PIV Products
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sa-4.11
+            title: System of Records
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.12
+            title: Data Ownership
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-5
       title: System Documentation
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-5.1
-      title: Functional Properties of Security Controls
-      rules: []
-      status: pending
-    - id: sa-5.2
-      title: Security-relevant External System Interfaces
-      rules: []
-      status: pending
-    - id: sa-5.3
-      title: High-level Design
-      rules: []
-      status: pending
-    - id: sa-5.4
-      title: Low-level Design
-      rules: []
-      status: pending
-    - id: sa-5.5
-      title: Source Code
-      rules: []
-      status: pending
+      controls:
+          - id: sa-5.1
+            title: Functional Properties of Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.2
+            title: Security-relevant External System Interfaces
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.3
+            title: High-level Design
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.4
+            title: Low-level Design
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.5
+            title: Source Code
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-6
       title: Software Usage Restrictions
       rules: []
@@ -134,318 +167,436 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sa-8.1
-      title: Clear Abstractions
-      rules: []
-      status: pending
-    - id: sa-8.2
-      title: Least Common Mechanism
-      rules: []
-      status: pending
-    - id: sa-8.3
-      title: Modularity and Layering
-      rules: []
-      status: pending
-    - id: sa-8.4
-      title: Partially Ordered Dependencies
-      rules: []
-      status: pending
-    - id: sa-8.5
-      title: Efficiently Mediated Access
-      rules: []
-      status: pending
-    - id: sa-8.6
-      title: Minimized Sharing
-      rules: []
-      status: pending
-    - id: sa-8.7
-      title: Reduced Complexity
-      rules: []
-      status: pending
-    - id: sa-8.8
-      title: Secure Evolvability
-      rules: []
-      status: pending
-    - id: sa-8.9
-      title: Trusted Components
-      rules: []
-      status: pending
-    - id: sa-8.10
-      title: Hierarchical Trust
-      rules: []
-      status: pending
-    - id: sa-8.11
-      title: Inverse Modification Threshold
-      rules: []
-      status: pending
-    - id: sa-8.12
-      title: Hierarchical Protection
-      rules: []
-      status: pending
-    - id: sa-8.13
-      title: Minimized Security Elements
-      rules: []
-      status: pending
-    - id: sa-8.14
-      title: Least Privilege
-      rules: []
-      status: pending
-    - id: sa-8.15
-      title: Predicate Permission
-      rules: []
-      status: pending
-    - id: sa-8.16
-      title: Self-reliant Trustworthiness
-      rules: []
-      status: pending
-    - id: sa-8.17
-      title: Secure Distributed Composition
-      rules: []
-      status: pending
-    - id: sa-8.18
-      title: Trusted Communications Channels
-      rules: []
-      status: pending
-    - id: sa-8.19
-      title: Continuous Protection
-      rules: []
-      status: pending
-    - id: sa-8.20
-      title: Secure Metadata Management
-      rules: []
-      status: pending
-    - id: sa-8.21
-      title: Self-analysis
-      rules: []
-      status: pending
-    - id: sa-8.22
-      title: Accountability and Traceability
-      rules: []
-      status: pending
-    - id: sa-8.23
-      title: Secure Defaults
-      rules: []
-      status: pending
-    - id: sa-8.24
-      title: Secure Failure and Recovery
-      rules: []
-      status: pending
-    - id: sa-8.25
-      title: Economic Security
-      rules: []
-      status: pending
-    - id: sa-8.26
-      title: Performance Security
-      rules: []
-      status: pending
-    - id: sa-8.27
-      title: Human Factored Security
-      rules: []
-      status: pending
-    - id: sa-8.28
-      title: Acceptable Security
-      rules: []
-      status: pending
-    - id: sa-8.29
-      title: Repeatable and Documented Procedures
-      rules: []
-      status: pending
-    - id: sa-8.30
-      title: Procedural Rigor
-      rules: []
-      status: pending
-    - id: sa-8.31
-      title: Secure System Modification
-      rules: []
-      status: pending
-    - id: sa-8.32
-      title: Sufficient Documentation
-      rules: []
-      status: pending
-    - id: sa-8.33
-      title: Minimization
-      rules: []
-      status: pending
+      controls:
+          - id: sa-8.1
+            title: Clear Abstractions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.2
+            title: Least Common Mechanism
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.3
+            title: Modularity and Layering
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.4
+            title: Partially Ordered Dependencies
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.5
+            title: Efficiently Mediated Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.6
+            title: Minimized Sharing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.7
+            title: Reduced Complexity
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.8
+            title: Secure Evolvability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.9
+            title: Trusted Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.10
+            title: Hierarchical Trust
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.11
+            title: Inverse Modification Threshold
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.12
+            title: Hierarchical Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.13
+            title: Minimized Security Elements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.14
+            title: Least Privilege
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.15
+            title: Predicate Permission
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.16
+            title: Self-reliant Trustworthiness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.17
+            title: Secure Distributed Composition
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.18
+            title: Trusted Communications Channels
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.19
+            title: Continuous Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.20
+            title: Secure Metadata Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.21
+            title: Self-analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.22
+            title: Accountability and Traceability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.23
+            title: Secure Defaults
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.24
+            title: Secure Failure and Recovery
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.25
+            title: Economic Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.26
+            title: Performance Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.27
+            title: Human Factored Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.28
+            title: Acceptable Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.29
+            title: Repeatable and Documented Procedures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.30
+            title: Procedural Rigor
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.31
+            title: Secure System Modification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.32
+            title: Sufficient Documentation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.33
+            title: Minimization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-9
       title: External System Services
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-9.1
-      title: Risk Assessments and Organizational Approvals
-      rules: []
-      status: pending
-    - id: sa-9.2
-      title: Identification of Functions, Ports, Protocols, and Services
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-9.3
-      title: Establish and Maintain Trust Relationship with Providers
-      rules: []
-      status: pending
-    - id: sa-9.4
-      title: Consistent Interests of Consumers and Providers
-      rules: []
-      status: pending
-    - id: sa-9.5
-      title: Processing, Storage, and Service Location
-      rules: []
-      status: pending
-    - id: sa-9.6
-      title: Organization-controlled Cryptographic Keys
-      rules: []
-      status: pending
-    - id: sa-9.7
-      title: Organization-controlled Integrity Checking
-      rules: []
-      status: pending
-    - id: sa-9.8
-      title: Processing and Storage Location — U.S. Jurisdiction
-      rules: []
-      status: pending
+      controls:
+          - id: sa-9.1
+            title: Risk Assessments and Organizational Approvals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.2
+            title: Identification of Functions, Ports, Protocols, and Services
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-9.3
+            title: Establish and Maintain Trust Relationship with Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.4
+            title: Consistent Interests of Consumers and Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.5
+            title: Processing, Storage, and Service Location
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.6
+            title: Organization-controlled Cryptographic Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.7
+            title: Organization-controlled Integrity Checking
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.8
+            title: Processing and Storage Location — U.S. Jurisdiction
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-10
       title: Developer Configuration Management
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-10.1
-      title: Software and Firmware Integrity Verification
-      rules: []
-      status: pending
-    - id: sa-10.2
-      title: Alternative Configuration Management Processes
-      rules: []
-      status: pending
-    - id: sa-10.3
-      title: Hardware Integrity Verification
-      rules: []
-      status: pending
-    - id: sa-10.4
-      title: Trusted Generation
-      rules: []
-      status: pending
-    - id: sa-10.5
-      title: Mapping Integrity for Version Control
-      rules: []
-      status: pending
-    - id: sa-10.6
-      title: Trusted Distribution
-      rules: []
-      status: pending
-    - id: sa-10.7
-      title: Security and Privacy Representatives
-      rules: []
-      status: pending
+      controls:
+          - id: sa-10.1
+            title: Software and Firmware Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.2
+            title: Alternative Configuration Management Processes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.3
+            title: Hardware Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.4
+            title: Trusted Generation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.5
+            title: Mapping Integrity for Version Control
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.6
+            title: Trusted Distribution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.7
+            title: Security and Privacy Representatives
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-11
       title: Developer Testing and Evaluation
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-11.1
-      title: Static Code Analysis
-      rules: []
-      status: pending
-    - id: sa-11.2
-      title: Threat Modeling and Vulnerability Analyses
-      rules: []
-      status: pending
-    - id: sa-11.3
-      title: Independent Verification of Assessment Plans and Evidence
-      rules: []
-      status: pending
-    - id: sa-11.4
-      title: Manual Code Reviews
-      rules: []
-      status: pending
-    - id: sa-11.5
-      title: Penetration Testing
-      rules: []
-      status: pending
-    - id: sa-11.6
-      title: Attack Surface Reviews
-      rules: []
-      status: pending
-    - id: sa-11.7
-      title: Verify Scope of Testing and Evaluation
-      rules: []
-      status: pending
-    - id: sa-11.8
-      title: Dynamic Code Analysis
-      rules: []
-      status: pending
-    - id: sa-11.9
-      title: Interactive Application Security Testing
-      rules: []
-      status: pending
+      controls:
+          - id: sa-11.1
+            title: Static Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.2
+            title: Threat Modeling and Vulnerability Analyses
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.3
+            title: Independent Verification of Assessment Plans and Evidence
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.4
+            title: Manual Code Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.5
+            title: Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.6
+            title: Attack Surface Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.7
+            title: Verify Scope of Testing and Evaluation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.8
+            title: Dynamic Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.9
+            title: Interactive Application Security Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-12
       title: Supply Chain Protection
       rules: []
       status: pending
-    - id: sa-12.1
-      title: Acquisition Strategies / Tools / Methods
-      rules: []
-      status: pending
-    - id: sa-12.2
-      title: Supplier Reviews
-      rules: []
-      status: pending
-    - id: sa-12.3
-      title: Trusted Shipping and Warehousing
-      rules: []
-      status: pending
-    - id: sa-12.4
-      title: Diversity of Suppliers
-      rules: []
-      status: pending
-    - id: sa-12.5
-      title: Limitation of Harm
-      rules: []
-      status: pending
-    - id: sa-12.6
-      title: Minimizing Procurement Time
-      rules: []
-      status: pending
-    - id: sa-12.7
-      title: Assessments Prior to Selection / Acceptance / Update
-      rules: []
-      status: pending
-    - id: sa-12.8
-      title: Use of All-source Intelligence
-      rules: []
-      status: pending
-    - id: sa-12.9
-      title: Operations Security
-      rules: []
-      status: pending
-    - id: sa-12.10
-      title: Validate as Genuine and Not Altered
-      rules: []
-      status: pending
-    - id: sa-12.11
-      title: Penetration Testing / Analysis of Elements, Processes, and Actors
-      rules: []
-      status: pending
-    - id: sa-12.12
-      title: Inter-organizational Agreements
-      rules: []
-      status: pending
-    - id: sa-12.13
-      title: Critical Information System Components
-      rules: []
-      status: pending
-    - id: sa-12.14
-      title: Identity and Traceability
-      rules: []
-      status: pending
-    - id: sa-12.15
-      title: Processes to Address Weaknesses or Deficiencies
-      rules: []
-      status: pending
+      controls:
+          - id: sa-12.1
+            title: Acquisition Strategies / Tools / Methods
+            rules: []
+            status: pending
+          - id: sa-12.2
+            title: Supplier Reviews
+            rules: []
+            status: pending
+          - id: sa-12.3
+            title: Trusted Shipping and Warehousing
+            rules: []
+            status: pending
+          - id: sa-12.4
+            title: Diversity of Suppliers
+            rules: []
+            status: pending
+          - id: sa-12.5
+            title: Limitation of Harm
+            rules: []
+            status: pending
+          - id: sa-12.6
+            title: Minimizing Procurement Time
+            rules: []
+            status: pending
+          - id: sa-12.7
+            title: Assessments Prior to Selection / Acceptance / Update
+            rules: []
+            status: pending
+          - id: sa-12.8
+            title: Use of All-source Intelligence
+            rules: []
+            status: pending
+          - id: sa-12.9
+            title: Operations Security
+            rules: []
+            status: pending
+          - id: sa-12.10
+            title: Validate as Genuine and Not Altered
+            rules: []
+            status: pending
+          - id: sa-12.11
+            title: Penetration Testing / Analysis of Elements, Processes, and
+                Actors
+            rules: []
+            status: pending
+          - id: sa-12.12
+            title: Inter-organizational Agreements
+            rules: []
+            status: pending
+          - id: sa-12.13
+            title: Critical Information System Components
+            rules: []
+            status: pending
+          - id: sa-12.14
+            title: Identity and Traceability
+            rules: []
+            status: pending
+          - id: sa-12.15
+            title: Processes to Address Weaknesses or Deficiencies
+            rules: []
+            status: pending
     - id: sa-13
       title: Trustworthiness
       rules: []
@@ -454,70 +605,96 @@ controls:
       title: Criticality Analysis
       rules: []
       status: pending
-    - id: sa-14.1
-      title: Critical Components with No Viable Alternative Sourcing
-      rules: []
-      status: pending
+      controls:
+          - id: sa-14.1
+            title: Critical Components with No Viable Alternative Sourcing
+            rules: []
+            status: pending
     - id: sa-15
       title: Development Process, Standards, and Tools
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-15.1
-      title: Quality Metrics
-      rules: []
-      status: pending
-    - id: sa-15.2
-      title: Security and Privacy Tracking Tools
-      rules: []
-      status: pending
-    - id: sa-15.3
-      title: Criticality Analysis
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-15.4
-      title: Threat Modeling and Vulnerability Analysis
-      rules: []
-      status: pending
-    - id: sa-15.5
-      title: Attack Surface Reduction
-      rules: []
-      status: pending
-    - id: sa-15.6
-      title: Continuous Improvement
-      rules: []
-      status: pending
-    - id: sa-15.7
-      title: Automated Vulnerability Analysis
-      rules: []
-      status: pending
-    - id: sa-15.8
-      title: Reuse of Threat and Vulnerability Information
-      rules: []
-      status: pending
-    - id: sa-15.9
-      title: Use of Live Data
-      rules: []
-      status: pending
-    - id: sa-15.10
-      title: Incident Response Plan
-      rules: []
-      status: pending
-    - id: sa-15.11
-      title: Archive System or Component
-      rules: []
-      status: pending
-    - id: sa-15.12
-      title: Minimize Personally Identifiable Information
-      rules: []
-      status: pending
-    - id: sa-15.13
-      title: Logging Syntax
-      rules: []
-      status: pending
+      controls:
+          - id: sa-15.1
+            title: Quality Metrics
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.2
+            title: Security and Privacy Tracking Tools
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.3
+            title: Criticality Analysis
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-15.4
+            title: Threat Modeling and Vulnerability Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.5
+            title: Attack Surface Reduction
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.6
+            title: Continuous Improvement
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.7
+            title: Automated Vulnerability Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.8
+            title: Reuse of Threat and Vulnerability Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.9
+            title: Use of Live Data
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.10
+            title: Incident Response Plan
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.11
+            title: Archive System or Component
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.12
+            title: Minimize Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.13
+            title: Logging Syntax
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-16
       title: Developer-provided Training
       levels:
@@ -530,74 +707,95 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sa-17.1
-      title: Formal Policy Model
-      rules: []
-      status: pending
-    - id: sa-17.2
-      title: Security-relevant Components
-      rules: []
-      status: pending
-    - id: sa-17.3
-      title: Formal Correspondence
-      rules: []
-      status: pending
-    - id: sa-17.4
-      title: Informal Correspondence
-      rules: []
-      status: pending
-    - id: sa-17.5
-      title: Conceptually Simple Design
-      rules: []
-      status: pending
-    - id: sa-17.6
-      title: Structure for Testing
-      rules: []
-      status: pending
-    - id: sa-17.7
-      title: Structure for Least Privilege
-      rules: []
-      status: pending
-    - id: sa-17.8
-      title: Orchestration
-      rules: []
-      status: pending
-    - id: sa-17.9
-      title: Design Diversity
-      rules: []
-      status: pending
+      controls:
+          - id: sa-17.1
+            title: Formal Policy Model
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.2
+            title: Security-relevant Components
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.3
+            title: Formal Correspondence
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.4
+            title: Informal Correspondence
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.5
+            title: Conceptually Simple Design
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.6
+            title: Structure for Testing
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.7
+            title: Structure for Least Privilege
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.8
+            title: Orchestration
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.9
+            title: Design Diversity
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sa-18
       title: Tamper Resistance and Detection
       rules: []
       status: pending
-    - id: sa-18.1
-      title: Multiple Phases of System Development Life Cycle
-      rules: []
-      status: pending
-    - id: sa-18.2
-      title: Inspection of Systems or Components
-      rules: []
-      status: pending
+      controls:
+          - id: sa-18.1
+            title: Multiple Phases of System Development Life Cycle
+            rules: []
+            status: pending
+          - id: sa-18.2
+            title: Inspection of Systems or Components
+            rules: []
+            status: pending
     - id: sa-19
       title: Component Authenticity
       rules: []
       status: pending
-    - id: sa-19.1
-      title: Anti-counterfeit Training
-      rules: []
-      status: pending
-    - id: sa-19.2
-      title: Configuration Control for Component Service and Repair
-      rules: []
-      status: pending
-    - id: sa-19.3
-      title: Component Disposal
-      rules: []
-      status: pending
-    - id: sa-19.4
-      title: Anti-counterfeit Scanning
-      rules: []
-      status: pending
+      controls:
+          - id: sa-19.1
+            title: Anti-counterfeit Training
+            rules: []
+            status: pending
+          - id: sa-19.2
+            title: Configuration Control for Component Service and Repair
+            rules: []
+            status: pending
+          - id: sa-19.3
+            title: Component Disposal
+            rules: []
+            status: pending
+          - id: sa-19.4
+            title: Anti-counterfeit Scanning
+            rules: []
+            status: pending
     - id: sa-20
       title: Customized Development of Critical Components
       rules: []
@@ -608,20 +806,26 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sa-21.1
-      title: Validation of Screening
-      rules: []
-      status: pending
+      controls:
+          - id: sa-21.1
+            title: Validation of Screening
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sa-22
       title: Unsupported System Components
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-22.1
-      title: Alternative Sources for Continued Support
-      rules: []
-      status: pending
+      controls:
+          - id: sa-22.1
+            title: Alternative Sources for Continued Support
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-23
       title: Specialization
       rules: []

--- a/products/rhel10/controls/nist_800_53/sc.yml
+++ b/products/rhel10/controls/nist_800_53/sc.yml
@@ -13,14 +13,19 @@ controls:
       rules:
           - sysctl_kernel_dmesg_restrict
       status: automated
-    - id: sc-2.1
-      title: Interfaces for Non-privileged Users
-      rules: []
-      status: pending
-    - id: sc-2.2
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: sc-2.1
+            title: Interfaces for Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-2.2
+            title: Disassociability
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-3
       title: Security Function Isolation
       levels:
@@ -30,26 +35,37 @@ controls:
           - selinux_state
           - var_selinux_state=enforcing
       status: automated
-    - id: sc-3.1
-      title: Hardware Separation
-      rules: []
-      status: pending
-    - id: sc-3.2
-      title: Access and Flow Control Functions
-      rules: []
-      status: pending
-    - id: sc-3.3
-      title: Minimize Nonsecurity Functionality
-      rules: []
-      status: pending
-    - id: sc-3.4
-      title: Module Coupling and Cohesiveness
-      rules: []
-      status: pending
-    - id: sc-3.5
-      title: Layered Structures
-      rules: []
-      status: pending
+      controls:
+          - id: sc-3.1
+            title: Hardware Separation
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.2
+            title: Access and Flow Control Functions
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.3
+            title: Minimize Nonsecurity Functionality
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.4
+            title: Module Coupling and Cohesiveness
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.5
+            title: Layered Structures
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sc-4
       title: Information in Shared System Resources
       levels:
@@ -58,14 +74,19 @@ controls:
           - dir_perms_world_writable_sticky_bits
           - file_permissions_unauthorized_world_writable
       status: automated
-    - id: sc-4.1
-      title: Security Levels
-      rules: []
-      status: pending
-    - id: sc-4.2
-      title: Multilevel or Periods Processing
-      rules: []
-      status: pending
+      controls:
+          - id: sc-4.1
+            title: Security Levels
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-4.2
+            title: Multilevel or Periods Processing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-5
       title: Denial-of-service Protection
       levels:
@@ -73,18 +94,25 @@ controls:
       rules:
           - sysctl_net_ipv4_tcp_syncookies
       status: automated
-    - id: sc-5.1
-      title: Restrict Ability to Attack Other Systems
-      rules: []
-      status: pending
-    - id: sc-5.2
-      title: Capacity, Bandwidth, and Redundancy
-      rules: []
-      status: pending
-    - id: sc-5.3
-      title: Detection and Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: sc-5.1
+            title: Restrict Ability to Attack Other Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-5.2
+            title: Capacity, Bandwidth, and Redundancy
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-5.3
+            title: Detection and Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-6
       title: Resource Availability
       rules: []
@@ -96,136 +124,183 @@ controls:
       rules:
           - service_firewalld_enabled
       status: automated
-    - id: sc-7.1
-      title: Physically Separated Subnetworks
-      rules: []
-      status: pending
-    - id: sc-7.2
-      title: Public Access
-      rules: []
-      status: pending
-    - id: sc-7.3
-      title: Access Points
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.4
-      title: External Telecommunications Services
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.5
-      title: Deny by Default — Allow by Exception
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.6
-      title: Response to Recognized Failures
-      rules: []
-      status: pending
-    - id: sc-7.7
-      title: Split Tunneling for Remote Devices
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.8
-      title: Route Traffic to Authenticated Proxy Servers
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.9
-      title: Restrict Threatening Outgoing Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-7.10
-      title: Prevent Exfiltration
-      rules: []
-      status: pending
-    - id: sc-7.11
-      title: Restrict Incoming Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-7.12
-      title: Host-based Protection
-      rules: []
-      status: pending
-    - id: sc-7.13
-      title: Isolation of Security Tools, Mechanisms, and Support Components
-      rules: []
-      status: pending
-    - id: sc-7.14
-      title: Protect Against Unauthorized Physical Connections
-      rules: []
-      status: pending
-    - id: sc-7.15
-      title: Networked Privileged Accesses
-      rules: []
-      status: pending
-    - id: sc-7.16
-      title: Prevent Discovery of System Components
-      rules: []
-      status: pending
-    - id: sc-7.17
-      title: Automated Enforcement of Protocol Formats
-      rules: []
-      status: pending
-    - id: sc-7.18
-      title: Fail Secure
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-7.19
-      title: Block Communication from Non-organizationally Configured Hosts
-      rules: []
-      status: pending
-    - id: sc-7.20
-      title: Dynamic Isolation and Segregation
-      rules: []
-      status: pending
-    - id: sc-7.21
-      title: Isolation of System Components
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-7.22
-      title: Separate Subnets for Connecting to Different Security Domains
-      rules: []
-      status: pending
-    - id: sc-7.23
-      title: Disable Sender Feedback on Protocol Validation Failure
-      rules: []
-      status: pending
-    - id: sc-7.24
-      title: Personally Identifiable Information
-      rules: []
-      status: pending
-    - id: sc-7.25
-      title: Unclassified National Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.26
-      title: Classified National Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.27
-      title: Unclassified Non-national Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.28
-      title: Connections to Public Networks
-      rules: []
-      status: pending
-    - id: sc-7.29
-      title: Separate Subnets to Isolate Functions
-      rules: []
-      status: pending
+      controls:
+          - id: sc-7.1
+            title: Physically Separated Subnetworks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.2
+            title: Public Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.3
+            title: Access Points
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.4
+            title: External Telecommunications Services
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.5
+            title: Deny by Default — Allow by Exception
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.6
+            title: Response to Recognized Failures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.7
+            title: Split Tunneling for Remote Devices
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.8
+            title: Route Traffic to Authenticated Proxy Servers
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.9
+            title: Restrict Threatening Outgoing Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.10
+            title: Prevent Exfiltration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.11
+            title: Restrict Incoming Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.12
+            title: Host-based Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.13
+            title: Isolation of Security Tools, Mechanisms, and Support
+                Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.14
+            title: Protect Against Unauthorized Physical Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.15
+            title: Networked Privileged Accesses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.16
+            title: Prevent Discovery of System Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.17
+            title: Automated Enforcement of Protocol Formats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.18
+            title: Fail Secure
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-7.19
+            title: Block Communication from Non-organizationally Configured
+                Hosts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.20
+            title: Dynamic Isolation and Segregation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.21
+            title: Isolation of System Components
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-7.22
+            title: Separate Subnets for Connecting to Different Security Domains
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.23
+            title: Disable Sender Feedback on Protocol Validation Failure
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.24
+            title: Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.25
+            title: Unclassified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.26
+            title: Classified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.27
+            title: Unclassified Non-national Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.28
+            title: Connections to Public Networks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.29
+            title: Separate Subnets to Isolate Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-8
       title: Transmission Confidentiality and Integrity
       levels:
@@ -233,28 +308,37 @@ controls:
       rules:
           - configure_custom_crypto_policy_cis
       status: automated
-    - id: sc-8.1
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-8.2
-      title: Pre- and Post-transmission Handling
-      rules: []
-      status: pending
-    - id: sc-8.3
-      title: Cryptographic Protection for Message Externals
-      rules: []
-      status: pending
-    - id: sc-8.4
-      title: Conceal or Randomize Communications
-      rules: []
-      status: pending
-    - id: sc-8.5
-      title: Protected Distribution System
-      rules: []
-      status: pending
+      controls:
+          - id: sc-8.1
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-8.2
+            title: Pre- and Post-transmission Handling
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.3
+            title: Cryptographic Protection for Message Externals
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.4
+            title: Conceal or Randomize Communications
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.5
+            title: Protected Distribution System
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-9
       title: Transmission Confidentiality
       rules: []
@@ -269,64 +353,85 @@ controls:
       title: Trusted Path
       rules: []
       status: pending
-    - id: sc-11.1
-      title: Irrefutable Communications Path
-      rules: []
-      status: pending
+      controls:
+          - id: sc-11.1
+            title: Irrefutable Communications Path
+            rules: []
+            status: pending
     - id: sc-12
       title: Cryptographic Key Establishment and Management
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-12.1
-      title: Availability
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-12.2
-      title: Symmetric Keys
-      rules: []
-      status: pending
-    - id: sc-12.3
-      title: Asymmetric Keys
-      rules: []
-      status: pending
-    - id: sc-12.4
-      title: PKI Certificates
-      rules: []
-      status: pending
-    - id: sc-12.5
-      title: PKI Certificates / Hardware Tokens
-      rules: []
-      status: pending
-    - id: sc-12.6
-      title: Physical Control of Keys
-      rules: []
-      status: pending
+      controls:
+          - id: sc-12.1
+            title: Availability
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-12.2
+            title: Symmetric Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.3
+            title: Asymmetric Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.4
+            title: PKI Certificates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.5
+            title: PKI Certificates / Hardware Tokens
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.6
+            title: Physical Control of Keys
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-13
       title: Cryptographic Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-13.1
-      title: FIPS-validated Cryptography
-      rules: []
-      status: pending
-    - id: sc-13.2
-      title: NSA-approved Cryptography
-      rules: []
-      status: pending
-    - id: sc-13.3
-      title: Individuals Without Formal Access Approvals
-      rules: []
-      status: pending
-    - id: sc-13.4
-      title: Digital Signatures
-      rules: []
-      status: pending
+      controls:
+          - id: sc-13.1
+            title: FIPS-validated Cryptography
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.2
+            title: NSA-approved Cryptography
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.3
+            title: Individuals Without Formal Access Approvals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.4
+            title: Digital Signatures
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-14
       title: Public Access Protections
       rules: []
@@ -337,38 +442,48 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-15.1
-      title: Physical or Logical Disconnect
-      rules: []
-      status: pending
-    - id: sc-15.2
-      title: Blocking Inbound and Outbound Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-15.3
-      title: Disabling and Removal in Secure Work Areas
-      rules: []
-      status: pending
-    - id: sc-15.4
-      title: Explicitly Indicate Current Participants
-      rules: []
-      status: pending
+      controls:
+          - id: sc-15.1
+            title: Physical or Logical Disconnect
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.2
+            title: Blocking Inbound and Outbound Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.3
+            title: Disabling and Removal in Secure Work Areas
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.4
+            title: Explicitly Indicate Current Participants
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-16
       title: Transmission of Security and Privacy Attributes
       rules: []
       status: pending
-    - id: sc-16.1
-      title: Integrity Verification
-      rules: []
-      status: pending
-    - id: sc-16.2
-      title: Anti-spoofing Mechanisms
-      rules: []
-      status: pending
-    - id: sc-16.3
-      title: Cryptographic Binding
-      rules: []
-      status: pending
+      controls:
+          - id: sc-16.1
+            title: Integrity Verification
+            rules: []
+            status: pending
+          - id: sc-16.2
+            title: Anti-spoofing Mechanisms
+            rules: []
+            status: pending
+          - id: sc-16.3
+            title: Cryptographic Binding
+            rules: []
+            status: pending
     - id: sc-17
       title: Public Key Infrastructure Certificates
       levels:
@@ -381,26 +496,37 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-18.1
-      title: Identify Unacceptable Code and Take Corrective Actions
-      rules: []
-      status: pending
-    - id: sc-18.2
-      title: Acquisition, Development, and Use
-      rules: []
-      status: pending
-    - id: sc-18.3
-      title: Prevent Downloading and Execution
-      rules: []
-      status: pending
-    - id: sc-18.4
-      title: Prevent Automatic Execution
-      rules: []
-      status: pending
-    - id: sc-18.5
-      title: Allow Execution Only in Confined Environments
-      rules: []
-      status: pending
+      controls:
+          - id: sc-18.1
+            title: Identify Unacceptable Code and Take Corrective Actions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.2
+            title: Acquisition, Development, and Use
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.3
+            title: Prevent Downloading and Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.4
+            title: Prevent Automatic Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.5
+            title: Allow Execution Only in Confined Environments
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-19
       title: Voice Over Internet Protocol
       rules: []
@@ -411,24 +537,33 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-20.1
-      title: Child Subspaces
-      rules: []
-      status: pending
-    - id: sc-20.2
-      title: Data Origin and Integrity
-      rules: []
-      status: pending
+      controls:
+          - id: sc-20.1
+            title: Child Subspaces
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-20.2
+            title: Data Origin and Integrity
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-21
-      title: Secure Name/Address Resolution Service (Recursive or Caching Resolver)
+      title: Secure Name/Address Resolution Service (Recursive or Caching
+          Resolver)
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-21.1
-      title: Data Origin and Integrity
-      rules: []
-      status: pending
+      controls:
+          - id: sc-21.1
+            title: Data Origin and Integrity
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-22
       title: Architecture and Provisioning for Name/Address Resolution Service
       levels:
@@ -441,26 +576,37 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-23.1
-      title: Invalidate Session Identifiers at Logout
-      rules: []
-      status: pending
-    - id: sc-23.2
-      title: User-initiated Logouts and Message Displays
-      rules: []
-      status: pending
-    - id: sc-23.3
-      title: Unique System-generated Session Identifiers
-      rules: []
-      status: pending
-    - id: sc-23.4
-      title: Unique Session Identifiers with Randomization
-      rules: []
-      status: pending
-    - id: sc-23.5
-      title: Allowed Certificate Authorities
-      rules: []
-      status: pending
+      controls:
+          - id: sc-23.1
+            title: Invalidate Session Identifiers at Logout
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.2
+            title: User-initiated Logouts and Message Displays
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.3
+            title: Unique System-generated Session Identifiers
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.4
+            title: Unique Session Identifiers with Randomization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.5
+            title: Allowed Certificate Authorities
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-24
       title: Fail in Known State
       levels:
@@ -476,10 +622,11 @@ controls:
       title: Decoys
       rules: []
       status: pending
-    - id: sc-26.1
-      title: Detection of Malicious Code
-      rules: []
-      status: pending
+      controls:
+          - id: sc-26.1
+            title: Detection of Malicious Code
+            rules: []
+            status: pending
     - id: sc-27
       title: Platform-independent Applications
       rules: []
@@ -490,76 +637,85 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-28.1
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-28.2
-      title: Offline Storage
-      rules: []
-      status: pending
-    - id: sc-28.3
-      title: Cryptographic Keys
-      rules: []
-      status: pending
+      controls:
+          - id: sc-28.1
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-28.2
+            title: Offline Storage
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-28.3
+            title: Cryptographic Keys
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-29
       title: Heterogeneity
       rules: []
       status: pending
-    - id: sc-29.1
-      title: Virtualization Techniques
-      rules: []
-      status: pending
+      controls:
+          - id: sc-29.1
+            title: Virtualization Techniques
+            rules: []
+            status: pending
     - id: sc-30
       title: Concealment and Misdirection
       rules: []
       status: pending
-    - id: sc-30.1
-      title: Virtualization Techniques
-      rules: []
-      status: pending
-    - id: sc-30.2
-      title: Randomness
-      rules: []
-      status: pending
-    - id: sc-30.3
-      title: Change Processing and Storage Locations
-      rules: []
-      status: pending
-    - id: sc-30.4
-      title: Misleading Information
-      rules: []
-      status: pending
-    - id: sc-30.5
-      title: Concealment of System Components
-      rules: []
-      status: pending
+      controls:
+          - id: sc-30.1
+            title: Virtualization Techniques
+            rules: []
+            status: pending
+          - id: sc-30.2
+            title: Randomness
+            rules: []
+            status: pending
+          - id: sc-30.3
+            title: Change Processing and Storage Locations
+            rules: []
+            status: pending
+          - id: sc-30.4
+            title: Misleading Information
+            rules: []
+            status: pending
+          - id: sc-30.5
+            title: Concealment of System Components
+            rules: []
+            status: pending
     - id: sc-31
       title: Covert Channel Analysis
       rules: []
       status: pending
-    - id: sc-31.1
-      title: Test Covert Channels for Exploitability
-      rules: []
-      status: pending
-    - id: sc-31.2
-      title: Maximum Bandwidth
-      rules: []
-      status: pending
-    - id: sc-31.3
-      title: Measure Bandwidth in Operational Environments
-      rules: []
-      status: pending
+      controls:
+          - id: sc-31.1
+            title: Test Covert Channels for Exploitability
+            rules: []
+            status: pending
+          - id: sc-31.2
+            title: Maximum Bandwidth
+            rules: []
+            status: pending
+          - id: sc-31.3
+            title: Measure Bandwidth in Operational Environments
+            rules: []
+            status: pending
     - id: sc-32
       title: System Partitioning
       rules: []
       status: pending
-    - id: sc-32.1
-      title: Separate Physical Domains for Privileged Functions
-      rules: []
-      status: pending
+      controls:
+          - id: sc-32.1
+            title: Separate Physical Domains for Privileged Functions
+            rules: []
+            status: pending
     - id: sc-33
       title: Transmission Preparation Integrity
       rules: []
@@ -568,18 +724,19 @@ controls:
       title: Non-modifiable Executable Programs
       rules: []
       status: pending
-    - id: sc-34.1
-      title: No Writable Storage
-      rules: []
-      status: pending
-    - id: sc-34.2
-      title: Integrity Protection on Read-only Media
-      rules: []
-      status: pending
-    - id: sc-34.3
-      title: Hardware-based Protection
-      rules: []
-      status: pending
+      controls:
+          - id: sc-34.1
+            title: No Writable Storage
+            rules: []
+            status: pending
+          - id: sc-34.2
+            title: Integrity Protection on Read-only Media
+            rules: []
+            status: pending
+          - id: sc-34.3
+            title: Hardware-based Protection
+            rules: []
+            status: pending
     - id: sc-35
       title: External Malicious Code Identification
       rules: []
@@ -588,22 +745,24 @@ controls:
       title: Distributed Processing and Storage
       rules: []
       status: pending
-    - id: sc-36.1
-      title: Polling Techniques
-      rules: []
-      status: pending
-    - id: sc-36.2
-      title: Synchronization
-      rules: []
-      status: pending
+      controls:
+          - id: sc-36.1
+            title: Polling Techniques
+            rules: []
+            status: pending
+          - id: sc-36.2
+            title: Synchronization
+            rules: []
+            status: pending
     - id: sc-37
       title: Out-of-band Channels
       rules: []
       status: pending
-    - id: sc-37.1
-      title: Ensure Delivery and Transmission
-      rules: []
-      status: pending
+      controls:
+          - id: sc-37.1
+            title: Ensure Delivery and Transmission
+            rules: []
+            status: pending
     - id: sc-38
       title: Operations Security
       rules: []
@@ -614,34 +773,40 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-39.1
-      title: Hardware Separation
-      rules: []
-      status: pending
-    - id: sc-39.2
-      title: Separate Execution Domain Per Thread
-      rules: []
-      status: pending
+      controls:
+          - id: sc-39.1
+            title: Hardware Separation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-39.2
+            title: Separate Execution Domain Per Thread
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-40
       title: Wireless Link Protection
       rules: []
       status: pending
-    - id: sc-40.1
-      title: Electromagnetic Interference
-      rules: []
-      status: pending
-    - id: sc-40.2
-      title: Reduce Detection Potential
-      rules: []
-      status: pending
-    - id: sc-40.3
-      title: Imitative or Manipulative Communications Deception
-      rules: []
-      status: pending
-    - id: sc-40.4
-      title: Signal Parameter Identification
-      rules: []
-      status: pending
+      controls:
+          - id: sc-40.1
+            title: Electromagnetic Interference
+            rules: []
+            status: pending
+          - id: sc-40.2
+            title: Reduce Detection Potential
+            rules: []
+            status: pending
+          - id: sc-40.3
+            title: Imitative or Manipulative Communications Deception
+            rules: []
+            status: pending
+          - id: sc-40.4
+            title: Signal Parameter Identification
+            rules: []
+            status: pending
     - id: sc-41
       title: Port and I/O Device Access
       rules: []
@@ -650,26 +815,27 @@ controls:
       title: Sensor Capability and Data
       rules: []
       status: pending
-    - id: sc-42.1
-      title: Reporting to Authorized Individuals or Roles
-      rules: []
-      status: pending
-    - id: sc-42.2
-      title: Authorized Use
-      rules: []
-      status: pending
-    - id: sc-42.3
-      title: Prohibit Use of Devices
-      rules: []
-      status: pending
-    - id: sc-42.4
-      title: Notice of Collection
-      rules: []
-      status: pending
-    - id: sc-42.5
-      title: Collection Minimization
-      rules: []
-      status: pending
+      controls:
+          - id: sc-42.1
+            title: Reporting to Authorized Individuals or Roles
+            rules: []
+            status: pending
+          - id: sc-42.2
+            title: Authorized Use
+            rules: []
+            status: pending
+          - id: sc-42.3
+            title: Prohibit Use of Devices
+            rules: []
+            status: pending
+          - id: sc-42.4
+            title: Notice of Collection
+            rules: []
+            status: pending
+          - id: sc-42.5
+            title: Collection Minimization
+            rules: []
+            status: pending
     - id: sc-43
       title: Usage Restrictions
       rules: []
@@ -682,14 +848,15 @@ controls:
       title: System Time Synchronization
       rules: []
       status: pending
-    - id: sc-45.1
-      title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
-    - id: sc-45.2
-      title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      controls:
+          - id: sc-45.1
+            title: Synchronization with Authoritative Time Source
+            rules: []
+            status: pending
+          - id: sc-45.2
+            title: Secondary Authoritative Time Source
+            rules: []
+            status: pending
     - id: sc-46
       title: Cross Domain Policy Enforcement
       rules: []
@@ -702,10 +869,11 @@ controls:
       title: Sensor Relocation
       rules: []
       status: pending
-    - id: sc-48.1
-      title: Dynamic Relocation of Sensors or Monitoring Capabilities
-      rules: []
-      status: pending
+      controls:
+          - id: sc-48.1
+            title: Dynamic Relocation of Sensors or Monitoring Capabilities
+            rules: []
+            status: pending
     - id: sc-49
       title: Hardware-enforced Separation and Policy Enforcement
       rules: []

--- a/products/rhel10/controls/nist_800_53/si.yml
+++ b/products/rhel10/controls/nist_800_53/si.yml
@@ -14,36 +14,49 @@ controls:
           - ensure_gpgcheck_globally_activated
           - ensure_redhat_gpgkey_installed
       status: automated
-    - id: si-2.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-2.2
-      title: Automated Flaw Remediation Status
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-2.3
-      title: Time to Remediate Flaws and Benchmarks for Corrective Actions
-      rules: []
-      status: pending
-    - id: si-2.4
-      title: Automated Patch Management Tools
-      rules: []
-      status: pending
-    - id: si-2.5
-      title: Automatic Software and Firmware Updates
-      rules: []
-      status: pending
-    - id: si-2.6
-      title: Removal of Previous Versions of Software and Firmware
-      rules: []
-      status: pending
-    - id: si-2.7
-      title: Root Cause Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-2.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.2
+            title: Automated Flaw Remediation Status
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-2.3
+            title: Time to Remediate Flaws and Benchmarks for Corrective Actions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.4
+            title: Automated Patch Management Tools
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.5
+            title: Automatic Software and Firmware Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.6
+            title: Removal of Previous Versions of Software and Firmware
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.7
+            title: Root Cause Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-3
       title: Malicious Code Protection
       levels:
@@ -52,46 +65,67 @@ controls:
           - kernel_module_usb-storage_disabled
           - service_autofs_disabled
       status: automated
-    - id: si-3.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-3.2
-      title: Automatic Updates
-      rules: []
-      status: pending
-    - id: si-3.3
-      title: Non-privileged Users
-      rules: []
-      status: pending
-    - id: si-3.4
-      title: Updates Only by Privileged Users
-      rules: []
-      status: pending
-    - id: si-3.5
-      title: Portable Storage Devices
-      rules: []
-      status: pending
-    - id: si-3.6
-      title: Testing and Verification
-      rules: []
-      status: pending
-    - id: si-3.7
-      title: Nonsignature-based Detection
-      rules: []
-      status: pending
-    - id: si-3.8
-      title: Detect Unauthorized Commands
-      rules: []
-      status: pending
-    - id: si-3.9
-      title: Authenticate Remote Commands
-      rules: []
-      status: pending
-    - id: si-3.10
-      title: Malicious Code Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-3.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.2
+            title: Automatic Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.3
+            title: Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.4
+            title: Updates Only by Privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.5
+            title: Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.6
+            title: Testing and Verification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.7
+            title: Nonsignature-based Detection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.8
+            title: Detect Unauthorized Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.9
+            title: Authenticate Remote Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.10
+            title: Malicious Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-4
       title: System Monitoring
       levels:
@@ -103,256 +137,329 @@ controls:
           - kernel_module_tipc_disabled
           - service_avahi-daemon_disabled
       status: automated
-    - id: si-4.1
-      title: System-wide Intrusion Detection System
-      rules: []
-      status: pending
-    - id: si-4.2
-      title: Automated Tools and Mechanisms for Real-time Analysis
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.3
-      title: Automated Tool and Mechanism Integration
-      rules: []
-      status: pending
-    - id: si-4.4
-      title: Inbound and Outbound Communications Traffic
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.5
-      title: System-generated Alerts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.6
-      title: Restrict Non-privileged Users
-      rules: []
-      status: pending
-    - id: si-4.7
-      title: Automated Response to Suspicious Events
-      rules: []
-      status: pending
-    - id: si-4.8
-      title: Protection of Monitoring Information
-      rules: []
-      status: pending
-    - id: si-4.9
-      title: Testing of Monitoring Tools and Mechanisms
-      rules: []
-      status: pending
-    - id: si-4.10
-      title: Visibility of Encrypted Communications
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.11
-      title: Analyze Communications Traffic Anomalies
-      rules: []
-      status: pending
-    - id: si-4.12
-      title: Automated Organization-generated Alerts
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.13
-      title: Analyze Traffic and Event Patterns
-      rules: []
-      status: pending
-    - id: si-4.14
-      title: Wireless Intrusion Detection
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.15
-      title: Wireless to Wireline Communications
-      rules: []
-      status: pending
-    - id: si-4.16
-      title: Correlate Monitoring Information
-      rules: []
-      status: pending
-    - id: si-4.17
-      title: Integrated Situational Awareness
-      rules: []
-      status: pending
-    - id: si-4.18
-      title: Analyze Traffic and Covert Exfiltration
-      rules: []
-      status: pending
-    - id: si-4.19
-      title: Risk for Individuals
-      rules: []
-      status: pending
-    - id: si-4.20
-      title: Privileged Users
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.21
-      title: Probationary Periods
-      rules: []
-      status: pending
-    - id: si-4.22
-      title: Unauthorized Network Services
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.23
-      title: Host-based Devices
-      rules: []
-      status: pending
-    - id: si-4.24
-      title: Indicators of Compromise
-      rules: []
-      status: pending
-    - id: si-4.25
-      title: Optimize Network Traffic Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-4.1
+            title: System-wide Intrusion Detection System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.2
+            title: Automated Tools and Mechanisms for Real-time Analysis
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.3
+            title: Automated Tool and Mechanism Integration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.4
+            title: Inbound and Outbound Communications Traffic
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.5
+            title: System-generated Alerts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.6
+            title: Restrict Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.7
+            title: Automated Response to Suspicious Events
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.8
+            title: Protection of Monitoring Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.9
+            title: Testing of Monitoring Tools and Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.10
+            title: Visibility of Encrypted Communications
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.11
+            title: Analyze Communications Traffic Anomalies
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.12
+            title: Automated Organization-generated Alerts
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.13
+            title: Analyze Traffic and Event Patterns
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.14
+            title: Wireless Intrusion Detection
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.15
+            title: Wireless to Wireline Communications
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.16
+            title: Correlate Monitoring Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.17
+            title: Integrated Situational Awareness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.18
+            title: Analyze Traffic and Covert Exfiltration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.19
+            title: Risk for Individuals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.20
+            title: Privileged Users
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.21
+            title: Probationary Periods
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.22
+            title: Unauthorized Network Services
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.23
+            title: Host-based Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.24
+            title: Indicators of Compromise
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.25
+            title: Optimize Network Traffic Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-5
       title: Security Alerts, Advisories, and Directives
       levels:
           - low
       rules: []
       status: pending
-    - id: si-5.1
-      title: Automated Alerts and Advisories
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: si-5.1
+            title: Automated Alerts and Advisories
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: si-6
       title: Security and Privacy Function Verification
       levels:
           - high
       rules: []
       status: pending
-    - id: si-6.1
-      title: Notification of Failed Security Tests
-      rules: []
-      status: pending
-    - id: si-6.2
-      title: Automation Support for Distributed Testing
-      rules: []
-      status: pending
-    - id: si-6.3
-      title: Report Verification Results
-      rules: []
-      status: pending
+      controls:
+          - id: si-6.1
+            title: Notification of Failed Security Tests
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: si-6.2
+            title: Automation Support for Distributed Testing
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: si-6.3
+            title: Report Verification Results
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: si-7
       title: Software, Firmware, and Information Integrity
       levels:
           - moderate
       rules: []
       status: pending
-    - id: si-7.1
-      title: Integrity Checks
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-7.2
-      title: Automated Notifications of Integrity Violations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.3
-      title: Centrally Managed Integrity Tools
-      rules: []
-      status: pending
-    - id: si-7.4
-      title: Tamper-evident Packaging
-      rules: []
-      status: pending
-    - id: si-7.5
-      title: Automated Response to Integrity Violations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.6
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: si-7.7
-      title: Integration of Detection and Response
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-7.8
-      title: Auditing Capability for Significant Events
-      rules: []
-      status: pending
-    - id: si-7.9
-      title: Verify Boot Process
-      rules: []
-      status: pending
-    - id: si-7.10
-      title: Protection of Boot Firmware
-      rules: []
-      status: pending
-    - id: si-7.11
-      title: Confined Environments with Limited Privileges
-      rules: []
-      status: pending
-    - id: si-7.12
-      title: Integrity Verification
-      rules: []
-      status: pending
-    - id: si-7.13
-      title: Code Execution in Protected Environments
-      rules: []
-      status: pending
-    - id: si-7.14
-      title: Binary or Machine Executable Code
-      rules: []
-      status: pending
-    - id: si-7.15
-      title: Code Authentication
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.16
-      title: Time Limit on Process Execution Without Supervision
-      rules: []
-      status: pending
-    - id: si-7.17
-      title: Runtime Application Self-protection
-      rules: []
-      status: pending
+      controls:
+          - id: si-7.1
+            title: Integrity Checks
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-7.2
+            title: Automated Notifications of Integrity Violations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.3
+            title: Centrally Managed Integrity Tools
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.4
+            title: Tamper-evident Packaging
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.5
+            title: Automated Response to Integrity Violations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.6
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.7
+            title: Integration of Detection and Response
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-7.8
+            title: Auditing Capability for Significant Events
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.9
+            title: Verify Boot Process
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.10
+            title: Protection of Boot Firmware
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.11
+            title: Confined Environments with Limited Privileges
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.12
+            title: Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.13
+            title: Code Execution in Protected Environments
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.14
+            title: Binary or Machine Executable Code
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.15
+            title: Code Authentication
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.16
+            title: Time Limit on Process Execution Without Supervision
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.17
+            title: Runtime Application Self-protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-8
       title: Spam Protection
       levels:
           - moderate
       rules: []
       status: pending
-    - id: si-8.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-8.2
-      title: Automatic Updates
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-8.3
-      title: Continuous Learning Capability
-      rules: []
-      status: pending
+      controls:
+          - id: si-8.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-8.2
+            title: Automatic Updates
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-8.3
+            title: Continuous Learning Capability
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-9
       title: Information Input Restrictions
       rules: []
@@ -363,30 +470,43 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: si-10.1
-      title: Manual Override Capability
-      rules: []
-      status: pending
-    - id: si-10.2
-      title: Review and Resolve Errors
-      rules: []
-      status: pending
-    - id: si-10.3
-      title: Predictable Behavior
-      rules: []
-      status: pending
-    - id: si-10.4
-      title: Timing Interactions
-      rules: []
-      status: pending
-    - id: si-10.5
-      title: Restrict Inputs to Trusted Sources and Approved Formats
-      rules: []
-      status: pending
-    - id: si-10.6
-      title: Injection Prevention
-      rules: []
-      status: pending
+      controls:
+          - id: si-10.1
+            title: Manual Override Capability
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.2
+            title: Review and Resolve Errors
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.3
+            title: Predictable Behavior
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.4
+            title: Timing Interactions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.5
+            title: Restrict Inputs to Trusted Sources and Approved Formats
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.6
+            title: Injection Prevention
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-11
       title: Error Handling
       levels:
@@ -399,58 +519,68 @@ controls:
           - low
       rules: []
       status: pending
-    - id: si-12.1
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
-    - id: si-12.2
-      title: Minimize Personally Identifiable Information in Testing, Training, and Research
-      rules: []
-      status: pending
-    - id: si-12.3
-      title: Information Disposal
-      rules: []
-      status: pending
+      controls:
+          - id: si-12.1
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-12.2
+            title: Minimize Personally Identifiable Information in Testing,
+                Training, and Research
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-12.3
+            title: Information Disposal
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-13
       title: Predictable Failure Prevention
       rules: []
       status: pending
-    - id: si-13.1
-      title: Transferring Component Responsibilities
-      rules: []
-      status: pending
-    - id: si-13.2
-      title: Time Limit on Process Execution Without Supervision
-      rules: []
-      status: pending
-    - id: si-13.3
-      title: Manual Transfer Between Components
-      rules: []
-      status: pending
-    - id: si-13.4
-      title: Standby Component Installation and Notification
-      rules: []
-      status: pending
-    - id: si-13.5
-      title: Failover Capability
-      rules: []
-      status: pending
+      controls:
+          - id: si-13.1
+            title: Transferring Component Responsibilities
+            rules: []
+            status: pending
+          - id: si-13.2
+            title: Time Limit on Process Execution Without Supervision
+            rules: []
+            status: pending
+          - id: si-13.3
+            title: Manual Transfer Between Components
+            rules: []
+            status: pending
+          - id: si-13.4
+            title: Standby Component Installation and Notification
+            rules: []
+            status: pending
+          - id: si-13.5
+            title: Failover Capability
+            rules: []
+            status: pending
     - id: si-14
       title: Non-persistence
       rules: []
       status: pending
-    - id: si-14.1
-      title: Refresh from Trusted Sources
-      rules: []
-      status: pending
-    - id: si-14.2
-      title: Non-persistent Information
-      rules: []
-      status: pending
-    - id: si-14.3
-      title: Non-persistent Connectivity
-      rules: []
-      status: pending
+      controls:
+          - id: si-14.1
+            title: Refresh from Trusted Sources
+            rules: []
+            status: pending
+          - id: si-14.2
+            title: Non-persistent Information
+            rules: []
+            status: pending
+          - id: si-14.3
+            title: Non-persistent Connectivity
+            rules: []
+            status: pending
     - id: si-15
       title: Information Output Filtering
       rules: []
@@ -470,62 +600,65 @@ controls:
       title: Personally Identifiable Information Quality Operations
       rules: []
       status: pending
-    - id: si-18.1
-      title: Automation Support
-      rules: []
-      status: pending
-    - id: si-18.2
-      title: Data Tags
-      rules: []
-      status: pending
-    - id: si-18.3
-      title: Collection
-      rules: []
-      status: pending
-    - id: si-18.4
-      title: Individual Requests
-      rules: []
-      status: pending
-    - id: si-18.5
-      title: Notice of Correction or Deletion
-      rules: []
-      status: pending
+      controls:
+          - id: si-18.1
+            title: Automation Support
+            rules: []
+            status: pending
+          - id: si-18.2
+            title: Data Tags
+            rules: []
+            status: pending
+          - id: si-18.3
+            title: Collection
+            rules: []
+            status: pending
+          - id: si-18.4
+            title: Individual Requests
+            rules: []
+            status: pending
+          - id: si-18.5
+            title: Notice of Correction or Deletion
+            rules: []
+            status: pending
     - id: si-19
       title: De-identification
       rules: []
       status: pending
-    - id: si-19.1
-      title: Collection
-      rules: []
-      status: pending
-    - id: si-19.2
-      title: Archiving
-      rules: []
-      status: pending
-    - id: si-19.3
-      title: Release
-      rules: []
-      status: pending
-    - id: si-19.4
-      title: Removal, Masking, Encryption, Hashing, or Replacement of Direct Identifiers
-      rules: []
-      status: pending
-    - id: si-19.5
-      title: Statistical Disclosure Control
-      rules: []
-      status: pending
-    - id: si-19.6
-      title: Differential Privacy
-      rules: []
-      status: pending
-    - id: si-19.7
-      title: Validated Algorithms and Software
-      rules: []
-      status: pending
-    - id: si-19.8
-      title: Motivated Intruder
-      rules: []
-      status: pending
+      controls:
+          - id: si-19.1
+            title: Collection
+            rules: []
+            status: pending
+          - id: si-19.2
+            title: Archiving
+            rules: []
+            status: pending
+          - id: si-19.3
+            title: Release
+            rules: []
+            status: pending
+          - id: si-19.4
+            title: Removal, Masking, Encryption, Hashing, or Replacement of
+                Direct Identifiers
+            rules: []
+            status: pending
+          - id: si-19.5
+            title: Statistical Disclosure Control
+            rules: []
+            status: pending
+          - id: si-19.6
+            title: Differential Privacy
+            rules: []
+            status: pending
+          - id: si-19.7
+            title: Validated Algorithms and Software
+            rules: []
+            status: pending
+          - id: si-19.8
+            title: Motivated Intruder
+            rules: []
+            status: pending
     - id: si-20
       title: Tainting
       rules: []

--- a/products/rhel10/controls/nist_800_53/sr.yml
+++ b/products/rhel10/controls/nist_800_53/sr.yml
@@ -12,74 +12,92 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sr-2.1
-      title: Establish SCRM Team
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: sr-2.1
+            title: Establish SCRM Team
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: sr-3
       title: Supply Chain Controls and Processes
       levels:
           - low
       rules: []
       status: pending
-    - id: sr-3.1
-      title: Diverse Supply Base
-      rules: []
-      status: pending
-    - id: sr-3.2
-      title: Limitation of Harm
-      rules: []
-      status: pending
-    - id: sr-3.3
-      title: Sub-tier Flow Down
-      rules: []
-      status: pending
+      controls:
+          - id: sr-3.1
+            title: Diverse Supply Base
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-3.2
+            title: Limitation of Harm
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-3.3
+            title: Sub-tier Flow Down
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-4
       title: Provenance
       rules: []
       status: pending
-    - id: sr-4.1
-      title: Identity
-      rules: []
-      status: pending
-    - id: sr-4.2
-      title: Track and Trace
-      rules: []
-      status: pending
-    - id: sr-4.3
-      title: Validate as Genuine and Not Altered
-      rules: []
-      status: pending
-    - id: sr-4.4
-      title: Supply Chain Integrity — Pedigree
-      rules: []
-      status: pending
+      controls:
+          - id: sr-4.1
+            title: Identity
+            rules: []
+            status: pending
+          - id: sr-4.2
+            title: Track and Trace
+            rules: []
+            status: pending
+          - id: sr-4.3
+            title: Validate as Genuine and Not Altered
+            rules: []
+            status: pending
+          - id: sr-4.4
+            title: Supply Chain Integrity — Pedigree
+            rules: []
+            status: pending
     - id: sr-5
       title: Acquisition Strategies, Tools, and Methods
       levels:
           - low
       rules: []
       status: pending
-    - id: sr-5.1
-      title: Adequate Supply
-      rules: []
-      status: pending
-    - id: sr-5.2
-      title: Assessments Prior to Selection, Acceptance, Modification, or Update
-      rules: []
-      status: pending
+      controls:
+          - id: sr-5.1
+            title: Adequate Supply
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-5.2
+            title: Assessments Prior to Selection, Acceptance, Modification, or
+                Update
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-6
       title: Supplier Assessments and Reviews
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sr-6.1
-      title: Testing and Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: sr-6.1
+            title: Testing and Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sr-7
       title: Supply Chain Operations Security
       rules: []
@@ -96,12 +114,13 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sr-9.1
-      title: Multiple Stages of System Development Life Cycle
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: sr-9.1
+            title: Multiple Stages of System Development Life Cycle
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: sr-10
       title: Inspection of Systems or Components
       levels:
@@ -114,22 +133,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sr-11.1
-      title: Anti-counterfeit Training
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sr-11.2
-      title: Configuration Control for Component Service and Repair
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sr-11.3
-      title: Anti-counterfeit Scanning
-      rules: []
-      status: pending
+      controls:
+          - id: sr-11.1
+            title: Anti-counterfeit Training
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sr-11.2
+            title: Configuration Control for Component Service and Repair
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sr-11.3
+            title: Anti-counterfeit Scanning
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-12
       title: Component Disposal
       levels:

--- a/products/rhel8/controls/nist_800_53/ac.yml
+++ b/products/rhel8/controls/nist_800_53/ac.yml
@@ -12,80 +12,91 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ac-2.1
-      title: Automated System Account Management
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.2
-      title: Automated Temporary and Emergency Account Management
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.3
-      title: Disable Accounts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.4
-      title: Automated Audit Actions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.5
-      title: Inactivity Logout
-      levels:
-          - moderate
-      rules:
-          - accounts_tmout
-          - inactivity_timeout_value=15_minutes
-          - no_invalid_shell_accounts_unlocked
-          - no_password_auth_for_systemaccounts
-          - no_shelllogin_for_systemaccounts
-          - var_accounts_tmout=15_min
-      status: automated
-    - id: ac-2.6
-      title: Dynamic Privilege Management
-      rules: []
-      status: pending
-    - id: ac-2.7
-      title: Privileged User Accounts
-      rules: []
-      status: pending
-    - id: ac-2.8
-      title: Dynamic Account Management
-      rules: []
-      status: pending
-    - id: ac-2.9
-      title: Restrictions on Use of Shared and Group Accounts
-      rules: []
-      status: pending
-    - id: ac-2.10
-      title: Shared and Group Account Credential Change
-      rules: []
-      status: pending
-    - id: ac-2.11
-      title: Usage Conditions
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-2.12
-      title: Account Monitoring for Atypical Usage
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-2.13
-      title: Disable Accounts for High-risk Individuals
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-2.1
+            title: Automated System Account Management
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.2
+            title: Automated Temporary and Emergency Account Management
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.3
+            title: Disable Accounts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.4
+            title: Automated Audit Actions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.5
+            title: Inactivity Logout
+            levels:
+                - moderate
+            rules:
+                - accounts_tmout
+                - inactivity_timeout_value=15_minutes
+                - no_invalid_shell_accounts_unlocked
+                - no_password_auth_for_systemaccounts
+                - no_shelllogin_for_systemaccounts
+                - var_accounts_tmout=15_min
+            status: automated
+          - id: ac-2.6
+            title: Dynamic Privilege Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.7
+            title: Privileged User Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.8
+            title: Dynamic Account Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.9
+            title: Restrictions on Use of Shared and Group Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.10
+            title: Shared and Group Account Credential Change
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.11
+            title: Usage Conditions
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-2.12
+            title: Account Monitoring for Atypical Usage
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-2.13
+            title: Disable Accounts for High-risk Individuals
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-3
       title: Access Enforcement
       levels:
@@ -228,202 +239,296 @@ controls:
           - var_pam_wheel_group_for_su=cis
           - var_selinux_policy_name=targeted
       status: automated
-    - id: ac-3.1
-      title: Restricted Access to Privileged Functions
-      rules: []
-      status: pending
-    - id: ac-3.2
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: ac-3.3
-      title: Mandatory Access Control
-      rules: []
-      status: pending
-    - id: ac-3.4
-      title: Discretionary Access Control
-      rules: []
-      status: pending
-    - id: ac-3.5
-      title: Security-relevant Information
-      rules: []
-      status: pending
-    - id: ac-3.6
-      title: Protection of User and System Information
-      rules: []
-      status: pending
-    - id: ac-3.7
-      title: Role-based Access Control
-      rules: []
-      status: pending
-    - id: ac-3.8
-      title: Revocation of Access Authorizations
-      rules: []
-      status: pending
-    - id: ac-3.9
-      title: Controlled Release
-      rules: []
-      status: pending
-    - id: ac-3.10
-      title: Audited Override of Access Control Mechanisms
-      rules: []
-      status: pending
-    - id: ac-3.11
-      title: Restrict Access to Specific Information Types
-      rules: []
-      status: pending
-    - id: ac-3.12
-      title: Assert and Enforce Application Access
-      rules: []
-      status: pending
-    - id: ac-3.13
-      title: Attribute-based Access Control
-      rules: []
-      status: pending
-    - id: ac-3.14
-      title: Individual Access
-      rules: []
-      status: pending
-    - id: ac-3.15
-      title: Discretionary and Mandatory Access Control
-      rules: []
-      status: pending
+      controls:
+          - id: ac-3.1
+            title: Restricted Access to Privileged Functions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.2
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.3
+            title: Mandatory Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.4
+            title: Discretionary Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.5
+            title: Security-relevant Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.6
+            title: Protection of User and System Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.7
+            title: Role-based Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.8
+            title: Revocation of Access Authorizations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.9
+            title: Controlled Release
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.10
+            title: Audited Override of Access Control Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.11
+            title: Restrict Access to Specific Information Types
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.12
+            title: Assert and Enforce Application Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.13
+            title: Attribute-based Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.14
+            title: Individual Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.15
+            title: Discretionary and Mandatory Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-4
       title: Information Flow Enforcement
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-4.1
-      title: Object Security and Privacy Attributes
-      rules: []
-      status: pending
-    - id: ac-4.2
-      title: Processing Domains
-      rules: []
-      status: pending
-    - id: ac-4.3
-      title: Dynamic Information Flow Control
-      rules: []
-      status: pending
-    - id: ac-4.4
-      title: Flow Control of Encrypted Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-4.5
-      title: Embedded Data Types
-      rules: []
-      status: pending
-    - id: ac-4.6
-      title: Metadata
-      rules: []
-      status: pending
-    - id: ac-4.7
-      title: One-way Flow Mechanisms
-      rules: []
-      status: pending
-    - id: ac-4.8
-      title: Security and Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.9
-      title: Human Reviews
-      rules: []
-      status: pending
-    - id: ac-4.10
-      title: Enable and Disable Security or Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.11
-      title: Configuration of Security or Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.12
-      title: Data Type Identifiers
-      rules: []
-      status: pending
-    - id: ac-4.13
-      title: Decomposition into Policy-relevant Subcomponents
-      rules: []
-      status: pending
-    - id: ac-4.14
-      title: Security or Privacy Policy Filter Constraints
-      rules: []
-      status: pending
-    - id: ac-4.15
-      title: Detection of Unsanctioned Information
-      rules: []
-      status: pending
-    - id: ac-4.16
-      title: Information Transfers on Interconnected Systems
-      rules: []
-      status: pending
-    - id: ac-4.17
-      title: Domain Authentication
-      rules: []
-      status: pending
-    - id: ac-4.18
-      title: Security Attribute Binding
-      rules: []
-      status: pending
-    - id: ac-4.19
-      title: Validation of Metadata
-      rules: []
-      status: pending
-    - id: ac-4.20
-      title: Approved Solutions
-      rules: []
-      status: pending
-    - id: ac-4.21
-      title: Physical or Logical Separation of Information Flows
-      rules: []
-      status: pending
-    - id: ac-4.22
-      title: Access Only
-      rules: []
-      status: pending
-    - id: ac-4.23
-      title: Modify Non-releasable Information
-      rules: []
-      status: pending
-    - id: ac-4.24
-      title: Internal Normalized Format
-      rules: []
-      status: pending
-    - id: ac-4.25
-      title: Data Sanitization
-      rules: []
-      status: pending
-    - id: ac-4.26
-      title: Audit Filtering Actions
-      rules: []
-      status: pending
-    - id: ac-4.27
-      title: Redundant/Independent Filtering Mechanisms
-      rules: []
-      status: pending
-    - id: ac-4.28
-      title: Linear Filter Pipelines
-      rules: []
-      status: pending
-    - id: ac-4.29
-      title: Filter Orchestration Engines
-      rules: []
-      status: pending
-    - id: ac-4.30
-      title: Filter Mechanisms Using Multiple Processes
-      rules: []
-      status: pending
-    - id: ac-4.31
-      title: Failed Content Transfer Prevention
-      rules: []
-      status: pending
-    - id: ac-4.32
-      title: Process Requirements for Information Transfer
-      rules: []
-      status: pending
+      controls:
+          - id: ac-4.1
+            title: Object Security and Privacy Attributes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.2
+            title: Processing Domains
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.3
+            title: Dynamic Information Flow Control
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.4
+            title: Flow Control of Encrypted Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-4.5
+            title: Embedded Data Types
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.6
+            title: Metadata
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.7
+            title: One-way Flow Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.8
+            title: Security and Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.9
+            title: Human Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.10
+            title: Enable and Disable Security or Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.11
+            title: Configuration of Security or Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.12
+            title: Data Type Identifiers
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.13
+            title: Decomposition into Policy-relevant Subcomponents
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.14
+            title: Security or Privacy Policy Filter Constraints
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.15
+            title: Detection of Unsanctioned Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.16
+            title: Information Transfers on Interconnected Systems
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.17
+            title: Domain Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.18
+            title: Security Attribute Binding
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.19
+            title: Validation of Metadata
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.20
+            title: Approved Solutions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.21
+            title: Physical or Logical Separation of Information Flows
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.22
+            title: Access Only
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.23
+            title: Modify Non-releasable Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.24
+            title: Internal Normalized Format
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.25
+            title: Data Sanitization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.26
+            title: Audit Filtering Actions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.27
+            title: Redundant/Independent Filtering Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.28
+            title: Linear Filter Pipelines
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.29
+            title: Filter Orchestration Engines
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.30
+            title: Filter Mechanisms Using Multiple Processes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.31
+            title: Failed Content Transfer Prevention
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.32
+            title: Process Requirements for Information Transfer
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-5
       title: Separation of Duties
       levels:
@@ -440,61 +545,69 @@ controls:
           - sudo_remove_no_authenticate
           - sudo_remove_nopasswd
       status: automated
-    - id: ac-6.1
-      title: Authorize Access to Security Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.2
-      title: Non-privileged Access for Nonsecurity Functions
-      levels:
-          - moderate
-      rules:
-          - package_sudo_installed
-      status: automated
-    - id: ac-6.3
-      title: Network Access to Privileged Commands
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-6.4
-      title: Separate Processing Domains
-      rules: []
-      status: pending
-    - id: ac-6.5
-      title: Privileged Accounts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.6
-      title: Privileged Access by Non-organizational Users
-      rules: []
-      status: pending
-    - id: ac-6.7
-      title: Review of User Privileges
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.8
-      title: Privilege Levels for Code Execution
-      rules: []
-      status: pending
-    - id: ac-6.9
-      title: Log Use of Privileged Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.10
-      title: Prohibit Non-privileged Users from Executing Privileged Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-6.1
+            title: Authorize Access to Security Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.2
+            title: Non-privileged Access for Nonsecurity Functions
+            levels:
+                - moderate
+            rules:
+                - package_sudo_installed
+            status: automated
+          - id: ac-6.3
+            title: Network Access to Privileged Commands
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-6.4
+            title: Separate Processing Domains
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.5
+            title: Privileged Accounts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.6
+            title: Privileged Access by Non-organizational Users
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.7
+            title: Review of User Privileges
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.8
+            title: Privilege Levels for Code Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.9
+            title: Log Use of Privileged Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.10
+            title: Prohibit Non-privileged Users from Executing Privileged
+                Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-7
       title: Unsuccessful Logon Attempts
       levels:
@@ -510,22 +623,31 @@ controls:
           - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
       status: automated
-    - id: ac-7.1
-      title: Automatic Account Lock
-      rules: []
-      status: pending
-    - id: ac-7.2
-      title: Purge or Wipe Mobile Device
-      rules: []
-      status: pending
-    - id: ac-7.3
-      title: Biometric Attempt Limiting
-      rules: []
-      status: pending
-    - id: ac-7.4
-      title: Use of Alternate Authentication Factor
-      rules: []
-      status: pending
+      controls:
+          - id: ac-7.1
+            title: Automatic Account Lock
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.2
+            title: Purge or Wipe Mobile Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.3
+            title: Biometric Attempt Limiting
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.4
+            title: Use of Alternate Authentication Factor
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-8
       title: System Use Notification
       levels:
@@ -538,22 +660,23 @@ controls:
       title: Previous Logon Notification
       rules: []
       status: pending
-    - id: ac-9.1
-      title: Unsuccessful Logons
-      rules: []
-      status: pending
-    - id: ac-9.2
-      title: Successful and Unsuccessful Logons
-      rules: []
-      status: pending
-    - id: ac-9.3
-      title: Notification of Account Changes
-      rules: []
-      status: pending
-    - id: ac-9.4
-      title: Additional Logon Information
-      rules: []
-      status: pending
+      controls:
+          - id: ac-9.1
+            title: Unsuccessful Logons
+            rules: []
+            status: pending
+          - id: ac-9.2
+            title: Successful and Unsuccessful Logons
+            rules: []
+            status: pending
+          - id: ac-9.3
+            title: Notification of Account Changes
+            rules: []
+            status: pending
+          - id: ac-9.4
+            title: Additional Logon Information
+            rules: []
+            status: pending
     - id: ac-10
       title: Concurrent Session Control
       levels:
@@ -571,30 +694,38 @@ controls:
           - dconf_gnome_session_idle_user_locks
           - var_screensaver_lock_delay=5_seconds
       status: automated
-    - id: ac-11.1
-      title: Pattern-hiding Displays
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-11.1
+            title: Pattern-hiding Displays
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-12
       title: Session Termination
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-12.1
-      title: User-initiated Logouts
-      rules: []
-      status: pending
-    - id: ac-12.2
-      title: Termination Message
-      rules: []
-      status: pending
-    - id: ac-12.3
-      title: Timeout Warning Message
-      rules: []
-      status: pending
+      controls:
+          - id: ac-12.1
+            title: User-initiated Logouts
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-12.2
+            title: Termination Message
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-12.3
+            title: Timeout Warning Message
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-13
       title: Supervision and Review — Access Control
       rules: []
@@ -605,10 +736,13 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ac-14.1
-      title: Necessary Uses
-      rules: []
-      status: pending
+      controls:
+          - id: ac-14.1
+            title: Necessary Uses
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-15
       title: Automated Marking
       rules: []
@@ -617,46 +751,47 @@ controls:
       title: Security and Privacy Attributes
       rules: []
       status: pending
-    - id: ac-16.1
-      title: Dynamic Attribute Association
-      rules: []
-      status: pending
-    - id: ac-16.2
-      title: Attribute Value Changes by Authorized Individuals
-      rules: []
-      status: pending
-    - id: ac-16.3
-      title: Maintenance of Attribute Associations by System
-      rules: []
-      status: pending
-    - id: ac-16.4
-      title: Association of Attributes by Authorized Individuals
-      rules: []
-      status: pending
-    - id: ac-16.5
-      title: Attribute Displays on Objects to Be Output
-      rules: []
-      status: pending
-    - id: ac-16.6
-      title: Maintenance of Attribute Association
-      rules: []
-      status: pending
-    - id: ac-16.7
-      title: Consistent Attribute Interpretation
-      rules: []
-      status: pending
-    - id: ac-16.8
-      title: Association Techniques and Technologies
-      rules: []
-      status: pending
-    - id: ac-16.9
-      title: Attribute Reassignment — Regrading Mechanisms
-      rules: []
-      status: pending
-    - id: ac-16.10
-      title: Attribute Configuration by Authorized Individuals
-      rules: []
-      status: pending
+      controls:
+          - id: ac-16.1
+            title: Dynamic Attribute Association
+            rules: []
+            status: pending
+          - id: ac-16.2
+            title: Attribute Value Changes by Authorized Individuals
+            rules: []
+            status: pending
+          - id: ac-16.3
+            title: Maintenance of Attribute Associations by System
+            rules: []
+            status: pending
+          - id: ac-16.4
+            title: Association of Attributes by Authorized Individuals
+            rules: []
+            status: pending
+          - id: ac-16.5
+            title: Attribute Displays on Objects to Be Output
+            rules: []
+            status: pending
+          - id: ac-16.6
+            title: Maintenance of Attribute Association
+            rules: []
+            status: pending
+          - id: ac-16.7
+            title: Consistent Attribute Interpretation
+            rules: []
+            status: pending
+          - id: ac-16.8
+            title: Association Techniques and Technologies
+            rules: []
+            status: pending
+          - id: ac-16.9
+            title: Attribute Reassignment — Regrading Mechanisms
+            rules: []
+            status: pending
+          - id: ac-16.10
+            title: Attribute Configuration by Authorized Individuals
+            rules: []
+            status: pending
     - id: ac-17
       title: Remote Access
       levels:
@@ -665,54 +800,67 @@ controls:
           - configure_custom_crypto_policy_cis
           - configure_ssh_crypto_policy
       status: automated
-    - id: ac-17.1
-      title: Monitoring and Control
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.2
-      title: Protection of Confidentiality and Integrity Using Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.3
-      title: Managed Access Control Points
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.4
-      title: Privileged Commands and Access
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.5
-      title: Monitoring for Unauthorized Connections
-      rules: []
-      status: pending
-    - id: ac-17.6
-      title: Protection of Mechanism Information
-      rules: []
-      status: pending
-    - id: ac-17.7
-      title: Additional Protection for Security Function Access
-      rules: []
-      status: pending
-    - id: ac-17.8
-      title: Disable Nonsecure Network Protocols
-      rules: []
-      status: pending
-    - id: ac-17.9
-      title: Disconnect or Disable Access
-      rules: []
-      status: pending
-    - id: ac-17.10
-      title: Authenticate Remote Commands
-      rules: []
-      status: pending
+      controls:
+          - id: ac-17.1
+            title: Monitoring and Control
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.2
+            title: Protection of Confidentiality and Integrity Using Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.3
+            title: Managed Access Control Points
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.4
+            title: Privileged Commands and Access
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.5
+            title: Monitoring for Unauthorized Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.6
+            title: Protection of Mechanism Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.7
+            title: Additional Protection for Security Function Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.8
+            title: Disable Nonsecure Network Protocols
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.9
+            title: Disconnect or Disable Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.10
+            title: Authenticate Remote Commands
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-18
       title: Wireless Access
       levels:
@@ -720,106 +868,130 @@ controls:
       rules:
           - wireless_disable_interfaces
       status: automated
-    - id: ac-18.1
-      title: Authentication and Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-18.2
-      title: Monitoring Unauthorized Connections
-      rules: []
-      status: pending
-    - id: ac-18.3
-      title: Disable Wireless Networking
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-18.4
-      title: Restrict Configurations by Users
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-18.5
-      title: Antennas and Transmission Power Levels
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ac-18.1
+            title: Authentication and Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-18.2
+            title: Monitoring Unauthorized Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-18.3
+            title: Disable Wireless Networking
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-18.4
+            title: Restrict Configurations by Users
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-18.5
+            title: Antennas and Transmission Power Levels
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ac-19
       title: Access Control for Mobile Devices
       levels:
           - low
       rules: []
       status: pending
-    - id: ac-19.1
-      title: Use of Writable and Portable Storage Devices
-      rules: []
-      status: pending
-    - id: ac-19.2
-      title: Use of Personally Owned Portable Storage Devices
-      rules: []
-      status: pending
-    - id: ac-19.3
-      title: Use of Portable Storage Devices with No Identifiable Owner
-      rules: []
-      status: pending
-    - id: ac-19.4
-      title: Restrictions for Classified Information
-      rules: []
-      status: pending
-    - id: ac-19.5
-      title: Full Device or Container-based Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-19.1
+            title: Use of Writable and Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.2
+            title: Use of Personally Owned Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.3
+            title: Use of Portable Storage Devices with No Identifiable Owner
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.4
+            title: Restrictions for Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.5
+            title: Full Device or Container-based Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-20
       title: Use of External Systems
       levels:
           - low
       rules: []
       status: pending
-    - id: ac-20.1
-      title: Limits on Authorized Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-20.2
-      title: Portable Storage Devices — Restricted Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-20.3
-      title: Non-organizationally Owned Systems — Restricted Use
-      rules: []
-      status: pending
-    - id: ac-20.4
-      title: Network Accessible Storage Devices — Prohibited Use
-      rules: []
-      status: pending
-    - id: ac-20.5
-      title: Portable Storage Devices — Prohibited Use
-      rules: []
-      status: pending
+      controls:
+          - id: ac-20.1
+            title: Limits on Authorized Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-20.2
+            title: Portable Storage Devices — Restricted Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-20.3
+            title: Non-organizationally Owned Systems — Restricted Use
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-20.4
+            title: Network Accessible Storage Devices — Prohibited Use
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-20.5
+            title: Portable Storage Devices — Prohibited Use
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-21
       title: Information Sharing
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-21.1
-      title: Automated Decision Support
-      rules: []
-      status: pending
-    - id: ac-21.2
-      title: Information Search and Retrieval
-      rules: []
-      status: pending
+      controls:
+          - id: ac-21.1
+            title: Automated Decision Support
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-21.2
+            title: Information Search and Retrieval
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-22
       title: Publicly Accessible Content
       levels:
@@ -834,14 +1006,15 @@ controls:
       title: Access Control Decisions
       rules: []
       status: pending
-    - id: ac-24.1
-      title: Transmit Access Authorization Information
-      rules: []
-      status: pending
-    - id: ac-24.2
-      title: No User or Process Identity
-      rules: []
-      status: pending
+      controls:
+          - id: ac-24.1
+            title: Transmit Access Authorization Information
+            rules: []
+            status: pending
+          - id: ac-24.2
+            title: No User or Process Identity
+            rules: []
+            status: pending
     - id: ac-25
       title: Reference Monitor
       rules: []

--- a/products/rhel8/controls/nist_800_53/at.yml
+++ b/products/rhel8/controls/nist_800_53/at.yml
@@ -12,60 +12,80 @@ controls:
           - low
       rules: []
       status: pending
-    - id: at-2.1
-      title: Practical Exercises
-      rules: []
-      status: pending
-    - id: at-2.2
-      title: Insider Threat
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: at-2.3
-      title: Social Engineering and Mining
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: at-2.4
-      title: Suspicious Communications and Anomalous System Behavior
-      rules: []
-      status: pending
-    - id: at-2.5
-      title: Advanced Persistent Threat
-      rules: []
-      status: pending
-    - id: at-2.6
-      title: Cyber Threat Environment
-      rules: []
-      status: pending
+      controls:
+          - id: at-2.1
+            title: Practical Exercises
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.2
+            title: Insider Threat
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: at-2.3
+            title: Social Engineering and Mining
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: at-2.4
+            title: Suspicious Communications and Anomalous System Behavior
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.5
+            title: Advanced Persistent Threat
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.6
+            title: Cyber Threat Environment
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: at-3
       title: Role-based Training
       levels:
           - low
       rules: []
       status: pending
-    - id: at-3.1
-      title: Environmental Controls
-      rules: []
-      status: pending
-    - id: at-3.2
-      title: Physical Security Controls
-      rules: []
-      status: pending
-    - id: at-3.3
-      title: Practical Exercises
-      rules: []
-      status: pending
-    - id: at-3.4
-      title: Suspicious Communications and Anomalous System Behavior
-      rules: []
-      status: pending
-    - id: at-3.5
-      title: Processing Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: at-3.1
+            title: Environmental Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.2
+            title: Physical Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.3
+            title: Practical Exercises
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.4
+            title: Suspicious Communications and Anomalous System Behavior
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.5
+            title: Processing Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: at-4
       title: Training Records
       levels:

--- a/products/rhel8/controls/nist_800_53/au.yml
+++ b/products/rhel8/controls/nist_800_53/au.yml
@@ -37,22 +37,31 @@ controls:
           - var_auditd_admin_space_left_action=cis_rhel8
           - var_auditd_space_left_action=cis_rhel8
       status: automated
-    - id: au-2.1
-      title: Compilation of Audit Records from Multiple Sources
-      rules: []
-      status: pending
-    - id: au-2.2
-      title: Selection of Audit Events by Component
-      rules: []
-      status: pending
-    - id: au-2.3
-      title: Reviews and Updates
-      rules: []
-      status: pending
-    - id: au-2.4
-      title: Privileged Functions
-      rules: []
-      status: pending
+      controls:
+          - id: au-2.1
+            title: Compilation of Audit Records from Multiple Sources
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.2
+            title: Selection of Audit Events by Component
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.3
+            title: Reviews and Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.4
+            title: Privileged Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-3
       title: Content of Audit Records
       levels:
@@ -121,20 +130,25 @@ controls:
           - sshd_max_auth_tries_value=4
           - var_multiple_time_servers=rhel
       status: automated
-    - id: au-3.1
-      title: Additional Audit Information
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-3.2
-      title: Centralized Management of Planned Audit Record Content
-      rules: []
-      status: pending
-    - id: au-3.3
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
+      controls:
+          - id: au-3.1
+            title: Additional Audit Information
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-3.2
+            title: Centralized Management of Planned Audit Record Content
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-3.3
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-4
       title: Audit Log Storage Capacity
       levels:
@@ -142,10 +156,13 @@ controls:
       rules:
           - journald_compress
       status: automated
-    - id: au-4.1
-      title: Transfer to Alternate Storage
-      rules: []
-      status: pending
+      controls:
+          - id: au-4.1
+            title: Transfer to Alternate Storage
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-5
       title: Response to Audit Logging Process Failures
       levels:
@@ -156,100 +173,123 @@ controls:
           - var_auditd_disk_error_action=cis_rhel8
           - var_auditd_disk_full_action=cis_rhel8
       status: automated
-    - id: au-5.1
-      title: Storage Capacity Warning
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-5.2
-      title: Real-time Alerts
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-5.3
-      title: Configurable Traffic Volume Thresholds
-      rules: []
-      status: pending
-    - id: au-5.4
-      title: Shutdown on Failure
-      rules: []
-      status: pending
-    - id: au-5.5
-      title: Alternate Audit Logging Capability
-      rules: []
-      status: pending
+      controls:
+          - id: au-5.1
+            title: Storage Capacity Warning
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-5.2
+            title: Real-time Alerts
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-5.3
+            title: Configurable Traffic Volume Thresholds
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-5.4
+            title: Shutdown on Failure
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-5.5
+            title: Alternate Audit Logging Capability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-6
       title: Audit Record Review, Analysis, and Reporting
       levels:
           - low
       rules: []
       status: pending
-    - id: au-6.1
-      title: Automated Process Integration
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-6.2
-      title: Automated Security Alerts
-      rules: []
-      status: pending
-    - id: au-6.3
-      title: Correlate Audit Record Repositories
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-6.4
-      title: Central Review and Analysis
-      rules: []
-      status: pending
-    - id: au-6.5
-      title: Integrated Analysis of Audit Records
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-6.6
-      title: Correlation with Physical Monitoring
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-6.7
-      title: Permitted Actions
-      rules: []
-      status: pending
-    - id: au-6.8
-      title: Full Text Analysis of Privileged Commands
-      rules: []
-      status: pending
-    - id: au-6.9
-      title: Correlation with Information from Nontechnical Sources
-      rules: []
-      status: pending
-    - id: au-6.10
-      title: Audit Level Adjustment
-      rules: []
-      status: pending
+      controls:
+          - id: au-6.1
+            title: Automated Process Integration
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-6.2
+            title: Automated Security Alerts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.3
+            title: Correlate Audit Record Repositories
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-6.4
+            title: Central Review and Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.5
+            title: Integrated Analysis of Audit Records
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-6.6
+            title: Correlation with Physical Monitoring
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-6.7
+            title: Permitted Actions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.8
+            title: Full Text Analysis of Privileged Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.9
+            title: Correlation with Information from Nontechnical Sources
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.10
+            title: Audit Level Adjustment
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-7
       title: Audit Record Reduction and Report Generation
       levels:
           - moderate
       rules: []
       status: pending
-    - id: au-7.1
-      title: Automatic Processing
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-7.2
-      title: Automatic Sort and Search
-      rules: []
-      status: pending
+      controls:
+          - id: au-7.1
+            title: Automatic Processing
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-7.2
+            title: Automatic Sort and Search
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: au-8
       title: Time Stamps
       levels:
@@ -260,14 +300,19 @@ controls:
           - var_auditd_max_log_file=8
           - var_auditd_max_log_file_action=keep_logs
       status: automated
-    - id: au-8.1
-      title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
-    - id: au-8.2
-      title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      controls:
+          - id: au-8.1
+            title: Synchronization with Authoritative Time Source
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-8.2
+            title: Secondary Authoritative Time Source
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-9
       title: Protection of Audit Information
       levels:
@@ -278,79 +323,102 @@ controls:
           - file_ownership_audit_binaries
           - file_ownership_audit_configuration
       status: automated
-    - id: au-9.1
-      title: Hardware Write-once Media
-      rules: []
-      status: pending
-    - id: au-9.2
-      title: Store on Separate Physical Systems or Components
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-9.3
-      title: Cryptographic Protection
-      levels:
-          - high
-      rules:
-          - aide_check_audit_tools
-      status: automated
-    - id: au-9.4
-      title: Access by Subset of Privileged Users
-      levels:
-          - moderate
-      rules:
-          - file_group_ownership_var_log_audit
-          - file_permissions_var_log_audit
-      status: automated
-    - id: au-9.5
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: au-9.6
-      title: Read-only Access
-      rules: []
-      status: pending
-    - id: au-9.7
-      title: Store on Component with Different Operating System
-      rules: []
-      status: pending
+      controls:
+          - id: au-9.1
+            title: Hardware Write-once Media
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.2
+            title: Store on Separate Physical Systems or Components
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-9.3
+            title: Cryptographic Protection
+            levels:
+                - high
+            rules:
+                - aide_check_audit_tools
+            status: automated
+          - id: au-9.4
+            title: Access by Subset of Privileged Users
+            levels:
+                - moderate
+            rules:
+                - file_group_ownership_var_log_audit
+                - file_permissions_var_log_audit
+            status: automated
+          - id: au-9.5
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.6
+            title: Read-only Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.7
+            title: Store on Component with Different Operating System
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-10
       title: Non-repudiation
       levels:
           - high
       rules: []
       status: pending
-    - id: au-10.1
-      title: Association of Identities
-      rules: []
-      status: pending
-    - id: au-10.2
-      title: Validate Binding of Information Producer Identity
-      rules: []
-      status: pending
-    - id: au-10.3
-      title: Chain of Custody
-      rules: []
-      status: pending
-    - id: au-10.4
-      title: Validate Binding of Information Reviewer Identity
-      rules: []
-      status: pending
-    - id: au-10.5
-      title: Digital Signatures
-      rules: []
-      status: pending
+      controls:
+          - id: au-10.1
+            title: Association of Identities
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.2
+            title: Validate Binding of Information Producer Identity
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.3
+            title: Chain of Custody
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.4
+            title: Validate Binding of Information Reviewer Identity
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.5
+            title: Digital Signatures
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: au-11
       title: Audit Record Retention
       levels:
           - low
       rules: []
       status: pending
-    - id: au-11.1
-      title: Long-term Retrieval Capability
-      rules: []
-      status: pending
+      controls:
+          - id: au-11.1
+            title: Long-term Retrieval Capability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-12
       title: Audit Record Generation
       levels:
@@ -404,58 +472,65 @@ controls:
           - grub2_audit_argument
           - service_auditd_enabled
       status: automated
-    - id: au-12.1
-      title: System-wide and Time-correlated Audit Trail
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-12.2
-      title: Standardized Formats
-      rules: []
-      status: pending
-    - id: au-12.3
-      title: Changes by Authorized Individuals
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-12.4
-      title: Query Parameter Audits of Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: au-12.1
+            title: System-wide and Time-correlated Audit Trail
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-12.2
+            title: Standardized Formats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-12.3
+            title: Changes by Authorized Individuals
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-12.4
+            title: Query Parameter Audits of Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-13
       title: Monitoring for Information Disclosure
       rules: []
       status: pending
-    - id: au-13.1
-      title: Use of Automated Tools
-      rules: []
-      status: pending
-    - id: au-13.2
-      title: Review of Monitored Sites
-      rules: []
-      status: pending
-    - id: au-13.3
-      title: Unauthorized Replication of Information
-      rules: []
-      status: pending
+      controls:
+          - id: au-13.1
+            title: Use of Automated Tools
+            rules: []
+            status: pending
+          - id: au-13.2
+            title: Review of Monitored Sites
+            rules: []
+            status: pending
+          - id: au-13.3
+            title: Unauthorized Replication of Information
+            rules: []
+            status: pending
     - id: au-14
       title: Session Audit
       rules: []
       status: pending
-    - id: au-14.1
-      title: System Start-up
-      rules: []
-      status: pending
-    - id: au-14.2
-      title: Capture and Record Content
-      rules: []
-      status: pending
-    - id: au-14.3
-      title: Remote Viewing and Listening
-      rules: []
-      status: pending
+      controls:
+          - id: au-14.1
+            title: System Start-up
+            rules: []
+            status: pending
+          - id: au-14.2
+            title: Capture and Record Content
+            rules: []
+            status: pending
+          - id: au-14.3
+            title: Remote Viewing and Listening
+            rules: []
+            status: pending
     - id: au-15
       title: Alternate Audit Logging Capability
       rules: []
@@ -464,15 +539,16 @@ controls:
       title: Cross-organizational Audit Logging
       rules: []
       status: pending
-    - id: au-16.1
-      title: Identity Preservation
-      rules: []
-      status: pending
-    - id: au-16.2
-      title: Sharing of Audit Information
-      rules: []
-      status: pending
-    - id: au-16.3
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: au-16.1
+            title: Identity Preservation
+            rules: []
+            status: pending
+          - id: au-16.2
+            title: Sharing of Audit Information
+            rules: []
+            status: pending
+          - id: au-16.3
+            title: Disassociability
+            rules: []
+            status: pending

--- a/products/rhel8/controls/nist_800_53/ca.yml
+++ b/products/rhel8/controls/nist_800_53/ca.yml
@@ -12,58 +12,74 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ca-2.1
-      title: Independent Assessors
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ca-2.2
-      title: Specialized Assessments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-2.3
-      title: Leveraging Results from External Organizations
-      rules: []
-      status: pending
+      controls:
+          - id: ca-2.1
+            title: Independent Assessors
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ca-2.2
+            title: Specialized Assessments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-2.3
+            title: Leveraging Results from External Organizations
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-3
       title: Information Exchange
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-3.1
-      title: Unclassified National Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.2
-      title: Classified National Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.3
-      title: Unclassified Non-national Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.4
-      title: Connections to Public Networks
-      rules: []
-      status: pending
-    - id: ca-3.5
-      title: Restrictions on External System Connections
-      rules: []
-      status: pending
-    - id: ca-3.6
-      title: Transfer Authorizations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-3.7
-      title: Transitive Information Exchanges
-      rules: []
-      status: pending
+      controls:
+          - id: ca-3.1
+            title: Unclassified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.2
+            title: Classified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.3
+            title: Unclassified Non-national Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.4
+            title: Connections to Public Networks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.5
+            title: Restrictions on External System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.6
+            title: Transfer Authorizations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-3.7
+            title: Transitive Information Exchanges
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-4
       title: Security Certification
       rules: []
@@ -74,78 +90,100 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ca-5.1
-      title: Automation Support for Accuracy and Currency
-      rules: []
-      status: pending
+      controls:
+          - id: ca-5.1
+            title: Automation Support for Accuracy and Currency
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-6
       title: Authorization
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-6.1
-      title: Joint Authorization — Intra-organization
-      rules: []
-      status: pending
-    - id: ca-6.2
-      title: Joint Authorization — Inter-organization
-      rules: []
-      status: pending
+      controls:
+          - id: ca-6.1
+            title: Joint Authorization — Intra-organization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-6.2
+            title: Joint Authorization — Inter-organization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-7
       title: Continuous Monitoring
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-7.1
-      title: Independent Assessment
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ca-7.2
-      title: Types of Assessments
-      rules: []
-      status: pending
-    - id: ca-7.3
-      title: Trend Analyses
-      rules: []
-      status: pending
-    - id: ca-7.4
-      title: Risk Monitoring
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ca-7.5
-      title: Consistency Analysis
-      rules: []
-      status: pending
-    - id: ca-7.6
-      title: Automation Support for Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: ca-7.1
+            title: Independent Assessment
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ca-7.2
+            title: Types of Assessments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.3
+            title: Trend Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.4
+            title: Risk Monitoring
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ca-7.5
+            title: Consistency Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.6
+            title: Automation Support for Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-8
       title: Penetration Testing
       levels:
           - high
       rules: []
       status: pending
-    - id: ca-8.1
-      title: Independent Penetration Testing Agent or Team
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-8.2
-      title: Red Team Exercises
-      rules: []
-      status: pending
-    - id: ca-8.3
-      title: Facility Penetration Testing
-      rules: []
-      status: pending
+      controls:
+          - id: ca-8.1
+            title: Independent Penetration Testing Agent or Team
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-8.2
+            title: Red Team Exercises
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: ca-8.3
+            title: Facility Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: ca-9
       title: Internal System Connections
       levels:
@@ -154,7 +192,10 @@ controls:
           - firewalld-backend
           - package_firewalld_installed
       status: automated
-    - id: ca-9.1
-      title: Compliance Checks
-      rules: []
-      status: pending
+      controls:
+          - id: ca-9.1
+            title: Compliance Checks
+            rules: []
+            status: pending
+            levels:
+                - low

--- a/products/rhel8/controls/nist_800_53/cm.yml
+++ b/products/rhel8/controls/nist_800_53/cm.yml
@@ -75,140 +75,173 @@ controls:
           - low
       rules: []
       status: pending
-    - id: cm-2.1
-      title: Reviews and Updates
-      rules: []
-      status: pending
-    - id: cm-2.2
-      title: Automation Support for Accuracy and Currency
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-2.3
-      title: Retention of Previous Configurations
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-2.4
-      title: Unauthorized Software
-      rules: []
-      status: pending
-    - id: cm-2.5
-      title: Authorized Software
-      rules: []
-      status: pending
-    - id: cm-2.6
-      title: Development and Test Environments
-      rules: []
-      status: pending
-    - id: cm-2.7
-      title: Configure Systems and Components for High-risk Areas
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-2.1
+            title: Reviews and Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.2
+            title: Automation Support for Accuracy and Currency
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-2.3
+            title: Retention of Previous Configurations
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-2.4
+            title: Unauthorized Software
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.5
+            title: Authorized Software
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.6
+            title: Development and Test Environments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.7
+            title: Configure Systems and Components for High-risk Areas
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-3
       title: Configuration Change Control
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-3.1
-      title: Automated Documentation, Notification, and Prohibition of Changes
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-3.2
-      title: Testing, Validation, and Documentation of Changes
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-3.3
-      title: Automated Change Implementation
-      rules: []
-      status: pending
-    - id: cm-3.4
-      title: Security and Privacy Representatives
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-3.5
-      title: Automated Security Response
-      rules: []
-      status: pending
-    - id: cm-3.6
-      title: Cryptography Management
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-3.7
-      title: Review System Changes
-      rules: []
-      status: pending
-    - id: cm-3.8
-      title: Prevent or Restrict Configuration Changes
-      rules: []
-      status: pending
+      controls:
+          - id: cm-3.1
+            title: Automated Documentation, Notification, and Prohibition of
+                Changes
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-3.2
+            title: Testing, Validation, and Documentation of Changes
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-3.3
+            title: Automated Change Implementation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.4
+            title: Security and Privacy Representatives
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-3.5
+            title: Automated Security Response
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.6
+            title: Cryptography Management
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-3.7
+            title: Review System Changes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.8
+            title: Prevent or Restrict Configuration Changes
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cm-4
       title: Impact Analyses
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-4.1
-      title: Separate Test Environments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-4.2
-      title: Verification of Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-4.1
+            title: Separate Test Environments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-4.2
+            title: Verification of Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-5
       title: Access Restrictions for Change
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-5.1
-      title: Automated Access Enforcement and Audit Records
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-5.2
-      title: Review System Changes
-      rules: []
-      status: pending
-    - id: cm-5.3
-      title: Signed Components
-      rules: []
-      status: pending
-    - id: cm-5.4
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: cm-5.5
-      title: Privilege Limitation for Production and Operation
-      rules: []
-      status: pending
-    - id: cm-5.6
-      title: Limit Library Privileges
-      rules: []
-      status: pending
-    - id: cm-5.7
-      title: Automatic Implementation of Security Safeguards
-      rules: []
-      status: pending
+      controls:
+          - id: cm-5.1
+            title: Automated Access Enforcement and Audit Records
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-5.2
+            title: Review System Changes
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.3
+            title: Signed Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.4
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.5
+            title: Privilege Limitation for Production and Operation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.6
+            title: Limit Library Privileges
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.7
+            title: Automatic Implementation of Security Safeguards
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-6
       title: Configuration Settings
       levels:
@@ -327,26 +360,31 @@ controls:
           - var_authselect_profile=sssd
           - var_sshd_set_login_grace_time=60
       status: automated
-    - id: cm-6.1
-      title: Automated Management, Application, and Verification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-6.2
-      title: Respond to Unauthorized Changes
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-6.3
-      title: Unauthorized Change Detection
-      rules: []
-      status: pending
-    - id: cm-6.4
-      title: Conformance Demonstration
-      rules: []
-      status: pending
+      controls:
+          - id: cm-6.1
+            title: Automated Management, Application, and Verification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-6.2
+            title: Respond to Unauthorized Changes
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-6.3
+            title: Unauthorized Change Detection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-6.4
+            title: Conformance Demonstration
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-7
       title: Least Functionality
       levels:
@@ -413,118 +451,148 @@ controls:
           - xwayland_disabled
           - var_postfix_inet_interfaces=loopback-only
       status: automated
-    - id: cm-7.1
-      title: Periodic Review
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.2
-      title: Prevent Program Execution
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.3
-      title: Registration Compliance
-      rules: []
-      status: pending
-    - id: cm-7.4
-      title: Unauthorized Software — Deny-by-exception
-      rules: []
-      status: pending
-    - id: cm-7.5
-      title: Authorized Software — Allow-by-exception
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.6
-      title: Confined Environments with Limited Privileges
-      rules: []
-      status: pending
-    - id: cm-7.7
-      title: Code Execution in Protected Environments
-      rules: []
-      status: pending
-    - id: cm-7.8
-      title: Binary or Machine Executable Code
-      rules: []
-      status: pending
-    - id: cm-7.9
-      title: Prohibiting The Use of Unauthorized Hardware
-      rules: []
-      status: pending
+      controls:
+          - id: cm-7.1
+            title: Periodic Review
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.2
+            title: Prevent Program Execution
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.3
+            title: Registration Compliance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.4
+            title: Unauthorized Software — Deny-by-exception
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.5
+            title: Authorized Software — Allow-by-exception
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.6
+            title: Confined Environments with Limited Privileges
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.7
+            title: Code Execution in Protected Environments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.8
+            title: Binary or Machine Executable Code
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.9
+            title: Prohibiting The Use of Unauthorized Hardware
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-8
       title: System Component Inventory
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-8.1
-      title: Updates During Installation and Removal
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-8.2
-      title: Automated Maintenance
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-8.3
-      title: Automated Unauthorized Component Detection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-8.4
-      title: Accountability Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-8.5
-      title: No Duplicate Accounting of Components
-      rules: []
-      status: pending
-    - id: cm-8.6
-      title: Assessed Configurations and Approved Deviations
-      rules: []
-      status: pending
-    - id: cm-8.7
-      title: Centralized Repository
-      rules: []
-      status: pending
-    - id: cm-8.8
-      title: Automated Location Tracking
-      rules: []
-      status: pending
-    - id: cm-8.9
-      title: Assignment of Components to Systems
-      rules: []
-      status: pending
+      controls:
+          - id: cm-8.1
+            title: Updates During Installation and Removal
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-8.2
+            title: Automated Maintenance
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-8.3
+            title: Automated Unauthorized Component Detection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-8.4
+            title: Accountability Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-8.5
+            title: No Duplicate Accounting of Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.6
+            title: Assessed Configurations and Approved Deviations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.7
+            title: Centralized Repository
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.8
+            title: Automated Location Tracking
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.9
+            title: Assignment of Components to Systems
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-9
       title: Configuration Management Plan
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-9.1
-      title: Assignment of Responsibility
-      rules: []
-      status: pending
+      controls:
+          - id: cm-9.1
+            title: Assignment of Responsibility
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cm-10
       title: Software Usage Restrictions
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-10.1
-      title: Open-source Software
-      rules: []
-      status: pending
+      controls:
+          - id: cm-10.1
+            title: Open-source Software
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-11
       title: User-installed Software
       levels:
@@ -532,30 +600,38 @@ controls:
       rules:
           - package_xorg-x11-server-Xwayland_removed
       status: automated
-    - id: cm-11.1
-      title: Alerts for Unauthorized Installations
-      rules: []
-      status: pending
-    - id: cm-11.2
-      title: Software Installation with Privileged Status
-      rules: []
-      status: pending
-    - id: cm-11.3
-      title: Automated Enforcement and Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: cm-11.1
+            title: Alerts for Unauthorized Installations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-11.2
+            title: Software Installation with Privileged Status
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-11.3
+            title: Automated Enforcement and Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-12
       title: Information Location
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-12.1
-      title: Automated Tools to Support Information Location
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-12.1
+            title: Automated Tools to Support Information Location
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-13
       title: Data Action Mapping
       rules: []

--- a/products/rhel8/controls/nist_800_53/cp.yml
+++ b/products/rhel8/controls/nist_800_53/cp.yml
@@ -12,94 +12,111 @@ controls:
           - low
       rules: []
       status: pending
-    - id: cp-2.1
-      title: Coordinate with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-2.2
-      title: Capacity Planning
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-2.3
-      title: Resume Mission and Business Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-2.4
-      title: Resume All Mission and Business Functions
-      rules: []
-      status: pending
-    - id: cp-2.5
-      title: Continue Mission and Business Functions
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-2.6
-      title: Alternate Processing and Storage Sites
-      rules: []
-      status: pending
-    - id: cp-2.7
-      title: Coordinate with External Service Providers
-      rules: []
-      status: pending
-    - id: cp-2.8
-      title: Identify Critical Assets
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-2.1
+            title: Coordinate with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-2.2
+            title: Capacity Planning
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-2.3
+            title: Resume Mission and Business Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-2.4
+            title: Resume All Mission and Business Functions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.5
+            title: Continue Mission and Business Functions
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-2.6
+            title: Alternate Processing and Storage Sites
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.7
+            title: Coordinate with External Service Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.8
+            title: Identify Critical Assets
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-3
       title: Contingency Training
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-3.1
-      title: Simulated Events
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-3.2
-      title: Mechanisms Used in Training Environments
-      rules: []
-      status: pending
+      controls:
+          - id: cp-3.1
+            title: Simulated Events
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-3.2
+            title: Mechanisms Used in Training Environments
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-4
       title: Contingency Plan Testing
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-4.1
-      title: Coordinate with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-4.2
-      title: Alternate Processing Site
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-4.3
-      title: Automated Testing
-      rules: []
-      status: pending
-    - id: cp-4.4
-      title: Full Recovery and Reconstitution
-      rules: []
-      status: pending
-    - id: cp-4.5
-      title: Self-challenge
-      rules: []
-      status: pending
+      controls:
+          - id: cp-4.1
+            title: Coordinate with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-4.2
+            title: Alternate Processing Site
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-4.3
+            title: Automated Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-4.4
+            title: Full Recovery and Reconstitution
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-4.5
+            title: Self-challenge
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-5
       title: Contingency Plan Update
       rules: []
@@ -110,178 +127,203 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: cp-6.1
-      title: Separation from Primary Site
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-6.2
-      title: Recovery Time and Recovery Point Objectives
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-6.3
-      title: Accessibility
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-6.1
+            title: Separation from Primary Site
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-6.2
+            title: Recovery Time and Recovery Point Objectives
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-6.3
+            title: Accessibility
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-7
       title: Alternate Processing Site
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cp-7.1
-      title: Separation from Primary Site
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.2
-      title: Accessibility
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.3
-      title: Priority of Service
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.4
-      title: Preparation for Use
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-7.5
-      title: Equivalent Information Security Safeguards
-      rules: []
-      status: pending
-    - id: cp-7.6
-      title: Inability to Return to Primary Site
-      rules: []
-      status: pending
+      controls:
+          - id: cp-7.1
+            title: Separation from Primary Site
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.2
+            title: Accessibility
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.3
+            title: Priority of Service
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.4
+            title: Preparation for Use
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-7.5
+            title: Equivalent Information Security Safeguards
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cp-7.6
+            title: Inability to Return to Primary Site
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cp-8
       title: Telecommunications Services
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cp-8.1
-      title: Priority of Service Provisions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-8.2
-      title: Single Points of Failure
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-8.3
-      title: Separation of Primary and Alternate Providers
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-8.4
-      title: Provider Contingency Plan
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-8.5
-      title: Alternate Telecommunication Service Testing
-      rules: []
-      status: pending
+      controls:
+          - id: cp-8.1
+            title: Priority of Service Provisions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-8.2
+            title: Single Points of Failure
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-8.3
+            title: Separation of Primary and Alternate Providers
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-8.4
+            title: Provider Contingency Plan
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-8.5
+            title: Alternate Telecommunication Service Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cp-9
       title: System Backup
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-9.1
-      title: Testing for Reliability and Integrity
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-9.2
-      title: Test Restoration Using Sampling
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.3
-      title: Separate Storage for Critical Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.4
-      title: Protection from Unauthorized Modification
-      rules: []
-      status: pending
-    - id: cp-9.5
-      title: Transfer to Alternate Storage Site
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.6
-      title: Redundant Secondary System
-      rules: []
-      status: pending
-    - id: cp-9.7
-      title: Dual Authorization for Deletion or Destruction
-      rules: []
-      status: pending
-    - id: cp-9.8
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-9.1
+            title: Testing for Reliability and Integrity
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-9.2
+            title: Test Restoration Using Sampling
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.3
+            title: Separate Storage for Critical Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.4
+            title: Protection from Unauthorized Modification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.5
+            title: Transfer to Alternate Storage Site
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.6
+            title: Redundant Secondary System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.7
+            title: Dual Authorization for Deletion or Destruction
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.8
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-10
       title: System Recovery and Reconstitution
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-10.1
-      title: Contingency Plan Testing
-      rules: []
-      status: pending
-    - id: cp-10.2
-      title: Transaction Recovery
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-10.3
-      title: Compensating Security Controls
-      rules: []
-      status: pending
-    - id: cp-10.4
-      title: Restore Within Time Period
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-10.5
-      title: Failover Capability
-      rules: []
-      status: pending
-    - id: cp-10.6
-      title: Component Protection
-      rules: []
-      status: pending
+      controls:
+          - id: cp-10.1
+            title: Contingency Plan Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.2
+            title: Transaction Recovery
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-10.3
+            title: Compensating Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.4
+            title: Restore Within Time Period
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-10.5
+            title: Failover Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.6
+            title: Component Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-11
       title: Alternate Communications Protocols
       rules: []

--- a/products/rhel8/controls/nist_800_53/ia.yml
+++ b/products/rhel8/controls/nist_800_53/ia.yml
@@ -13,68 +13,85 @@ controls:
       rules:
           - account_unique_id
       status: automated
-    - id: ia-2.1
-      title: Multi-factor Authentication to Privileged Accounts
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.2
-      title: Multi-factor Authentication to Non-privileged Accounts
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.3
-      title: Local Access to Privileged Accounts
-      rules: []
-      status: pending
-    - id: ia-2.4
-      title: Local Access to Non-privileged Accounts
-      rules: []
-      status: pending
-    - id: ia-2.5
-      title: Individual Authentication with Group Authentication
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ia-2.6
-      title: Access to Accounts —separate Device
-      rules: []
-      status: pending
-    - id: ia-2.7
-      title: Network Access to Non-privileged Accounts — Separate Device
-      rules: []
-      status: pending
-    - id: ia-2.8
-      title: Access to Accounts — Replay Resistant
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.9
-      title: Network Access to Non-privileged Accounts — Replay Resistant
-      rules: []
-      status: pending
-    - id: ia-2.10
-      title: Single Sign-on
-      rules: []
-      status: pending
-    - id: ia-2.11
-      title: Remote Access — Separate Device
-      rules: []
-      status: pending
-    - id: ia-2.12
-      title: Acceptance of PIV Credentials
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.13
-      title: Out-of-band Authentication
-      rules: []
-      status: pending
+      controls:
+          - id: ia-2.1
+            title: Multi-factor Authentication to Privileged Accounts
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.2
+            title: Multi-factor Authentication to Non-privileged Accounts
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.3
+            title: Local Access to Privileged Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.4
+            title: Local Access to Non-privileged Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.5
+            title: Individual Authentication with Group Authentication
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ia-2.6
+            title: Access to Accounts —separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.7
+            title: Network Access to Non-privileged Accounts — Separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.8
+            title: Access to Accounts — Replay Resistant
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.9
+            title: Network Access to Non-privileged Accounts — Replay Resistant
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.10
+            title: Single Sign-on
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.11
+            title: Remote Access — Separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.12
+            title: Acceptance of PIV Credentials
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.13
+            title: Out-of-band Authentication
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-3
       title: Device Identification and Authentication
       levels:
@@ -84,22 +101,31 @@ controls:
           - dconf_gnome_disable_automount_open
           - kernel_module_usb-storage_disabled
       status: automated
-    - id: ia-3.1
-      title: Cryptographic Bidirectional Authentication
-      rules: []
-      status: pending
-    - id: ia-3.2
-      title: Cryptographic Bidirectional Network Authentication
-      rules: []
-      status: pending
-    - id: ia-3.3
-      title: Dynamic Address Allocation
-      rules: []
-      status: pending
-    - id: ia-3.4
-      title: Device Attestation
-      rules: []
-      status: pending
+      controls:
+          - id: ia-3.1
+            title: Cryptographic Bidirectional Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.2
+            title: Cryptographic Bidirectional Network Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.3
+            title: Dynamic Address Allocation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.4
+            title: Device Attestation
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ia-4
       title: Identifier Management
       levels:
@@ -109,44 +135,61 @@ controls:
           - accounts_set_post_pw_existing
           - var_account_disable_post_pw_expiration=45
       status: automated
-    - id: ia-4.1
-      title: Prohibit Account Identifiers as Public Identifiers
-      rules: []
-      status: pending
-    - id: ia-4.2
-      title: Supervisor Authorization
-      rules: []
-      status: pending
-    - id: ia-4.3
-      title: Multiple Forms of Certification
-      rules: []
-      status: pending
-    - id: ia-4.4
-      title: Identify User Status
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-4.5
-      title: Dynamic Management
-      rules: []
-      status: pending
-    - id: ia-4.6
-      title: Cross-organization Management
-      rules: []
-      status: pending
-    - id: ia-4.7
-      title: In-person Registration
-      rules: []
-      status: pending
-    - id: ia-4.8
-      title: Pairwise Pseudonymous Identifiers
-      rules: []
-      status: pending
-    - id: ia-4.9
-      title: Attribute Maintenance and Protection
-      rules: []
-      status: pending
+      controls:
+          - id: ia-4.1
+            title: Prohibit Account Identifiers as Public Identifiers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.2
+            title: Supervisor Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.3
+            title: Multiple Forms of Certification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.4
+            title: Identify User Status
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-4.5
+            title: Dynamic Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.6
+            title: Cross-organization Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.7
+            title: In-person Registration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.8
+            title: Pairwise Pseudonymous Identifiers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.9
+            title: Attribute Maintenance and Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-5
       title: Authenticator Management
       levels:
@@ -181,90 +224,121 @@ controls:
           - var_password_pam_maxsequence=3
           - var_password_pam_minlen=14
       status: automated
-    - id: ia-5.1
-      title: Password-based Authentication
-      levels:
-          - low
-      rules:
-          - accounts_password_pam_pwhistory_remember_password_auth
-          - accounts_password_pam_pwhistory_remember_system_auth
-          - accounts_password_pam_unix_enabled
-          - accounts_password_pam_unix_no_remember
-          - var_password_pam_remember=24
-          - var_password_pam_remember_control_flag=requisite_or_required
-      status: automated
-    - id: ia-5.2
-      title: Public Key-based Authentication
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-5.3
-      title: In-person or Trusted External Party Registration
-      rules: []
-      status: pending
-    - id: ia-5.4
-      title: Automated Support for Password Strength Determination
-      rules: []
-      status: pending
-    - id: ia-5.5
-      title: Change Authenticators Prior to Delivery
-      rules: []
-      status: pending
-    - id: ia-5.6
-      title: Protection of Authenticators
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-5.7
-      title: No Embedded Unencrypted Static Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.8
-      title: Multiple System Accounts
-      rules: []
-      status: pending
-    - id: ia-5.9
-      title: Federated Credential Management
-      rules: []
-      status: pending
-    - id: ia-5.10
-      title: Dynamic Credential Binding
-      rules: []
-      status: pending
-    - id: ia-5.11
-      title: Hardware Token-based Authentication
-      rules: []
-      status: pending
-    - id: ia-5.12
-      title: Biometric Authentication Performance
-      rules: []
-      status: pending
-    - id: ia-5.13
-      title: Expiration of Cached Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.14
-      title: Managing Content of PKI Trust Stores
-      rules: []
-      status: pending
-    - id: ia-5.15
-      title: GSA-approved Products and Services
-      rules: []
-      status: pending
-    - id: ia-5.16
-      title: In-person or Trusted External Party Authenticator Issuance
-      rules: []
-      status: pending
-    - id: ia-5.17
-      title: Presentation Attack Detection for Biometric Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.18
-      title: Password Managers
-      rules: []
-      status: pending
+      controls:
+          - id: ia-5.1
+            title: Password-based Authentication
+            levels:
+                - low
+            rules:
+                - accounts_password_pam_pwhistory_remember_password_auth
+                - accounts_password_pam_pwhistory_remember_system_auth
+                - accounts_password_pam_unix_enabled
+                - accounts_password_pam_unix_no_remember
+                - var_password_pam_remember=24
+                - var_password_pam_remember_control_flag=requisite_or_required
+            status: automated
+          - id: ia-5.2
+            title: Public Key-based Authentication
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-5.3
+            title: In-person or Trusted External Party Registration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.4
+            title: Automated Support for Password Strength Determination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.5
+            title: Change Authenticators Prior to Delivery
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.6
+            title: Protection of Authenticators
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-5.7
+            title: No Embedded Unencrypted Static Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.8
+            title: Multiple System Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.9
+            title: Federated Credential Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.10
+            title: Dynamic Credential Binding
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.11
+            title: Hardware Token-based Authentication
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.12
+            title: Biometric Authentication Performance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.13
+            title: Expiration of Cached Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.14
+            title: Managing Content of PKI Trust Stores
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.15
+            title: GSA-approved Products and Services
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.16
+            title: In-person or Trusted External Party Authenticator Issuance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.17
+            title: Presentation Attack Detection for Biometric Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.18
+            title: Password Managers
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-6
       title: Authentication Feedback
       levels:
@@ -283,48 +357,56 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ia-8.1
-      title: Acceptance of PIV Credentials from Other Agencies
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.2
-      title: Acceptance of External Authenticators
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.3
-      title: Use of FICAM-approved Products
-      rules: []
-      status: pending
-    - id: ia-8.4
-      title: Use of Defined Profiles
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.5
-      title: Acceptance of PIV-I Credentials
-      rules: []
-      status: pending
-    - id: ia-8.6
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: ia-8.1
+            title: Acceptance of PIV Credentials from Other Agencies
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.2
+            title: Acceptance of External Authenticators
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.3
+            title: Use of FICAM-approved Products
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-8.4
+            title: Use of Defined Profiles
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.5
+            title: Acceptance of PIV-I Credentials
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-8.6
+            title: Disassociability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-9
       title: Service Identification and Authentication
       rules: []
       status: pending
-    - id: ia-9.1
-      title: Information Exchange
-      rules: []
-      status: pending
-    - id: ia-9.2
-      title: Transmission of Decisions
-      rules: []
-      status: pending
+      controls:
+          - id: ia-9.1
+            title: Information Exchange
+            rules: []
+            status: pending
+          - id: ia-9.2
+            title: Transmission of Decisions
+            rules: []
+            status: pending
     - id: ia-10
       title: Adaptive Authentication
       rules: []
@@ -343,51 +425,57 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: ia-12.1
-      title: Supervisor Authorization
-      rules: []
-      status: pending
-    - id: ia-12.2
-      title: Identity Evidence
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.3
-      title: Identity Evidence Validation and Verification
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.4
-      title: In-person Validation and Verification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ia-12.5
-      title: Address Confirmation
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.6
-      title: Accept Externally-proofed Identities
-      rules: []
-      status: pending
+      controls:
+          - id: ia-12.1
+            title: Supervisor Authorization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-12.2
+            title: Identity Evidence
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.3
+            title: Identity Evidence Validation and Verification
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.4
+            title: In-person Validation and Verification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ia-12.5
+            title: Address Confirmation
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.6
+            title: Accept Externally-proofed Identities
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ia-13
       title: Identity Providers and Authorization Servers
       rules: []
       status: pending
-    - id: ia-13.1
-      title: Protection of Cryptographic Keys
-      rules: []
-      status: pending
-    - id: ia-13.2
-      title: Verification of Identity Assertions and Access Tokens
-      rules: []
-      status: pending
-    - id: ia-13.3
-      title: Token Management
-      rules: []
-      status: pending
+      controls:
+          - id: ia-13.1
+            title: Protection of Cryptographic Keys
+            rules: []
+            status: pending
+          - id: ia-13.2
+            title: Verification of Identity Assertions and Access Tokens
+            rules: []
+            status: pending
+          - id: ia-13.3
+            title: Token Management
+            rules: []
+            status: pending

--- a/products/rhel8/controls/nist_800_53/ir.yml
+++ b/products/rhel8/controls/nist_800_53/ir.yml
@@ -12,194 +12,239 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ir-2.1
-      title: Simulated Events
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-2.2
-      title: Automated Training Environments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-2.3
-      title: Breach
-      rules: []
-      status: pending
+      controls:
+          - id: ir-2.1
+            title: Simulated Events
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-2.2
+            title: Automated Training Environments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-2.3
+            title: Breach
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-3
       title: Incident Response Testing
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ir-3.1
-      title: Automated Testing
-      rules: []
-      status: pending
-    - id: ir-3.2
-      title: Coordination with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-3.3
-      title: Continuous Improvement
-      rules: []
-      status: pending
+      controls:
+          - id: ir-3.1
+            title: Automated Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ir-3.2
+            title: Coordination with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-3.3
+            title: Continuous Improvement
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ir-4
       title: Incident Handling
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-4.1
-      title: Automated Incident Handling Processes
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-4.2
-      title: Dynamic Reconfiguration
-      rules: []
-      status: pending
-    - id: ir-4.3
-      title: Continuity of Operations
-      rules: []
-      status: pending
-    - id: ir-4.4
-      title: Information Correlation
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-4.5
-      title: Automatic Disabling of System
-      rules: []
-      status: pending
-    - id: ir-4.6
-      title: Insider Threats
-      rules: []
-      status: pending
-    - id: ir-4.7
-      title: Insider Threats — Intra-organization Coordination
-      rules: []
-      status: pending
-    - id: ir-4.8
-      title: Correlation with External Organizations
-      rules: []
-      status: pending
-    - id: ir-4.9
-      title: Dynamic Response Capability
-      rules: []
-      status: pending
-    - id: ir-4.10
-      title: Supply Chain Coordination
-      rules: []
-      status: pending
-    - id: ir-4.11
-      title: Integrated Incident Response Team
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-4.12
-      title: Malicious Code and Forensic Analysis
-      rules: []
-      status: pending
-    - id: ir-4.13
-      title: Behavior Analysis
-      rules: []
-      status: pending
-    - id: ir-4.14
-      title: Security Operations Center
-      rules: []
-      status: pending
-    - id: ir-4.15
-      title: Public Relations and Reputation Repair
-      rules: []
-      status: pending
+      controls:
+          - id: ir-4.1
+            title: Automated Incident Handling Processes
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-4.2
+            title: Dynamic Reconfiguration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.3
+            title: Continuity of Operations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.4
+            title: Information Correlation
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-4.5
+            title: Automatic Disabling of System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.6
+            title: Insider Threats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.7
+            title: Insider Threats — Intra-organization Coordination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.8
+            title: Correlation with External Organizations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.9
+            title: Dynamic Response Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.10
+            title: Supply Chain Coordination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.11
+            title: Integrated Incident Response Team
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-4.12
+            title: Malicious Code and Forensic Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.13
+            title: Behavior Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.14
+            title: Security Operations Center
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.15
+            title: Public Relations and Reputation Repair
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-5
       title: Incident Monitoring
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-5.1
-      title: Automated Tracking, Data Collection, and Analysis
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ir-5.1
+            title: Automated Tracking, Data Collection, and Analysis
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ir-6
       title: Incident Reporting
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-6.1
-      title: Automated Reporting
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-6.2
-      title: Vulnerabilities Related to Incidents
-      rules: []
-      status: pending
-    - id: ir-6.3
-      title: Supply Chain Coordination
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ir-6.1
+            title: Automated Reporting
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-6.2
+            title: Vulnerabilities Related to Incidents
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-6.3
+            title: Supply Chain Coordination
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ir-7
       title: Incident Response Assistance
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-7.1
-      title: Automation Support for Availability of Information and Support
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-7.2
-      title: Coordination with External Providers
-      rules: []
-      status: pending
+      controls:
+          - id: ir-7.1
+            title: Automation Support for Availability of Information and
+                Support
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-7.2
+            title: Coordination with External Providers
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-8
       title: Incident Response Plan
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-8.1
-      title: Breaches
-      rules: []
-      status: pending
+      controls:
+          - id: ir-8.1
+            title: Breaches
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-9
       title: Information Spillage Response
       rules: []
       status: pending
-    - id: ir-9.1
-      title: Responsible Personnel
-      rules: []
-      status: pending
-    - id: ir-9.2
-      title: Training
-      rules: []
-      status: pending
-    - id: ir-9.3
-      title: Post-spill Operations
-      rules: []
-      status: pending
-    - id: ir-9.4
-      title: Exposure to Unauthorized Personnel
-      rules: []
-      status: pending
+      controls:
+          - id: ir-9.1
+            title: Responsible Personnel
+            rules: []
+            status: pending
+          - id: ir-9.2
+            title: Training
+            rules: []
+            status: pending
+          - id: ir-9.3
+            title: Post-spill Operations
+            rules: []
+            status: pending
+          - id: ir-9.4
+            title: Exposure to Unauthorized Personnel
+            rules: []
+            status: pending
     - id: ir-10
       title: Integrated Information Security Analysis Team
       rules: []

--- a/products/rhel8/controls/nist_800_53/ma.yml
+++ b/products/rhel8/controls/nist_800_53/ma.yml
@@ -12,134 +12,173 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ma-2.1
-      title: Record Content
-      rules: []
-      status: pending
-    - id: ma-2.2
-      title: Automated Maintenance Activities
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ma-2.1
+            title: Record Content
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-2.2
+            title: Automated Maintenance Activities
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ma-3
       title: Maintenance Tools
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ma-3.1
-      title: Inspect Tools
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.2
-      title: Inspect Media
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.3
-      title: Prevent Unauthorized Removal
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.4
-      title: Restricted Tool Use
-      rules: []
-      status: pending
-    - id: ma-3.5
-      title: Execution with Privilege
-      rules: []
-      status: pending
-    - id: ma-3.6
-      title: Software Updates and Patches
-      rules: []
-      status: pending
+      controls:
+          - id: ma-3.1
+            title: Inspect Tools
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.2
+            title: Inspect Media
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.3
+            title: Prevent Unauthorized Removal
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.4
+            title: Restricted Tool Use
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-3.5
+            title: Execution with Privilege
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-3.6
+            title: Software Updates and Patches
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ma-4
       title: Nonlocal Maintenance
       levels:
           - low
       rules: []
       status: pending
-    - id: ma-4.1
-      title: Logging and Review
-      rules: []
-      status: pending
-    - id: ma-4.2
-      title: Document Nonlocal Maintenance
-      rules: []
-      status: pending
-    - id: ma-4.3
-      title: Comparable Security and Sanitization
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ma-4.4
-      title: Authentication and Separation of Maintenance Sessions
-      rules: []
-      status: pending
-    - id: ma-4.5
-      title: Approvals and Notifications
-      rules: []
-      status: pending
-    - id: ma-4.6
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: ma-4.7
-      title: Disconnect Verification
-      rules: []
-      status: pending
+      controls:
+          - id: ma-4.1
+            title: Logging and Review
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.2
+            title: Document Nonlocal Maintenance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.3
+            title: Comparable Security and Sanitization
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ma-4.4
+            title: Authentication and Separation of Maintenance Sessions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.5
+            title: Approvals and Notifications
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.6
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.7
+            title: Disconnect Verification
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ma-5
       title: Maintenance Personnel
       levels:
           - low
       rules: []
       status: pending
-    - id: ma-5.1
-      title: Individuals Without Appropriate Access
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ma-5.2
-      title: Security Clearances for Classified Systems
-      rules: []
-      status: pending
-    - id: ma-5.3
-      title: Citizenship Requirements for Classified Systems
-      rules: []
-      status: pending
-    - id: ma-5.4
-      title: Foreign Nationals
-      rules: []
-      status: pending
-    - id: ma-5.5
-      title: Non-system Maintenance
-      rules: []
-      status: pending
+      controls:
+          - id: ma-5.1
+            title: Individuals Without Appropriate Access
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ma-5.2
+            title: Security Clearances for Classified Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.3
+            title: Citizenship Requirements for Classified Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.4
+            title: Foreign Nationals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.5
+            title: Non-system Maintenance
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ma-6
       title: Timely Maintenance
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ma-6.1
-      title: Preventive Maintenance
-      rules: []
-      status: pending
-    - id: ma-6.2
-      title: Predictive Maintenance
-      rules: []
-      status: pending
-    - id: ma-6.3
-      title: Automated Support for Predictive Maintenance
-      rules: []
-      status: pending
+      controls:
+          - id: ma-6.1
+            title: Preventive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-6.2
+            title: Predictive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-6.3
+            title: Automated Support for Predictive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ma-7
       title: Field Maintenance
       rules: []

--- a/products/rhel8/controls/nist_800_53/mp.yml
+++ b/products/rhel8/controls/nist_800_53/mp.yml
@@ -12,14 +12,19 @@ controls:
           - low
       rules: []
       status: pending
-    - id: mp-2.1
-      title: Automated Restricted Access
-      rules: []
-      status: pending
-    - id: mp-2.2
-      title: Cryptographic Protection
-      rules: []
-      status: pending
+      controls:
+          - id: mp-2.1
+            title: Automated Restricted Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-2.2
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-3
       title: Media Marking
       levels:
@@ -32,111 +37,142 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: mp-4.1
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: mp-4.2
-      title: Automated Restricted Access
-      rules: []
-      status: pending
+      controls:
+          - id: mp-4.1
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-4.2
+            title: Automated Restricted Access
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: mp-5
       title: Media Transport
       levels:
           - moderate
       rules: []
       status: pending
-    - id: mp-5.1
-      title: Protection Outside of Controlled Areas
-      rules: []
-      status: pending
-    - id: mp-5.2
-      title: Documentation of Activities
-      rules: []
-      status: pending
-    - id: mp-5.3
-      title: Custodians
-      rules: []
-      status: pending
-    - id: mp-5.4
-      title: Cryptographic Protection
-      rules: []
-      status: pending
+      controls:
+          - id: mp-5.1
+            title: Protection Outside of Controlled Areas
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.2
+            title: Documentation of Activities
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.3
+            title: Custodians
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.4
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: mp-6
       title: Media Sanitization
       levels:
           - low
       rules: []
       status: pending
-    - id: mp-6.1
-      title: Review, Approve, Track, Document, and Verify
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.2
-      title: Equipment Testing
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.3
-      title: Nondestructive Techniques
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.4
-      title: Controlled Unclassified Information
-      rules: []
-      status: pending
-    - id: mp-6.5
-      title: Classified Information
-      rules: []
-      status: pending
-    - id: mp-6.6
-      title: Media Destruction
-      rules: []
-      status: pending
-    - id: mp-6.7
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: mp-6.8
-      title: Remote Purging or Wiping of Information
-      rules: []
-      status: pending
+      controls:
+          - id: mp-6.1
+            title: Review, Approve, Track, Document, and Verify
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.2
+            title: Equipment Testing
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.3
+            title: Nondestructive Techniques
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.4
+            title: Controlled Unclassified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.5
+            title: Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.6
+            title: Media Destruction
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.7
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.8
+            title: Remote Purging or Wiping of Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-7
       title: Media Use
       levels:
           - low
       rules: []
       status: pending
-    - id: mp-7.1
-      title: Prohibit Use Without Owner
-      rules: []
-      status: pending
-    - id: mp-7.2
-      title: Prohibit Use of Sanitization-resistant Media
-      rules: []
-      status: pending
+      controls:
+          - id: mp-7.1
+            title: Prohibit Use Without Owner
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-7.2
+            title: Prohibit Use of Sanitization-resistant Media
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-8
       title: Media Downgrading
       rules: []
       status: pending
-    - id: mp-8.1
-      title: Documentation of Process
-      rules: []
-      status: pending
-    - id: mp-8.2
-      title: Equipment Testing
-      rules: []
-      status: pending
-    - id: mp-8.3
-      title: Controlled Unclassified Information
-      rules: []
-      status: pending
-    - id: mp-8.4
-      title: Classified Information
-      rules: []
-      status: pending
+      controls:
+          - id: mp-8.1
+            title: Documentation of Process
+            rules: []
+            status: pending
+          - id: mp-8.2
+            title: Equipment Testing
+            rules: []
+            status: pending
+          - id: mp-8.3
+            title: Controlled Unclassified Information
+            rules: []
+            status: pending
+          - id: mp-8.4
+            title: Classified Information
+            rules: []
+            status: pending

--- a/products/rhel8/controls/nist_800_53/pe.yml
+++ b/products/rhel8/controls/nist_800_53/pe.yml
@@ -12,58 +12,80 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pe-2.1
-      title: Access by Position or Role
-      rules: []
-      status: pending
-    - id: pe-2.2
-      title: Two Forms of Identification
-      rules: []
-      status: pending
-    - id: pe-2.3
-      title: Restrict Unescorted Access
-      rules: []
-      status: pending
+      controls:
+          - id: pe-2.1
+            title: Access by Position or Role
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-2.2
+            title: Two Forms of Identification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-2.3
+            title: Restrict Unescorted Access
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-3
       title: Physical Access Control
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-3.1
-      title: System Access
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-3.2
-      title: Facility and Systems
-      rules: []
-      status: pending
-    - id: pe-3.3
-      title: Continuous Guards
-      rules: []
-      status: pending
-    - id: pe-3.4
-      title: Lockable Casings
-      rules: []
-      status: pending
-    - id: pe-3.5
-      title: Tamper Protection
-      rules: []
-      status: pending
-    - id: pe-3.6
-      title: Facility Penetration Testing
-      rules: []
-      status: pending
-    - id: pe-3.7
-      title: Physical Barriers
-      rules: []
-      status: pending
-    - id: pe-3.8
-      title: Access Control Vestibules
-      rules: []
-      status: pending
+      controls:
+          - id: pe-3.1
+            title: System Access
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-3.2
+            title: Facility and Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.3
+            title: Continuous Guards
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.4
+            title: Lockable Casings
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.5
+            title: Tamper Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.6
+            title: Facility Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.7
+            title: Physical Barriers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.8
+            title: Access Control Vestibules
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-4
       title: Access Control for Transmission
       levels:
@@ -76,44 +98,56 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: pe-5.1
-      title: Access to Output by Authorized Individuals
-      rules: []
-      status: pending
-    - id: pe-5.2
-      title: Link to Individual Identity
-      rules: []
-      status: pending
-    - id: pe-5.3
-      title: Marking Output Devices
-      rules: []
-      status: pending
+      controls:
+          - id: pe-5.1
+            title: Access to Output by Authorized Individuals
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-5.2
+            title: Link to Individual Identity
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-5.3
+            title: Marking Output Devices
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-6
       title: Monitoring Physical Access
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-6.1
-      title: Intrusion Alarms and Surveillance Equipment
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: pe-6.2
-      title: Automated Intrusion Recognition and Responses
-      rules: []
-      status: pending
-    - id: pe-6.3
-      title: Video Surveillance
-      rules: []
-      status: pending
-    - id: pe-6.4
-      title: Monitoring Physical Access to Systems
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: pe-6.1
+            title: Intrusion Alarms and Surveillance Equipment
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: pe-6.2
+            title: Automated Intrusion Recognition and Responses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-6.3
+            title: Video Surveillance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-6.4
+            title: Monitoring Physical Access to Systems
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: pe-7
       title: Visitor Control
       rules: []
@@ -124,122 +158,152 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pe-8.1
-      title: Automated Records Maintenance and Review
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-8.2
-      title: Physical Access Records
-      rules: []
-      status: pending
-    - id: pe-8.3
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
+      controls:
+          - id: pe-8.1
+            title: Automated Records Maintenance and Review
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-8.2
+            title: Physical Access Records
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-8.3
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-9
       title: Power Equipment and Cabling
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-9.1
-      title: Redundant Cabling
-      rules: []
-      status: pending
-    - id: pe-9.2
-      title: Automatic Voltage Controls
-      rules: []
-      status: pending
+      controls:
+          - id: pe-9.1
+            title: Redundant Cabling
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-9.2
+            title: Automatic Voltage Controls
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-10
       title: Emergency Shutoff
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-10.1
-      title: Accidental and Unauthorized Activation
-      rules: []
-      status: pending
+      controls:
+          - id: pe-10.1
+            title: Accidental and Unauthorized Activation
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-11
       title: Emergency Power
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-11.1
-      title: Alternate Power Supply — Minimal Operational Capability
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-11.2
-      title: Alternate Power Supply — Self-contained
-      rules: []
-      status: pending
+      controls:
+          - id: pe-11.1
+            title: Alternate Power Supply — Minimal Operational Capability
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-11.2
+            title: Alternate Power Supply — Self-contained
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-12
       title: Emergency Lighting
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-12.1
-      title: Essential Mission and Business Functions
-      rules: []
-      status: pending
+      controls:
+          - id: pe-12.1
+            title: Essential Mission and Business Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-13
       title: Fire Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-13.1
-      title: Detection Systems — Automatic Activation and Notification
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: pe-13.2
-      title: Suppression Systems — Automatic Activation and Notification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-13.3
-      title: Automatic Fire Suppression
-      rules: []
-      status: pending
-    - id: pe-13.4
-      title: Inspections
-      rules: []
-      status: pending
+      controls:
+          - id: pe-13.1
+            title: Detection Systems — Automatic Activation and Notification
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: pe-13.2
+            title: Suppression Systems — Automatic Activation and Notification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-13.3
+            title: Automatic Fire Suppression
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-13.4
+            title: Inspections
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-14
       title: Environmental Controls
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-14.1
-      title: Automatic Controls
-      rules: []
-      status: pending
-    - id: pe-14.2
-      title: Monitoring with Alarms and Notifications
-      rules: []
-      status: pending
+      controls:
+          - id: pe-14.1
+            title: Automatic Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-14.2
+            title: Monitoring with Alarms and Notifications
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-15
       title: Water Damage Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-15.1
-      title: Automation Support
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: pe-15.1
+            title: Automation Support
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: pe-16
       title: Delivery and Removal
       levels:
@@ -258,18 +322,22 @@ controls:
           - high
       rules: []
       status: pending
-    - id: pe-18.1
-      title: Facility Site
-      rules: []
-      status: pending
+      controls:
+          - id: pe-18.1
+            title: Facility Site
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: pe-19
       title: Information Leakage
       rules: []
       status: pending
-    - id: pe-19.1
-      title: National Emissions Policies and Procedures
-      rules: []
-      status: pending
+      controls:
+          - id: pe-19.1
+            title: National Emissions Policies and Procedures
+            rules: []
+            status: pending
     - id: pe-20
       title: Asset Monitoring and Tracking
       rules: []

--- a/products/rhel8/controls/nist_800_53/pl.yml
+++ b/products/rhel8/controls/nist_800_53/pl.yml
@@ -12,18 +12,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pl-2.1
-      title: Concept of Operations
-      rules: []
-      status: pending
-    - id: pl-2.2
-      title: Functional Architecture
-      rules: []
-      status: pending
-    - id: pl-2.3
-      title: Plan and Coordinate with Other Organizational Entities
-      rules: []
-      status: pending
+      controls:
+          - id: pl-2.1
+            title: Concept of Operations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pl-2.2
+            title: Functional Architecture
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pl-2.3
+            title: Plan and Coordinate with Other Organizational Entities
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pl-3
       title: System Security Plan Update
       rules: []
@@ -34,12 +41,13 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pl-4.1
-      title: Social Media and External Site/Application Usage Restrictions
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: pl-4.1
+            title: Social Media and External Site/Application Usage Restrictions
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: pl-5
       title: Privacy Impact Assessment
       rules: []
@@ -58,14 +66,19 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: pl-8.1
-      title: Defense in Depth
-      rules: []
-      status: pending
-    - id: pl-8.2
-      title: Supplier Diversity
-      rules: []
-      status: pending
+      controls:
+          - id: pl-8.1
+            title: Defense in Depth
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pl-8.2
+            title: Supplier Diversity
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pl-9
       title: Central Management
       rules: []

--- a/products/rhel8/controls/nist_800_53/pm.yml
+++ b/products/rhel8/controls/nist_800_53/pm.yml
@@ -20,10 +20,11 @@ controls:
       title: System Inventory
       rules: []
       status: pending
-    - id: pm-5.1
-      title: Inventory of Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: pm-5.1
+            title: Inventory of Personally Identifiable Information
+            rules: []
+            status: pending
     - id: pm-6
       title: Measures of Performance
       rules: []
@@ -32,10 +33,11 @@ controls:
       title: Enterprise Architecture
       rules: []
       status: pending
-    - id: pm-7.1
-      title: Offloading
-      rules: []
-      status: pending
+      controls:
+          - id: pm-7.1
+            title: Offloading
+            rules: []
+            status: pending
     - id: pm-8
       title: Critical Infrastructure Plan
       rules: []
@@ -72,10 +74,11 @@ controls:
       title: Threat Awareness Program
       rules: []
       status: pending
-    - id: pm-16.1
-      title: Automated Means for Sharing Threat Intelligence
-      rules: []
-      status: pending
+      controls:
+          - id: pm-16.1
+            title: Automated Means for Sharing Threat Intelligence
+            rules: []
+            status: pending
     - id: pm-17
       title: Protecting Controlled Unclassified Information on External Systems
       rules: []
@@ -92,10 +95,12 @@ controls:
       title: Dissemination of Privacy Program Information
       rules: []
       status: pending
-    - id: pm-20.1
-      title: Privacy Policies on Websites, Applications, and Digital Services
-      rules: []
-      status: pending
+      controls:
+          - id: pm-20.1
+            title: Privacy Policies on Websites, Applications, and Digital
+                Services
+            rules: []
+            status: pending
     - id: pm-21
       title: Accounting of Disclosures
       rules: []
@@ -113,8 +118,8 @@ controls:
       rules: []
       status: pending
     - id: pm-25
-      title: Minimization of Personally Identifiable Information Used in Testing, Training, and
-          Research
+      title: Minimization of Personally Identifiable Information Used in
+          Testing, Training, and Research
       rules: []
       status: pending
     - id: pm-26
@@ -137,10 +142,11 @@ controls:
       title: Supply Chain Risk Management Strategy
       rules: []
       status: pending
-    - id: pm-30.1
-      title: Suppliers of Critical or Mission-essential Items
-      rules: []
-      status: pending
+      controls:
+          - id: pm-30.1
+            title: Suppliers of Critical or Mission-essential Items
+            rules: []
+            status: pending
     - id: pm-31
       title: Continuous Monitoring Strategy
       rules: []

--- a/products/rhel8/controls/nist_800_53/ps.yml
+++ b/products/rhel8/controls/nist_800_53/ps.yml
@@ -18,38 +18,50 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ps-3.1
-      title: Classified Information
-      rules: []
-      status: pending
-    - id: ps-3.2
-      title: Formal Indoctrination
-      rules: []
-      status: pending
-    - id: ps-3.3
-      title: Information Requiring Special Protective Measures
-      rules: []
-      status: pending
-    - id: ps-3.4
-      title: Citizenship Requirements
-      rules: []
-      status: pending
+      controls:
+          - id: ps-3.1
+            title: Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.2
+            title: Formal Indoctrination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.3
+            title: Information Requiring Special Protective Measures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.4
+            title: Citizenship Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ps-4
       title: Personnel Termination
       levels:
           - low
       rules: []
       status: pending
-    - id: ps-4.1
-      title: Post-employment Requirements
-      rules: []
-      status: pending
-    - id: ps-4.2
-      title: Automated Actions
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ps-4.1
+            title: Post-employment Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-4.2
+            title: Automated Actions
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ps-5
       title: Personnel Transfer
       levels:
@@ -62,18 +74,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ps-6.1
-      title: Information Requiring Special Protection
-      rules: []
-      status: pending
-    - id: ps-6.2
-      title: Classified Information Requiring Special Protection
-      rules: []
-      status: pending
-    - id: ps-6.3
-      title: Post-employment Requirements
-      rules: []
-      status: pending
+      controls:
+          - id: ps-6.1
+            title: Information Requiring Special Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-6.2
+            title: Classified Information Requiring Special Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-6.3
+            title: Post-employment Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ps-7
       title: External Personnel Security
       levels:

--- a/products/rhel8/controls/nist_800_53/pt.yml
+++ b/products/rhel8/controls/nist_800_53/pt.yml
@@ -8,78 +8,84 @@ controls:
       title: Authority to Process Personally Identifiable Information
       rules: []
       status: pending
-    - id: pt-2.1
-      title: Data Tagging
-      rules: []
-      status: pending
-    - id: pt-2.2
-      title: Automation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-2.1
+            title: Data Tagging
+            rules: []
+            status: pending
+          - id: pt-2.2
+            title: Automation
+            rules: []
+            status: pending
     - id: pt-3
       title: Personally Identifiable Information Processing Purposes
       rules: []
       status: pending
-    - id: pt-3.1
-      title: Data Tagging
-      rules: []
-      status: pending
-    - id: pt-3.2
-      title: Automation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-3.1
+            title: Data Tagging
+            rules: []
+            status: pending
+          - id: pt-3.2
+            title: Automation
+            rules: []
+            status: pending
     - id: pt-4
       title: Consent
       rules: []
       status: pending
-    - id: pt-4.1
-      title: Tailored Consent
-      rules: []
-      status: pending
-    - id: pt-4.2
-      title: Just-in-time Consent
-      rules: []
-      status: pending
-    - id: pt-4.3
-      title: Revocation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-4.1
+            title: Tailored Consent
+            rules: []
+            status: pending
+          - id: pt-4.2
+            title: Just-in-time Consent
+            rules: []
+            status: pending
+          - id: pt-4.3
+            title: Revocation
+            rules: []
+            status: pending
     - id: pt-5
       title: Privacy Notice
       rules: []
       status: pending
-    - id: pt-5.1
-      title: Just-in-time Notice
-      rules: []
-      status: pending
-    - id: pt-5.2
-      title: Privacy Act Statements
-      rules: []
-      status: pending
+      controls:
+          - id: pt-5.1
+            title: Just-in-time Notice
+            rules: []
+            status: pending
+          - id: pt-5.2
+            title: Privacy Act Statements
+            rules: []
+            status: pending
     - id: pt-6
       title: System of Records Notice
       rules: []
       status: pending
-    - id: pt-6.1
-      title: Routine Uses
-      rules: []
-      status: pending
-    - id: pt-6.2
-      title: Exemption Rules
-      rules: []
-      status: pending
+      controls:
+          - id: pt-6.1
+            title: Routine Uses
+            rules: []
+            status: pending
+          - id: pt-6.2
+            title: Exemption Rules
+            rules: []
+            status: pending
     - id: pt-7
       title: Specific Categories of Personally Identifiable Information
       rules: []
       status: pending
-    - id: pt-7.1
-      title: Social Security Numbers
-      rules: []
-      status: pending
-    - id: pt-7.2
-      title: First Amendment Information
-      rules: []
-      status: pending
+      controls:
+          - id: pt-7.1
+            title: Social Security Numbers
+            rules: []
+            status: pending
+          - id: pt-7.2
+            title: First Amendment Information
+            rules: []
+            status: pending
     - id: pt-8
       title: Computer Matching Requirements
       rules: []

--- a/products/rhel8/controls/nist_800_53/ra.yml
+++ b/products/rhel8/controls/nist_800_53/ra.yml
@@ -12,34 +12,44 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ra-2.1
-      title: Impact-level Prioritization
-      rules: []
-      status: pending
+      controls:
+          - id: ra-2.1
+            title: Impact-level Prioritization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ra-3
       title: Risk Assessment
       levels:
           - low
       rules: []
       status: pending
-    - id: ra-3.1
-      title: Supply Chain Risk Assessment
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ra-3.2
-      title: Use of All-source Intelligence
-      rules: []
-      status: pending
-    - id: ra-3.3
-      title: Dynamic Threat Awareness
-      rules: []
-      status: pending
-    - id: ra-3.4
-      title: Predictive Cyber Analytics
-      rules: []
-      status: pending
+      controls:
+          - id: ra-3.1
+            title: Supply Chain Risk Assessment
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ra-3.2
+            title: Use of All-source Intelligence
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-3.3
+            title: Dynamic Threat Awareness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-3.4
+            title: Predictive Cyber Analytics
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ra-4
       title: Risk Assessment Update
       rules: []
@@ -50,58 +60,74 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ra-5.1
-      title: Update Tool Capability
-      rules: []
-      status: pending
-    - id: ra-5.2
-      title: Update Vulnerabilities to Be Scanned
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ra-5.3
-      title: Breadth and Depth of Coverage
-      rules: []
-      status: pending
-    - id: ra-5.4
-      title: Discoverable Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ra-5.5
-      title: Privileged Access
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ra-5.6
-      title: Automated Trend Analyses
-      rules: []
-      status: pending
-    - id: ra-5.7
-      title: Automated Detection and Notification of Unauthorized Components
-      rules: []
-      status: pending
-    - id: ra-5.8
-      title: Review Historic Audit Logs
-      rules: []
-      status: pending
-    - id: ra-5.9
-      title: Penetration Testing and Analyses
-      rules: []
-      status: pending
-    - id: ra-5.10
-      title: Correlate Scanning Information
-      rules: []
-      status: pending
-    - id: ra-5.11
-      title: Public Disclosure Program
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: ra-5.1
+            title: Update Tool Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.2
+            title: Update Vulnerabilities to Be Scanned
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ra-5.3
+            title: Breadth and Depth of Coverage
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.4
+            title: Discoverable Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ra-5.5
+            title: Privileged Access
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ra-5.6
+            title: Automated Trend Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.7
+            title: Automated Detection and Notification of Unauthorized
+                Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.8
+            title: Review Historic Audit Logs
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.9
+            title: Penetration Testing and Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.10
+            title: Correlate Scanning Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.11
+            title: Public Disclosure Program
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: ra-6
       title: Technical Surveillance Countermeasures Survey
       rules: []

--- a/products/rhel8/controls/nist_800_53/sa.yml
+++ b/products/rhel8/controls/nist_800_53/sa.yml
@@ -18,108 +18,141 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sa-3.1
-      title: Manage Preproduction Environment
-      rules: []
-      status: pending
-    - id: sa-3.2
-      title: Use of Live or Operational Data
-      rules: []
-      status: pending
-    - id: sa-3.3
-      title: Technology Refresh
-      rules: []
-      status: pending
+      controls:
+          - id: sa-3.1
+            title: Manage Preproduction Environment
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-3.2
+            title: Use of Live or Operational Data
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-3.3
+            title: Technology Refresh
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-4
       title: Acquisition Process
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-4.1
-      title: Functional Properties of Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.2
-      title: Design and Implementation Information for Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.3
-      title: Development Methods, Techniques, and Practices
-      rules: []
-      status: pending
-    - id: sa-4.4
-      title: Assignment of Components to Systems
-      rules: []
-      status: pending
-    - id: sa-4.5
-      title: System, Component, and Service Configurations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sa-4.6
-      title: Use of Information Assurance Products
-      rules: []
-      status: pending
-    - id: sa-4.7
-      title: 'NIAP-approved Protection Profiles '
-      rules: []
-      status: pending
-    - id: sa-4.8
-      title: Continuous Monitoring Plan for Controls
-      rules: []
-      status: pending
-    - id: sa-4.9
-      title: Functions, Ports, Protocols, and Services in Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.10
-      title: Use of Approved PIV Products
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sa-4.11
-      title: System of Records
-      rules: []
-      status: pending
-    - id: sa-4.12
-      title: Data Ownership
-      rules: []
-      status: pending
+      controls:
+          - id: sa-4.1
+            title: Functional Properties of Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.2
+            title: Design and Implementation Information for Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.3
+            title: Development Methods, Techniques, and Practices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.4
+            title: Assignment of Components to Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.5
+            title: System, Component, and Service Configurations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sa-4.6
+            title: Use of Information Assurance Products
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.7
+            title: 'NIAP-approved Protection Profiles '
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.8
+            title: Continuous Monitoring Plan for Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.9
+            title: Functions, Ports, Protocols, and Services in Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.10
+            title: Use of Approved PIV Products
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sa-4.11
+            title: System of Records
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.12
+            title: Data Ownership
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-5
       title: System Documentation
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-5.1
-      title: Functional Properties of Security Controls
-      rules: []
-      status: pending
-    - id: sa-5.2
-      title: Security-relevant External System Interfaces
-      rules: []
-      status: pending
-    - id: sa-5.3
-      title: High-level Design
-      rules: []
-      status: pending
-    - id: sa-5.4
-      title: Low-level Design
-      rules: []
-      status: pending
-    - id: sa-5.5
-      title: Source Code
-      rules: []
-      status: pending
+      controls:
+          - id: sa-5.1
+            title: Functional Properties of Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.2
+            title: Security-relevant External System Interfaces
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.3
+            title: High-level Design
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.4
+            title: Low-level Design
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.5
+            title: Source Code
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-6
       title: Software Usage Restrictions
       rules: []
@@ -134,318 +167,436 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sa-8.1
-      title: Clear Abstractions
-      rules: []
-      status: pending
-    - id: sa-8.2
-      title: Least Common Mechanism
-      rules: []
-      status: pending
-    - id: sa-8.3
-      title: Modularity and Layering
-      rules: []
-      status: pending
-    - id: sa-8.4
-      title: Partially Ordered Dependencies
-      rules: []
-      status: pending
-    - id: sa-8.5
-      title: Efficiently Mediated Access
-      rules: []
-      status: pending
-    - id: sa-8.6
-      title: Minimized Sharing
-      rules: []
-      status: pending
-    - id: sa-8.7
-      title: Reduced Complexity
-      rules: []
-      status: pending
-    - id: sa-8.8
-      title: Secure Evolvability
-      rules: []
-      status: pending
-    - id: sa-8.9
-      title: Trusted Components
-      rules: []
-      status: pending
-    - id: sa-8.10
-      title: Hierarchical Trust
-      rules: []
-      status: pending
-    - id: sa-8.11
-      title: Inverse Modification Threshold
-      rules: []
-      status: pending
-    - id: sa-8.12
-      title: Hierarchical Protection
-      rules: []
-      status: pending
-    - id: sa-8.13
-      title: Minimized Security Elements
-      rules: []
-      status: pending
-    - id: sa-8.14
-      title: Least Privilege
-      rules: []
-      status: pending
-    - id: sa-8.15
-      title: Predicate Permission
-      rules: []
-      status: pending
-    - id: sa-8.16
-      title: Self-reliant Trustworthiness
-      rules: []
-      status: pending
-    - id: sa-8.17
-      title: Secure Distributed Composition
-      rules: []
-      status: pending
-    - id: sa-8.18
-      title: Trusted Communications Channels
-      rules: []
-      status: pending
-    - id: sa-8.19
-      title: Continuous Protection
-      rules: []
-      status: pending
-    - id: sa-8.20
-      title: Secure Metadata Management
-      rules: []
-      status: pending
-    - id: sa-8.21
-      title: Self-analysis
-      rules: []
-      status: pending
-    - id: sa-8.22
-      title: Accountability and Traceability
-      rules: []
-      status: pending
-    - id: sa-8.23
-      title: Secure Defaults
-      rules: []
-      status: pending
-    - id: sa-8.24
-      title: Secure Failure and Recovery
-      rules: []
-      status: pending
-    - id: sa-8.25
-      title: Economic Security
-      rules: []
-      status: pending
-    - id: sa-8.26
-      title: Performance Security
-      rules: []
-      status: pending
-    - id: sa-8.27
-      title: Human Factored Security
-      rules: []
-      status: pending
-    - id: sa-8.28
-      title: Acceptable Security
-      rules: []
-      status: pending
-    - id: sa-8.29
-      title: Repeatable and Documented Procedures
-      rules: []
-      status: pending
-    - id: sa-8.30
-      title: Procedural Rigor
-      rules: []
-      status: pending
-    - id: sa-8.31
-      title: Secure System Modification
-      rules: []
-      status: pending
-    - id: sa-8.32
-      title: Sufficient Documentation
-      rules: []
-      status: pending
-    - id: sa-8.33
-      title: Minimization
-      rules: []
-      status: pending
+      controls:
+          - id: sa-8.1
+            title: Clear Abstractions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.2
+            title: Least Common Mechanism
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.3
+            title: Modularity and Layering
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.4
+            title: Partially Ordered Dependencies
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.5
+            title: Efficiently Mediated Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.6
+            title: Minimized Sharing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.7
+            title: Reduced Complexity
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.8
+            title: Secure Evolvability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.9
+            title: Trusted Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.10
+            title: Hierarchical Trust
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.11
+            title: Inverse Modification Threshold
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.12
+            title: Hierarchical Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.13
+            title: Minimized Security Elements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.14
+            title: Least Privilege
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.15
+            title: Predicate Permission
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.16
+            title: Self-reliant Trustworthiness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.17
+            title: Secure Distributed Composition
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.18
+            title: Trusted Communications Channels
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.19
+            title: Continuous Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.20
+            title: Secure Metadata Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.21
+            title: Self-analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.22
+            title: Accountability and Traceability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.23
+            title: Secure Defaults
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.24
+            title: Secure Failure and Recovery
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.25
+            title: Economic Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.26
+            title: Performance Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.27
+            title: Human Factored Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.28
+            title: Acceptable Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.29
+            title: Repeatable and Documented Procedures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.30
+            title: Procedural Rigor
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.31
+            title: Secure System Modification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.32
+            title: Sufficient Documentation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.33
+            title: Minimization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-9
       title: External System Services
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-9.1
-      title: Risk Assessments and Organizational Approvals
-      rules: []
-      status: pending
-    - id: sa-9.2
-      title: Identification of Functions, Ports, Protocols, and Services
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-9.3
-      title: Establish and Maintain Trust Relationship with Providers
-      rules: []
-      status: pending
-    - id: sa-9.4
-      title: Consistent Interests of Consumers and Providers
-      rules: []
-      status: pending
-    - id: sa-9.5
-      title: Processing, Storage, and Service Location
-      rules: []
-      status: pending
-    - id: sa-9.6
-      title: Organization-controlled Cryptographic Keys
-      rules: []
-      status: pending
-    - id: sa-9.7
-      title: Organization-controlled Integrity Checking
-      rules: []
-      status: pending
-    - id: sa-9.8
-      title: Processing and Storage Location — U.S. Jurisdiction
-      rules: []
-      status: pending
+      controls:
+          - id: sa-9.1
+            title: Risk Assessments and Organizational Approvals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.2
+            title: Identification of Functions, Ports, Protocols, and Services
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-9.3
+            title: Establish and Maintain Trust Relationship with Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.4
+            title: Consistent Interests of Consumers and Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.5
+            title: Processing, Storage, and Service Location
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.6
+            title: Organization-controlled Cryptographic Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.7
+            title: Organization-controlled Integrity Checking
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.8
+            title: Processing and Storage Location — U.S. Jurisdiction
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-10
       title: Developer Configuration Management
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-10.1
-      title: Software and Firmware Integrity Verification
-      rules: []
-      status: pending
-    - id: sa-10.2
-      title: Alternative Configuration Management Processes
-      rules: []
-      status: pending
-    - id: sa-10.3
-      title: Hardware Integrity Verification
-      rules: []
-      status: pending
-    - id: sa-10.4
-      title: Trusted Generation
-      rules: []
-      status: pending
-    - id: sa-10.5
-      title: Mapping Integrity for Version Control
-      rules: []
-      status: pending
-    - id: sa-10.6
-      title: Trusted Distribution
-      rules: []
-      status: pending
-    - id: sa-10.7
-      title: Security and Privacy Representatives
-      rules: []
-      status: pending
+      controls:
+          - id: sa-10.1
+            title: Software and Firmware Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.2
+            title: Alternative Configuration Management Processes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.3
+            title: Hardware Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.4
+            title: Trusted Generation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.5
+            title: Mapping Integrity for Version Control
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.6
+            title: Trusted Distribution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.7
+            title: Security and Privacy Representatives
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-11
       title: Developer Testing and Evaluation
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-11.1
-      title: Static Code Analysis
-      rules: []
-      status: pending
-    - id: sa-11.2
-      title: Threat Modeling and Vulnerability Analyses
-      rules: []
-      status: pending
-    - id: sa-11.3
-      title: Independent Verification of Assessment Plans and Evidence
-      rules: []
-      status: pending
-    - id: sa-11.4
-      title: Manual Code Reviews
-      rules: []
-      status: pending
-    - id: sa-11.5
-      title: Penetration Testing
-      rules: []
-      status: pending
-    - id: sa-11.6
-      title: Attack Surface Reviews
-      rules: []
-      status: pending
-    - id: sa-11.7
-      title: Verify Scope of Testing and Evaluation
-      rules: []
-      status: pending
-    - id: sa-11.8
-      title: Dynamic Code Analysis
-      rules: []
-      status: pending
-    - id: sa-11.9
-      title: Interactive Application Security Testing
-      rules: []
-      status: pending
+      controls:
+          - id: sa-11.1
+            title: Static Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.2
+            title: Threat Modeling and Vulnerability Analyses
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.3
+            title: Independent Verification of Assessment Plans and Evidence
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.4
+            title: Manual Code Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.5
+            title: Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.6
+            title: Attack Surface Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.7
+            title: Verify Scope of Testing and Evaluation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.8
+            title: Dynamic Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.9
+            title: Interactive Application Security Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-12
       title: Supply Chain Protection
       rules: []
       status: pending
-    - id: sa-12.1
-      title: Acquisition Strategies / Tools / Methods
-      rules: []
-      status: pending
-    - id: sa-12.2
-      title: Supplier Reviews
-      rules: []
-      status: pending
-    - id: sa-12.3
-      title: Trusted Shipping and Warehousing
-      rules: []
-      status: pending
-    - id: sa-12.4
-      title: Diversity of Suppliers
-      rules: []
-      status: pending
-    - id: sa-12.5
-      title: Limitation of Harm
-      rules: []
-      status: pending
-    - id: sa-12.6
-      title: Minimizing Procurement Time
-      rules: []
-      status: pending
-    - id: sa-12.7
-      title: Assessments Prior to Selection / Acceptance / Update
-      rules: []
-      status: pending
-    - id: sa-12.8
-      title: Use of All-source Intelligence
-      rules: []
-      status: pending
-    - id: sa-12.9
-      title: Operations Security
-      rules: []
-      status: pending
-    - id: sa-12.10
-      title: Validate as Genuine and Not Altered
-      rules: []
-      status: pending
-    - id: sa-12.11
-      title: Penetration Testing / Analysis of Elements, Processes, and Actors
-      rules: []
-      status: pending
-    - id: sa-12.12
-      title: Inter-organizational Agreements
-      rules: []
-      status: pending
-    - id: sa-12.13
-      title: Critical Information System Components
-      rules: []
-      status: pending
-    - id: sa-12.14
-      title: Identity and Traceability
-      rules: []
-      status: pending
-    - id: sa-12.15
-      title: Processes to Address Weaknesses or Deficiencies
-      rules: []
-      status: pending
+      controls:
+          - id: sa-12.1
+            title: Acquisition Strategies / Tools / Methods
+            rules: []
+            status: pending
+          - id: sa-12.2
+            title: Supplier Reviews
+            rules: []
+            status: pending
+          - id: sa-12.3
+            title: Trusted Shipping and Warehousing
+            rules: []
+            status: pending
+          - id: sa-12.4
+            title: Diversity of Suppliers
+            rules: []
+            status: pending
+          - id: sa-12.5
+            title: Limitation of Harm
+            rules: []
+            status: pending
+          - id: sa-12.6
+            title: Minimizing Procurement Time
+            rules: []
+            status: pending
+          - id: sa-12.7
+            title: Assessments Prior to Selection / Acceptance / Update
+            rules: []
+            status: pending
+          - id: sa-12.8
+            title: Use of All-source Intelligence
+            rules: []
+            status: pending
+          - id: sa-12.9
+            title: Operations Security
+            rules: []
+            status: pending
+          - id: sa-12.10
+            title: Validate as Genuine and Not Altered
+            rules: []
+            status: pending
+          - id: sa-12.11
+            title: Penetration Testing / Analysis of Elements, Processes, and
+                Actors
+            rules: []
+            status: pending
+          - id: sa-12.12
+            title: Inter-organizational Agreements
+            rules: []
+            status: pending
+          - id: sa-12.13
+            title: Critical Information System Components
+            rules: []
+            status: pending
+          - id: sa-12.14
+            title: Identity and Traceability
+            rules: []
+            status: pending
+          - id: sa-12.15
+            title: Processes to Address Weaknesses or Deficiencies
+            rules: []
+            status: pending
     - id: sa-13
       title: Trustworthiness
       rules: []
@@ -454,70 +605,96 @@ controls:
       title: Criticality Analysis
       rules: []
       status: pending
-    - id: sa-14.1
-      title: Critical Components with No Viable Alternative Sourcing
-      rules: []
-      status: pending
+      controls:
+          - id: sa-14.1
+            title: Critical Components with No Viable Alternative Sourcing
+            rules: []
+            status: pending
     - id: sa-15
       title: Development Process, Standards, and Tools
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-15.1
-      title: Quality Metrics
-      rules: []
-      status: pending
-    - id: sa-15.2
-      title: Security and Privacy Tracking Tools
-      rules: []
-      status: pending
-    - id: sa-15.3
-      title: Criticality Analysis
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-15.4
-      title: Threat Modeling and Vulnerability Analysis
-      rules: []
-      status: pending
-    - id: sa-15.5
-      title: Attack Surface Reduction
-      rules: []
-      status: pending
-    - id: sa-15.6
-      title: Continuous Improvement
-      rules: []
-      status: pending
-    - id: sa-15.7
-      title: Automated Vulnerability Analysis
-      rules: []
-      status: pending
-    - id: sa-15.8
-      title: Reuse of Threat and Vulnerability Information
-      rules: []
-      status: pending
-    - id: sa-15.9
-      title: Use of Live Data
-      rules: []
-      status: pending
-    - id: sa-15.10
-      title: Incident Response Plan
-      rules: []
-      status: pending
-    - id: sa-15.11
-      title: Archive System or Component
-      rules: []
-      status: pending
-    - id: sa-15.12
-      title: Minimize Personally Identifiable Information
-      rules: []
-      status: pending
-    - id: sa-15.13
-      title: Logging Syntax
-      rules: []
-      status: pending
+      controls:
+          - id: sa-15.1
+            title: Quality Metrics
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.2
+            title: Security and Privacy Tracking Tools
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.3
+            title: Criticality Analysis
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-15.4
+            title: Threat Modeling and Vulnerability Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.5
+            title: Attack Surface Reduction
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.6
+            title: Continuous Improvement
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.7
+            title: Automated Vulnerability Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.8
+            title: Reuse of Threat and Vulnerability Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.9
+            title: Use of Live Data
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.10
+            title: Incident Response Plan
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.11
+            title: Archive System or Component
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.12
+            title: Minimize Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.13
+            title: Logging Syntax
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-16
       title: Developer-provided Training
       levels:
@@ -530,74 +707,95 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sa-17.1
-      title: Formal Policy Model
-      rules: []
-      status: pending
-    - id: sa-17.2
-      title: Security-relevant Components
-      rules: []
-      status: pending
-    - id: sa-17.3
-      title: Formal Correspondence
-      rules: []
-      status: pending
-    - id: sa-17.4
-      title: Informal Correspondence
-      rules: []
-      status: pending
-    - id: sa-17.5
-      title: Conceptually Simple Design
-      rules: []
-      status: pending
-    - id: sa-17.6
-      title: Structure for Testing
-      rules: []
-      status: pending
-    - id: sa-17.7
-      title: Structure for Least Privilege
-      rules: []
-      status: pending
-    - id: sa-17.8
-      title: Orchestration
-      rules: []
-      status: pending
-    - id: sa-17.9
-      title: Design Diversity
-      rules: []
-      status: pending
+      controls:
+          - id: sa-17.1
+            title: Formal Policy Model
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.2
+            title: Security-relevant Components
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.3
+            title: Formal Correspondence
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.4
+            title: Informal Correspondence
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.5
+            title: Conceptually Simple Design
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.6
+            title: Structure for Testing
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.7
+            title: Structure for Least Privilege
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.8
+            title: Orchestration
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.9
+            title: Design Diversity
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sa-18
       title: Tamper Resistance and Detection
       rules: []
       status: pending
-    - id: sa-18.1
-      title: Multiple Phases of System Development Life Cycle
-      rules: []
-      status: pending
-    - id: sa-18.2
-      title: Inspection of Systems or Components
-      rules: []
-      status: pending
+      controls:
+          - id: sa-18.1
+            title: Multiple Phases of System Development Life Cycle
+            rules: []
+            status: pending
+          - id: sa-18.2
+            title: Inspection of Systems or Components
+            rules: []
+            status: pending
     - id: sa-19
       title: Component Authenticity
       rules: []
       status: pending
-    - id: sa-19.1
-      title: Anti-counterfeit Training
-      rules: []
-      status: pending
-    - id: sa-19.2
-      title: Configuration Control for Component Service and Repair
-      rules: []
-      status: pending
-    - id: sa-19.3
-      title: Component Disposal
-      rules: []
-      status: pending
-    - id: sa-19.4
-      title: Anti-counterfeit Scanning
-      rules: []
-      status: pending
+      controls:
+          - id: sa-19.1
+            title: Anti-counterfeit Training
+            rules: []
+            status: pending
+          - id: sa-19.2
+            title: Configuration Control for Component Service and Repair
+            rules: []
+            status: pending
+          - id: sa-19.3
+            title: Component Disposal
+            rules: []
+            status: pending
+          - id: sa-19.4
+            title: Anti-counterfeit Scanning
+            rules: []
+            status: pending
     - id: sa-20
       title: Customized Development of Critical Components
       rules: []
@@ -608,20 +806,26 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sa-21.1
-      title: Validation of Screening
-      rules: []
-      status: pending
+      controls:
+          - id: sa-21.1
+            title: Validation of Screening
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sa-22
       title: Unsupported System Components
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-22.1
-      title: Alternative Sources for Continued Support
-      rules: []
-      status: pending
+      controls:
+          - id: sa-22.1
+            title: Alternative Sources for Continued Support
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-23
       title: Specialization
       rules: []

--- a/products/rhel8/controls/nist_800_53/sc.yml
+++ b/products/rhel8/controls/nist_800_53/sc.yml
@@ -13,14 +13,19 @@ controls:
       rules:
           - sysctl_kernel_dmesg_restrict
       status: automated
-    - id: sc-2.1
-      title: Interfaces for Non-privileged Users
-      rules: []
-      status: pending
-    - id: sc-2.2
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: sc-2.1
+            title: Interfaces for Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-2.2
+            title: Disassociability
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-3
       title: Security Function Isolation
       levels:
@@ -30,26 +35,37 @@ controls:
           - selinux_state
           - var_selinux_state=enforcing
       status: automated
-    - id: sc-3.1
-      title: Hardware Separation
-      rules: []
-      status: pending
-    - id: sc-3.2
-      title: Access and Flow Control Functions
-      rules: []
-      status: pending
-    - id: sc-3.3
-      title: Minimize Nonsecurity Functionality
-      rules: []
-      status: pending
-    - id: sc-3.4
-      title: Module Coupling and Cohesiveness
-      rules: []
-      status: pending
-    - id: sc-3.5
-      title: Layered Structures
-      rules: []
-      status: pending
+      controls:
+          - id: sc-3.1
+            title: Hardware Separation
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.2
+            title: Access and Flow Control Functions
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.3
+            title: Minimize Nonsecurity Functionality
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.4
+            title: Module Coupling and Cohesiveness
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.5
+            title: Layered Structures
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sc-4
       title: Information in Shared System Resources
       levels:
@@ -58,14 +74,19 @@ controls:
           - dir_perms_world_writable_sticky_bits
           - file_permissions_unauthorized_world_writable
       status: automated
-    - id: sc-4.1
-      title: Security Levels
-      rules: []
-      status: pending
-    - id: sc-4.2
-      title: Multilevel or Periods Processing
-      rules: []
-      status: pending
+      controls:
+          - id: sc-4.1
+            title: Security Levels
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-4.2
+            title: Multilevel or Periods Processing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-5
       title: Denial-of-service Protection
       levels:
@@ -73,18 +94,25 @@ controls:
       rules:
           - sysctl_net_ipv4_tcp_syncookies
       status: automated
-    - id: sc-5.1
-      title: Restrict Ability to Attack Other Systems
-      rules: []
-      status: pending
-    - id: sc-5.2
-      title: Capacity, Bandwidth, and Redundancy
-      rules: []
-      status: pending
-    - id: sc-5.3
-      title: Detection and Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: sc-5.1
+            title: Restrict Ability to Attack Other Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-5.2
+            title: Capacity, Bandwidth, and Redundancy
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-5.3
+            title: Detection and Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-6
       title: Resource Availability
       rules: []
@@ -96,136 +124,183 @@ controls:
       rules:
           - service_firewalld_enabled
       status: automated
-    - id: sc-7.1
-      title: Physically Separated Subnetworks
-      rules: []
-      status: pending
-    - id: sc-7.2
-      title: Public Access
-      rules: []
-      status: pending
-    - id: sc-7.3
-      title: Access Points
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.4
-      title: External Telecommunications Services
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.5
-      title: Deny by Default — Allow by Exception
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.6
-      title: Response to Recognized Failures
-      rules: []
-      status: pending
-    - id: sc-7.7
-      title: Split Tunneling for Remote Devices
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.8
-      title: Route Traffic to Authenticated Proxy Servers
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.9
-      title: Restrict Threatening Outgoing Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-7.10
-      title: Prevent Exfiltration
-      rules: []
-      status: pending
-    - id: sc-7.11
-      title: Restrict Incoming Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-7.12
-      title: Host-based Protection
-      rules: []
-      status: pending
-    - id: sc-7.13
-      title: Isolation of Security Tools, Mechanisms, and Support Components
-      rules: []
-      status: pending
-    - id: sc-7.14
-      title: Protect Against Unauthorized Physical Connections
-      rules: []
-      status: pending
-    - id: sc-7.15
-      title: Networked Privileged Accesses
-      rules: []
-      status: pending
-    - id: sc-7.16
-      title: Prevent Discovery of System Components
-      rules: []
-      status: pending
-    - id: sc-7.17
-      title: Automated Enforcement of Protocol Formats
-      rules: []
-      status: pending
-    - id: sc-7.18
-      title: Fail Secure
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-7.19
-      title: Block Communication from Non-organizationally Configured Hosts
-      rules: []
-      status: pending
-    - id: sc-7.20
-      title: Dynamic Isolation and Segregation
-      rules: []
-      status: pending
-    - id: sc-7.21
-      title: Isolation of System Components
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-7.22
-      title: Separate Subnets for Connecting to Different Security Domains
-      rules: []
-      status: pending
-    - id: sc-7.23
-      title: Disable Sender Feedback on Protocol Validation Failure
-      rules: []
-      status: pending
-    - id: sc-7.24
-      title: Personally Identifiable Information
-      rules: []
-      status: pending
-    - id: sc-7.25
-      title: Unclassified National Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.26
-      title: Classified National Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.27
-      title: Unclassified Non-national Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.28
-      title: Connections to Public Networks
-      rules: []
-      status: pending
-    - id: sc-7.29
-      title: Separate Subnets to Isolate Functions
-      rules: []
-      status: pending
+      controls:
+          - id: sc-7.1
+            title: Physically Separated Subnetworks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.2
+            title: Public Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.3
+            title: Access Points
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.4
+            title: External Telecommunications Services
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.5
+            title: Deny by Default — Allow by Exception
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.6
+            title: Response to Recognized Failures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.7
+            title: Split Tunneling for Remote Devices
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.8
+            title: Route Traffic to Authenticated Proxy Servers
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.9
+            title: Restrict Threatening Outgoing Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.10
+            title: Prevent Exfiltration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.11
+            title: Restrict Incoming Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.12
+            title: Host-based Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.13
+            title: Isolation of Security Tools, Mechanisms, and Support
+                Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.14
+            title: Protect Against Unauthorized Physical Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.15
+            title: Networked Privileged Accesses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.16
+            title: Prevent Discovery of System Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.17
+            title: Automated Enforcement of Protocol Formats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.18
+            title: Fail Secure
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-7.19
+            title: Block Communication from Non-organizationally Configured
+                Hosts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.20
+            title: Dynamic Isolation and Segregation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.21
+            title: Isolation of System Components
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-7.22
+            title: Separate Subnets for Connecting to Different Security Domains
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.23
+            title: Disable Sender Feedback on Protocol Validation Failure
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.24
+            title: Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.25
+            title: Unclassified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.26
+            title: Classified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.27
+            title: Unclassified Non-national Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.28
+            title: Connections to Public Networks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.29
+            title: Separate Subnets to Isolate Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-8
       title: Transmission Confidentiality and Integrity
       levels:
@@ -233,28 +308,37 @@ controls:
       rules:
           - configure_custom_crypto_policy_cis
       status: automated
-    - id: sc-8.1
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-8.2
-      title: Pre- and Post-transmission Handling
-      rules: []
-      status: pending
-    - id: sc-8.3
-      title: Cryptographic Protection for Message Externals
-      rules: []
-      status: pending
-    - id: sc-8.4
-      title: Conceal or Randomize Communications
-      rules: []
-      status: pending
-    - id: sc-8.5
-      title: Protected Distribution System
-      rules: []
-      status: pending
+      controls:
+          - id: sc-8.1
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-8.2
+            title: Pre- and Post-transmission Handling
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.3
+            title: Cryptographic Protection for Message Externals
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.4
+            title: Conceal or Randomize Communications
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.5
+            title: Protected Distribution System
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-9
       title: Transmission Confidentiality
       rules: []
@@ -269,64 +353,85 @@ controls:
       title: Trusted Path
       rules: []
       status: pending
-    - id: sc-11.1
-      title: Irrefutable Communications Path
-      rules: []
-      status: pending
+      controls:
+          - id: sc-11.1
+            title: Irrefutable Communications Path
+            rules: []
+            status: pending
     - id: sc-12
       title: Cryptographic Key Establishment and Management
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-12.1
-      title: Availability
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-12.2
-      title: Symmetric Keys
-      rules: []
-      status: pending
-    - id: sc-12.3
-      title: Asymmetric Keys
-      rules: []
-      status: pending
-    - id: sc-12.4
-      title: PKI Certificates
-      rules: []
-      status: pending
-    - id: sc-12.5
-      title: PKI Certificates / Hardware Tokens
-      rules: []
-      status: pending
-    - id: sc-12.6
-      title: Physical Control of Keys
-      rules: []
-      status: pending
+      controls:
+          - id: sc-12.1
+            title: Availability
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-12.2
+            title: Symmetric Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.3
+            title: Asymmetric Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.4
+            title: PKI Certificates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.5
+            title: PKI Certificates / Hardware Tokens
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.6
+            title: Physical Control of Keys
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-13
       title: Cryptographic Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-13.1
-      title: FIPS-validated Cryptography
-      rules: []
-      status: pending
-    - id: sc-13.2
-      title: NSA-approved Cryptography
-      rules: []
-      status: pending
-    - id: sc-13.3
-      title: Individuals Without Formal Access Approvals
-      rules: []
-      status: pending
-    - id: sc-13.4
-      title: Digital Signatures
-      rules: []
-      status: pending
+      controls:
+          - id: sc-13.1
+            title: FIPS-validated Cryptography
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.2
+            title: NSA-approved Cryptography
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.3
+            title: Individuals Without Formal Access Approvals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.4
+            title: Digital Signatures
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-14
       title: Public Access Protections
       rules: []
@@ -337,38 +442,48 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-15.1
-      title: Physical or Logical Disconnect
-      rules: []
-      status: pending
-    - id: sc-15.2
-      title: Blocking Inbound and Outbound Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-15.3
-      title: Disabling and Removal in Secure Work Areas
-      rules: []
-      status: pending
-    - id: sc-15.4
-      title: Explicitly Indicate Current Participants
-      rules: []
-      status: pending
+      controls:
+          - id: sc-15.1
+            title: Physical or Logical Disconnect
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.2
+            title: Blocking Inbound and Outbound Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.3
+            title: Disabling and Removal in Secure Work Areas
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.4
+            title: Explicitly Indicate Current Participants
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-16
       title: Transmission of Security and Privacy Attributes
       rules: []
       status: pending
-    - id: sc-16.1
-      title: Integrity Verification
-      rules: []
-      status: pending
-    - id: sc-16.2
-      title: Anti-spoofing Mechanisms
-      rules: []
-      status: pending
-    - id: sc-16.3
-      title: Cryptographic Binding
-      rules: []
-      status: pending
+      controls:
+          - id: sc-16.1
+            title: Integrity Verification
+            rules: []
+            status: pending
+          - id: sc-16.2
+            title: Anti-spoofing Mechanisms
+            rules: []
+            status: pending
+          - id: sc-16.3
+            title: Cryptographic Binding
+            rules: []
+            status: pending
     - id: sc-17
       title: Public Key Infrastructure Certificates
       levels:
@@ -381,26 +496,37 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-18.1
-      title: Identify Unacceptable Code and Take Corrective Actions
-      rules: []
-      status: pending
-    - id: sc-18.2
-      title: Acquisition, Development, and Use
-      rules: []
-      status: pending
-    - id: sc-18.3
-      title: Prevent Downloading and Execution
-      rules: []
-      status: pending
-    - id: sc-18.4
-      title: Prevent Automatic Execution
-      rules: []
-      status: pending
-    - id: sc-18.5
-      title: Allow Execution Only in Confined Environments
-      rules: []
-      status: pending
+      controls:
+          - id: sc-18.1
+            title: Identify Unacceptable Code and Take Corrective Actions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.2
+            title: Acquisition, Development, and Use
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.3
+            title: Prevent Downloading and Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.4
+            title: Prevent Automatic Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.5
+            title: Allow Execution Only in Confined Environments
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-19
       title: Voice Over Internet Protocol
       rules: []
@@ -411,24 +537,33 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-20.1
-      title: Child Subspaces
-      rules: []
-      status: pending
-    - id: sc-20.2
-      title: Data Origin and Integrity
-      rules: []
-      status: pending
+      controls:
+          - id: sc-20.1
+            title: Child Subspaces
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-20.2
+            title: Data Origin and Integrity
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-21
-      title: Secure Name/Address Resolution Service (Recursive or Caching Resolver)
+      title: Secure Name/Address Resolution Service (Recursive or Caching
+          Resolver)
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-21.1
-      title: Data Origin and Integrity
-      rules: []
-      status: pending
+      controls:
+          - id: sc-21.1
+            title: Data Origin and Integrity
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-22
       title: Architecture and Provisioning for Name/Address Resolution Service
       levels:
@@ -441,26 +576,37 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-23.1
-      title: Invalidate Session Identifiers at Logout
-      rules: []
-      status: pending
-    - id: sc-23.2
-      title: User-initiated Logouts and Message Displays
-      rules: []
-      status: pending
-    - id: sc-23.3
-      title: Unique System-generated Session Identifiers
-      rules: []
-      status: pending
-    - id: sc-23.4
-      title: Unique Session Identifiers with Randomization
-      rules: []
-      status: pending
-    - id: sc-23.5
-      title: Allowed Certificate Authorities
-      rules: []
-      status: pending
+      controls:
+          - id: sc-23.1
+            title: Invalidate Session Identifiers at Logout
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.2
+            title: User-initiated Logouts and Message Displays
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.3
+            title: Unique System-generated Session Identifiers
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.4
+            title: Unique Session Identifiers with Randomization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.5
+            title: Allowed Certificate Authorities
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-24
       title: Fail in Known State
       levels:
@@ -476,10 +622,11 @@ controls:
       title: Decoys
       rules: []
       status: pending
-    - id: sc-26.1
-      title: Detection of Malicious Code
-      rules: []
-      status: pending
+      controls:
+          - id: sc-26.1
+            title: Detection of Malicious Code
+            rules: []
+            status: pending
     - id: sc-27
       title: Platform-independent Applications
       rules: []
@@ -490,76 +637,85 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-28.1
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-28.2
-      title: Offline Storage
-      rules: []
-      status: pending
-    - id: sc-28.3
-      title: Cryptographic Keys
-      rules: []
-      status: pending
+      controls:
+          - id: sc-28.1
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-28.2
+            title: Offline Storage
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-28.3
+            title: Cryptographic Keys
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-29
       title: Heterogeneity
       rules: []
       status: pending
-    - id: sc-29.1
-      title: Virtualization Techniques
-      rules: []
-      status: pending
+      controls:
+          - id: sc-29.1
+            title: Virtualization Techniques
+            rules: []
+            status: pending
     - id: sc-30
       title: Concealment and Misdirection
       rules: []
       status: pending
-    - id: sc-30.1
-      title: Virtualization Techniques
-      rules: []
-      status: pending
-    - id: sc-30.2
-      title: Randomness
-      rules: []
-      status: pending
-    - id: sc-30.3
-      title: Change Processing and Storage Locations
-      rules: []
-      status: pending
-    - id: sc-30.4
-      title: Misleading Information
-      rules: []
-      status: pending
-    - id: sc-30.5
-      title: Concealment of System Components
-      rules: []
-      status: pending
+      controls:
+          - id: sc-30.1
+            title: Virtualization Techniques
+            rules: []
+            status: pending
+          - id: sc-30.2
+            title: Randomness
+            rules: []
+            status: pending
+          - id: sc-30.3
+            title: Change Processing and Storage Locations
+            rules: []
+            status: pending
+          - id: sc-30.4
+            title: Misleading Information
+            rules: []
+            status: pending
+          - id: sc-30.5
+            title: Concealment of System Components
+            rules: []
+            status: pending
     - id: sc-31
       title: Covert Channel Analysis
       rules: []
       status: pending
-    - id: sc-31.1
-      title: Test Covert Channels for Exploitability
-      rules: []
-      status: pending
-    - id: sc-31.2
-      title: Maximum Bandwidth
-      rules: []
-      status: pending
-    - id: sc-31.3
-      title: Measure Bandwidth in Operational Environments
-      rules: []
-      status: pending
+      controls:
+          - id: sc-31.1
+            title: Test Covert Channels for Exploitability
+            rules: []
+            status: pending
+          - id: sc-31.2
+            title: Maximum Bandwidth
+            rules: []
+            status: pending
+          - id: sc-31.3
+            title: Measure Bandwidth in Operational Environments
+            rules: []
+            status: pending
     - id: sc-32
       title: System Partitioning
       rules: []
       status: pending
-    - id: sc-32.1
-      title: Separate Physical Domains for Privileged Functions
-      rules: []
-      status: pending
+      controls:
+          - id: sc-32.1
+            title: Separate Physical Domains for Privileged Functions
+            rules: []
+            status: pending
     - id: sc-33
       title: Transmission Preparation Integrity
       rules: []
@@ -568,18 +724,19 @@ controls:
       title: Non-modifiable Executable Programs
       rules: []
       status: pending
-    - id: sc-34.1
-      title: No Writable Storage
-      rules: []
-      status: pending
-    - id: sc-34.2
-      title: Integrity Protection on Read-only Media
-      rules: []
-      status: pending
-    - id: sc-34.3
-      title: Hardware-based Protection
-      rules: []
-      status: pending
+      controls:
+          - id: sc-34.1
+            title: No Writable Storage
+            rules: []
+            status: pending
+          - id: sc-34.2
+            title: Integrity Protection on Read-only Media
+            rules: []
+            status: pending
+          - id: sc-34.3
+            title: Hardware-based Protection
+            rules: []
+            status: pending
     - id: sc-35
       title: External Malicious Code Identification
       rules: []
@@ -588,22 +745,24 @@ controls:
       title: Distributed Processing and Storage
       rules: []
       status: pending
-    - id: sc-36.1
-      title: Polling Techniques
-      rules: []
-      status: pending
-    - id: sc-36.2
-      title: Synchronization
-      rules: []
-      status: pending
+      controls:
+          - id: sc-36.1
+            title: Polling Techniques
+            rules: []
+            status: pending
+          - id: sc-36.2
+            title: Synchronization
+            rules: []
+            status: pending
     - id: sc-37
       title: Out-of-band Channels
       rules: []
       status: pending
-    - id: sc-37.1
-      title: Ensure Delivery and Transmission
-      rules: []
-      status: pending
+      controls:
+          - id: sc-37.1
+            title: Ensure Delivery and Transmission
+            rules: []
+            status: pending
     - id: sc-38
       title: Operations Security
       rules: []
@@ -614,34 +773,40 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-39.1
-      title: Hardware Separation
-      rules: []
-      status: pending
-    - id: sc-39.2
-      title: Separate Execution Domain Per Thread
-      rules: []
-      status: pending
+      controls:
+          - id: sc-39.1
+            title: Hardware Separation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-39.2
+            title: Separate Execution Domain Per Thread
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-40
       title: Wireless Link Protection
       rules: []
       status: pending
-    - id: sc-40.1
-      title: Electromagnetic Interference
-      rules: []
-      status: pending
-    - id: sc-40.2
-      title: Reduce Detection Potential
-      rules: []
-      status: pending
-    - id: sc-40.3
-      title: Imitative or Manipulative Communications Deception
-      rules: []
-      status: pending
-    - id: sc-40.4
-      title: Signal Parameter Identification
-      rules: []
-      status: pending
+      controls:
+          - id: sc-40.1
+            title: Electromagnetic Interference
+            rules: []
+            status: pending
+          - id: sc-40.2
+            title: Reduce Detection Potential
+            rules: []
+            status: pending
+          - id: sc-40.3
+            title: Imitative or Manipulative Communications Deception
+            rules: []
+            status: pending
+          - id: sc-40.4
+            title: Signal Parameter Identification
+            rules: []
+            status: pending
     - id: sc-41
       title: Port and I/O Device Access
       rules: []
@@ -650,26 +815,27 @@ controls:
       title: Sensor Capability and Data
       rules: []
       status: pending
-    - id: sc-42.1
-      title: Reporting to Authorized Individuals or Roles
-      rules: []
-      status: pending
-    - id: sc-42.2
-      title: Authorized Use
-      rules: []
-      status: pending
-    - id: sc-42.3
-      title: Prohibit Use of Devices
-      rules: []
-      status: pending
-    - id: sc-42.4
-      title: Notice of Collection
-      rules: []
-      status: pending
-    - id: sc-42.5
-      title: Collection Minimization
-      rules: []
-      status: pending
+      controls:
+          - id: sc-42.1
+            title: Reporting to Authorized Individuals or Roles
+            rules: []
+            status: pending
+          - id: sc-42.2
+            title: Authorized Use
+            rules: []
+            status: pending
+          - id: sc-42.3
+            title: Prohibit Use of Devices
+            rules: []
+            status: pending
+          - id: sc-42.4
+            title: Notice of Collection
+            rules: []
+            status: pending
+          - id: sc-42.5
+            title: Collection Minimization
+            rules: []
+            status: pending
     - id: sc-43
       title: Usage Restrictions
       rules: []
@@ -682,14 +848,15 @@ controls:
       title: System Time Synchronization
       rules: []
       status: pending
-    - id: sc-45.1
-      title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
-    - id: sc-45.2
-      title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      controls:
+          - id: sc-45.1
+            title: Synchronization with Authoritative Time Source
+            rules: []
+            status: pending
+          - id: sc-45.2
+            title: Secondary Authoritative Time Source
+            rules: []
+            status: pending
     - id: sc-46
       title: Cross Domain Policy Enforcement
       rules: []
@@ -702,10 +869,11 @@ controls:
       title: Sensor Relocation
       rules: []
       status: pending
-    - id: sc-48.1
-      title: Dynamic Relocation of Sensors or Monitoring Capabilities
-      rules: []
-      status: pending
+      controls:
+          - id: sc-48.1
+            title: Dynamic Relocation of Sensors or Monitoring Capabilities
+            rules: []
+            status: pending
     - id: sc-49
       title: Hardware-enforced Separation and Policy Enforcement
       rules: []

--- a/products/rhel8/controls/nist_800_53/si.yml
+++ b/products/rhel8/controls/nist_800_53/si.yml
@@ -15,36 +15,49 @@ controls:
           - ensure_gpgcheck_never_disabled
           - ensure_redhat_gpgkey_installed
       status: automated
-    - id: si-2.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-2.2
-      title: Automated Flaw Remediation Status
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-2.3
-      title: Time to Remediate Flaws and Benchmarks for Corrective Actions
-      rules: []
-      status: pending
-    - id: si-2.4
-      title: Automated Patch Management Tools
-      rules: []
-      status: pending
-    - id: si-2.5
-      title: Automatic Software and Firmware Updates
-      rules: []
-      status: pending
-    - id: si-2.6
-      title: Removal of Previous Versions of Software and Firmware
-      rules: []
-      status: pending
-    - id: si-2.7
-      title: Root Cause Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-2.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.2
+            title: Automated Flaw Remediation Status
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-2.3
+            title: Time to Remediate Flaws and Benchmarks for Corrective Actions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.4
+            title: Automated Patch Management Tools
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.5
+            title: Automatic Software and Firmware Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.6
+            title: Removal of Previous Versions of Software and Firmware
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.7
+            title: Root Cause Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-3
       title: Malicious Code Protection
       levels:
@@ -53,46 +66,67 @@ controls:
           - kernel_module_usb-storage_disabled
           - service_autofs_disabled
       status: automated
-    - id: si-3.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-3.2
-      title: Automatic Updates
-      rules: []
-      status: pending
-    - id: si-3.3
-      title: Non-privileged Users
-      rules: []
-      status: pending
-    - id: si-3.4
-      title: Updates Only by Privileged Users
-      rules: []
-      status: pending
-    - id: si-3.5
-      title: Portable Storage Devices
-      rules: []
-      status: pending
-    - id: si-3.6
-      title: Testing and Verification
-      rules: []
-      status: pending
-    - id: si-3.7
-      title: Nonsignature-based Detection
-      rules: []
-      status: pending
-    - id: si-3.8
-      title: Detect Unauthorized Commands
-      rules: []
-      status: pending
-    - id: si-3.9
-      title: Authenticate Remote Commands
-      rules: []
-      status: pending
-    - id: si-3.10
-      title: Malicious Code Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-3.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.2
+            title: Automatic Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.3
+            title: Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.4
+            title: Updates Only by Privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.5
+            title: Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.6
+            title: Testing and Verification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.7
+            title: Nonsignature-based Detection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.8
+            title: Detect Unauthorized Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.9
+            title: Authenticate Remote Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.10
+            title: Malicious Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-4
       title: System Monitoring
       levels:
@@ -104,256 +138,329 @@ controls:
           - kernel_module_tipc_disabled
           - service_avahi-daemon_disabled
       status: automated
-    - id: si-4.1
-      title: System-wide Intrusion Detection System
-      rules: []
-      status: pending
-    - id: si-4.2
-      title: Automated Tools and Mechanisms for Real-time Analysis
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.3
-      title: Automated Tool and Mechanism Integration
-      rules: []
-      status: pending
-    - id: si-4.4
-      title: Inbound and Outbound Communications Traffic
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.5
-      title: System-generated Alerts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.6
-      title: Restrict Non-privileged Users
-      rules: []
-      status: pending
-    - id: si-4.7
-      title: Automated Response to Suspicious Events
-      rules: []
-      status: pending
-    - id: si-4.8
-      title: Protection of Monitoring Information
-      rules: []
-      status: pending
-    - id: si-4.9
-      title: Testing of Monitoring Tools and Mechanisms
-      rules: []
-      status: pending
-    - id: si-4.10
-      title: Visibility of Encrypted Communications
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.11
-      title: Analyze Communications Traffic Anomalies
-      rules: []
-      status: pending
-    - id: si-4.12
-      title: Automated Organization-generated Alerts
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.13
-      title: Analyze Traffic and Event Patterns
-      rules: []
-      status: pending
-    - id: si-4.14
-      title: Wireless Intrusion Detection
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.15
-      title: Wireless to Wireline Communications
-      rules: []
-      status: pending
-    - id: si-4.16
-      title: Correlate Monitoring Information
-      rules: []
-      status: pending
-    - id: si-4.17
-      title: Integrated Situational Awareness
-      rules: []
-      status: pending
-    - id: si-4.18
-      title: Analyze Traffic and Covert Exfiltration
-      rules: []
-      status: pending
-    - id: si-4.19
-      title: Risk for Individuals
-      rules: []
-      status: pending
-    - id: si-4.20
-      title: Privileged Users
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.21
-      title: Probationary Periods
-      rules: []
-      status: pending
-    - id: si-4.22
-      title: Unauthorized Network Services
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.23
-      title: Host-based Devices
-      rules: []
-      status: pending
-    - id: si-4.24
-      title: Indicators of Compromise
-      rules: []
-      status: pending
-    - id: si-4.25
-      title: Optimize Network Traffic Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-4.1
+            title: System-wide Intrusion Detection System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.2
+            title: Automated Tools and Mechanisms for Real-time Analysis
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.3
+            title: Automated Tool and Mechanism Integration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.4
+            title: Inbound and Outbound Communications Traffic
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.5
+            title: System-generated Alerts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.6
+            title: Restrict Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.7
+            title: Automated Response to Suspicious Events
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.8
+            title: Protection of Monitoring Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.9
+            title: Testing of Monitoring Tools and Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.10
+            title: Visibility of Encrypted Communications
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.11
+            title: Analyze Communications Traffic Anomalies
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.12
+            title: Automated Organization-generated Alerts
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.13
+            title: Analyze Traffic and Event Patterns
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.14
+            title: Wireless Intrusion Detection
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.15
+            title: Wireless to Wireline Communications
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.16
+            title: Correlate Monitoring Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.17
+            title: Integrated Situational Awareness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.18
+            title: Analyze Traffic and Covert Exfiltration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.19
+            title: Risk for Individuals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.20
+            title: Privileged Users
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.21
+            title: Probationary Periods
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.22
+            title: Unauthorized Network Services
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.23
+            title: Host-based Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.24
+            title: Indicators of Compromise
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.25
+            title: Optimize Network Traffic Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-5
       title: Security Alerts, Advisories, and Directives
       levels:
           - low
       rules: []
       status: pending
-    - id: si-5.1
-      title: Automated Alerts and Advisories
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: si-5.1
+            title: Automated Alerts and Advisories
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: si-6
       title: Security and Privacy Function Verification
       levels:
           - high
       rules: []
       status: pending
-    - id: si-6.1
-      title: Notification of Failed Security Tests
-      rules: []
-      status: pending
-    - id: si-6.2
-      title: Automation Support for Distributed Testing
-      rules: []
-      status: pending
-    - id: si-6.3
-      title: Report Verification Results
-      rules: []
-      status: pending
+      controls:
+          - id: si-6.1
+            title: Notification of Failed Security Tests
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: si-6.2
+            title: Automation Support for Distributed Testing
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: si-6.3
+            title: Report Verification Results
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: si-7
       title: Software, Firmware, and Information Integrity
       levels:
           - moderate
       rules: []
       status: pending
-    - id: si-7.1
-      title: Integrity Checks
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-7.2
-      title: Automated Notifications of Integrity Violations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.3
-      title: Centrally Managed Integrity Tools
-      rules: []
-      status: pending
-    - id: si-7.4
-      title: Tamper-evident Packaging
-      rules: []
-      status: pending
-    - id: si-7.5
-      title: Automated Response to Integrity Violations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.6
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: si-7.7
-      title: Integration of Detection and Response
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-7.8
-      title: Auditing Capability for Significant Events
-      rules: []
-      status: pending
-    - id: si-7.9
-      title: Verify Boot Process
-      rules: []
-      status: pending
-    - id: si-7.10
-      title: Protection of Boot Firmware
-      rules: []
-      status: pending
-    - id: si-7.11
-      title: Confined Environments with Limited Privileges
-      rules: []
-      status: pending
-    - id: si-7.12
-      title: Integrity Verification
-      rules: []
-      status: pending
-    - id: si-7.13
-      title: Code Execution in Protected Environments
-      rules: []
-      status: pending
-    - id: si-7.14
-      title: Binary or Machine Executable Code
-      rules: []
-      status: pending
-    - id: si-7.15
-      title: Code Authentication
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.16
-      title: Time Limit on Process Execution Without Supervision
-      rules: []
-      status: pending
-    - id: si-7.17
-      title: Runtime Application Self-protection
-      rules: []
-      status: pending
+      controls:
+          - id: si-7.1
+            title: Integrity Checks
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-7.2
+            title: Automated Notifications of Integrity Violations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.3
+            title: Centrally Managed Integrity Tools
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.4
+            title: Tamper-evident Packaging
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.5
+            title: Automated Response to Integrity Violations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.6
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.7
+            title: Integration of Detection and Response
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-7.8
+            title: Auditing Capability for Significant Events
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.9
+            title: Verify Boot Process
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.10
+            title: Protection of Boot Firmware
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.11
+            title: Confined Environments with Limited Privileges
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.12
+            title: Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.13
+            title: Code Execution in Protected Environments
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.14
+            title: Binary or Machine Executable Code
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.15
+            title: Code Authentication
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.16
+            title: Time Limit on Process Execution Without Supervision
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.17
+            title: Runtime Application Self-protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-8
       title: Spam Protection
       levels:
           - moderate
       rules: []
       status: pending
-    - id: si-8.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-8.2
-      title: Automatic Updates
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-8.3
-      title: Continuous Learning Capability
-      rules: []
-      status: pending
+      controls:
+          - id: si-8.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-8.2
+            title: Automatic Updates
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-8.3
+            title: Continuous Learning Capability
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-9
       title: Information Input Restrictions
       rules: []
@@ -364,30 +471,43 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: si-10.1
-      title: Manual Override Capability
-      rules: []
-      status: pending
-    - id: si-10.2
-      title: Review and Resolve Errors
-      rules: []
-      status: pending
-    - id: si-10.3
-      title: Predictable Behavior
-      rules: []
-      status: pending
-    - id: si-10.4
-      title: Timing Interactions
-      rules: []
-      status: pending
-    - id: si-10.5
-      title: Restrict Inputs to Trusted Sources and Approved Formats
-      rules: []
-      status: pending
-    - id: si-10.6
-      title: Injection Prevention
-      rules: []
-      status: pending
+      controls:
+          - id: si-10.1
+            title: Manual Override Capability
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.2
+            title: Review and Resolve Errors
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.3
+            title: Predictable Behavior
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.4
+            title: Timing Interactions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.5
+            title: Restrict Inputs to Trusted Sources and Approved Formats
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.6
+            title: Injection Prevention
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-11
       title: Error Handling
       levels:
@@ -400,58 +520,68 @@ controls:
           - low
       rules: []
       status: pending
-    - id: si-12.1
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
-    - id: si-12.2
-      title: Minimize Personally Identifiable Information in Testing, Training, and Research
-      rules: []
-      status: pending
-    - id: si-12.3
-      title: Information Disposal
-      rules: []
-      status: pending
+      controls:
+          - id: si-12.1
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-12.2
+            title: Minimize Personally Identifiable Information in Testing,
+                Training, and Research
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-12.3
+            title: Information Disposal
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-13
       title: Predictable Failure Prevention
       rules: []
       status: pending
-    - id: si-13.1
-      title: Transferring Component Responsibilities
-      rules: []
-      status: pending
-    - id: si-13.2
-      title: Time Limit on Process Execution Without Supervision
-      rules: []
-      status: pending
-    - id: si-13.3
-      title: Manual Transfer Between Components
-      rules: []
-      status: pending
-    - id: si-13.4
-      title: Standby Component Installation and Notification
-      rules: []
-      status: pending
-    - id: si-13.5
-      title: Failover Capability
-      rules: []
-      status: pending
+      controls:
+          - id: si-13.1
+            title: Transferring Component Responsibilities
+            rules: []
+            status: pending
+          - id: si-13.2
+            title: Time Limit on Process Execution Without Supervision
+            rules: []
+            status: pending
+          - id: si-13.3
+            title: Manual Transfer Between Components
+            rules: []
+            status: pending
+          - id: si-13.4
+            title: Standby Component Installation and Notification
+            rules: []
+            status: pending
+          - id: si-13.5
+            title: Failover Capability
+            rules: []
+            status: pending
     - id: si-14
       title: Non-persistence
       rules: []
       status: pending
-    - id: si-14.1
-      title: Refresh from Trusted Sources
-      rules: []
-      status: pending
-    - id: si-14.2
-      title: Non-persistent Information
-      rules: []
-      status: pending
-    - id: si-14.3
-      title: Non-persistent Connectivity
-      rules: []
-      status: pending
+      controls:
+          - id: si-14.1
+            title: Refresh from Trusted Sources
+            rules: []
+            status: pending
+          - id: si-14.2
+            title: Non-persistent Information
+            rules: []
+            status: pending
+          - id: si-14.3
+            title: Non-persistent Connectivity
+            rules: []
+            status: pending
     - id: si-15
       title: Information Output Filtering
       rules: []
@@ -471,62 +601,65 @@ controls:
       title: Personally Identifiable Information Quality Operations
       rules: []
       status: pending
-    - id: si-18.1
-      title: Automation Support
-      rules: []
-      status: pending
-    - id: si-18.2
-      title: Data Tags
-      rules: []
-      status: pending
-    - id: si-18.3
-      title: Collection
-      rules: []
-      status: pending
-    - id: si-18.4
-      title: Individual Requests
-      rules: []
-      status: pending
-    - id: si-18.5
-      title: Notice of Correction or Deletion
-      rules: []
-      status: pending
+      controls:
+          - id: si-18.1
+            title: Automation Support
+            rules: []
+            status: pending
+          - id: si-18.2
+            title: Data Tags
+            rules: []
+            status: pending
+          - id: si-18.3
+            title: Collection
+            rules: []
+            status: pending
+          - id: si-18.4
+            title: Individual Requests
+            rules: []
+            status: pending
+          - id: si-18.5
+            title: Notice of Correction or Deletion
+            rules: []
+            status: pending
     - id: si-19
       title: De-identification
       rules: []
       status: pending
-    - id: si-19.1
-      title: Collection
-      rules: []
-      status: pending
-    - id: si-19.2
-      title: Archiving
-      rules: []
-      status: pending
-    - id: si-19.3
-      title: Release
-      rules: []
-      status: pending
-    - id: si-19.4
-      title: Removal, Masking, Encryption, Hashing, or Replacement of Direct Identifiers
-      rules: []
-      status: pending
-    - id: si-19.5
-      title: Statistical Disclosure Control
-      rules: []
-      status: pending
-    - id: si-19.6
-      title: Differential Privacy
-      rules: []
-      status: pending
-    - id: si-19.7
-      title: Validated Algorithms and Software
-      rules: []
-      status: pending
-    - id: si-19.8
-      title: Motivated Intruder
-      rules: []
-      status: pending
+      controls:
+          - id: si-19.1
+            title: Collection
+            rules: []
+            status: pending
+          - id: si-19.2
+            title: Archiving
+            rules: []
+            status: pending
+          - id: si-19.3
+            title: Release
+            rules: []
+            status: pending
+          - id: si-19.4
+            title: Removal, Masking, Encryption, Hashing, or Replacement of
+                Direct Identifiers
+            rules: []
+            status: pending
+          - id: si-19.5
+            title: Statistical Disclosure Control
+            rules: []
+            status: pending
+          - id: si-19.6
+            title: Differential Privacy
+            rules: []
+            status: pending
+          - id: si-19.7
+            title: Validated Algorithms and Software
+            rules: []
+            status: pending
+          - id: si-19.8
+            title: Motivated Intruder
+            rules: []
+            status: pending
     - id: si-20
       title: Tainting
       rules: []

--- a/products/rhel8/controls/nist_800_53/sr.yml
+++ b/products/rhel8/controls/nist_800_53/sr.yml
@@ -12,74 +12,92 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sr-2.1
-      title: Establish SCRM Team
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: sr-2.1
+            title: Establish SCRM Team
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: sr-3
       title: Supply Chain Controls and Processes
       levels:
           - low
       rules: []
       status: pending
-    - id: sr-3.1
-      title: Diverse Supply Base
-      rules: []
-      status: pending
-    - id: sr-3.2
-      title: Limitation of Harm
-      rules: []
-      status: pending
-    - id: sr-3.3
-      title: Sub-tier Flow Down
-      rules: []
-      status: pending
+      controls:
+          - id: sr-3.1
+            title: Diverse Supply Base
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-3.2
+            title: Limitation of Harm
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-3.3
+            title: Sub-tier Flow Down
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-4
       title: Provenance
       rules: []
       status: pending
-    - id: sr-4.1
-      title: Identity
-      rules: []
-      status: pending
-    - id: sr-4.2
-      title: Track and Trace
-      rules: []
-      status: pending
-    - id: sr-4.3
-      title: Validate as Genuine and Not Altered
-      rules: []
-      status: pending
-    - id: sr-4.4
-      title: Supply Chain Integrity — Pedigree
-      rules: []
-      status: pending
+      controls:
+          - id: sr-4.1
+            title: Identity
+            rules: []
+            status: pending
+          - id: sr-4.2
+            title: Track and Trace
+            rules: []
+            status: pending
+          - id: sr-4.3
+            title: Validate as Genuine and Not Altered
+            rules: []
+            status: pending
+          - id: sr-4.4
+            title: Supply Chain Integrity — Pedigree
+            rules: []
+            status: pending
     - id: sr-5
       title: Acquisition Strategies, Tools, and Methods
       levels:
           - low
       rules: []
       status: pending
-    - id: sr-5.1
-      title: Adequate Supply
-      rules: []
-      status: pending
-    - id: sr-5.2
-      title: Assessments Prior to Selection, Acceptance, Modification, or Update
-      rules: []
-      status: pending
+      controls:
+          - id: sr-5.1
+            title: Adequate Supply
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-5.2
+            title: Assessments Prior to Selection, Acceptance, Modification, or
+                Update
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-6
       title: Supplier Assessments and Reviews
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sr-6.1
-      title: Testing and Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: sr-6.1
+            title: Testing and Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sr-7
       title: Supply Chain Operations Security
       rules: []
@@ -96,12 +114,13 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sr-9.1
-      title: Multiple Stages of System Development Life Cycle
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: sr-9.1
+            title: Multiple Stages of System Development Life Cycle
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: sr-10
       title: Inspection of Systems or Components
       levels:
@@ -114,22 +133,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sr-11.1
-      title: Anti-counterfeit Training
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sr-11.2
-      title: Configuration Control for Component Service and Repair
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sr-11.3
-      title: Anti-counterfeit Scanning
-      rules: []
-      status: pending
+      controls:
+          - id: sr-11.1
+            title: Anti-counterfeit Training
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sr-11.2
+            title: Configuration Control for Component Service and Repair
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sr-11.3
+            title: Anti-counterfeit Scanning
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-12
       title: Component Disposal
       levels:

--- a/products/rhel9/controls/nist_800_53/ac.yml
+++ b/products/rhel9/controls/nist_800_53/ac.yml
@@ -12,80 +12,91 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ac-2.1
-      title: Automated System Account Management
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.2
-      title: Automated Temporary and Emergency Account Management
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.3
-      title: Disable Accounts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.4
-      title: Automated Audit Actions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-2.5
-      title: Inactivity Logout
-      levels:
-          - moderate
-      rules:
-          - accounts_tmout
-          - inactivity_timeout_value=15_minutes
-          - no_invalid_shell_accounts_unlocked
-          - no_password_auth_for_systemaccounts
-          - no_shelllogin_for_systemaccounts
-          - var_accounts_tmout=15_min
-      status: automated
-    - id: ac-2.6
-      title: Dynamic Privilege Management
-      rules: []
-      status: pending
-    - id: ac-2.7
-      title: Privileged User Accounts
-      rules: []
-      status: pending
-    - id: ac-2.8
-      title: Dynamic Account Management
-      rules: []
-      status: pending
-    - id: ac-2.9
-      title: Restrictions on Use of Shared and Group Accounts
-      rules: []
-      status: pending
-    - id: ac-2.10
-      title: Shared and Group Account Credential Change
-      rules: []
-      status: pending
-    - id: ac-2.11
-      title: Usage Conditions
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-2.12
-      title: Account Monitoring for Atypical Usage
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-2.13
-      title: Disable Accounts for High-risk Individuals
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-2.1
+            title: Automated System Account Management
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.2
+            title: Automated Temporary and Emergency Account Management
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.3
+            title: Disable Accounts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.4
+            title: Automated Audit Actions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-2.5
+            title: Inactivity Logout
+            levels:
+                - moderate
+            rules:
+                - accounts_tmout
+                - inactivity_timeout_value=15_minutes
+                - no_invalid_shell_accounts_unlocked
+                - no_password_auth_for_systemaccounts
+                - no_shelllogin_for_systemaccounts
+                - var_accounts_tmout=15_min
+            status: automated
+          - id: ac-2.6
+            title: Dynamic Privilege Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.7
+            title: Privileged User Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.8
+            title: Dynamic Account Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.9
+            title: Restrictions on Use of Shared and Group Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.10
+            title: Shared and Group Account Credential Change
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-2.11
+            title: Usage Conditions
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-2.12
+            title: Account Monitoring for Atypical Usage
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-2.13
+            title: Disable Accounts for High-risk Individuals
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-3
       title: Access Enforcement
       levels:
@@ -214,202 +225,296 @@ controls:
           - var_accounts_user_umask=027
           - var_pam_wheel_group_for_su=cis
       status: automated
-    - id: ac-3.1
-      title: Restricted Access to Privileged Functions
-      rules: []
-      status: pending
-    - id: ac-3.2
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: ac-3.3
-      title: Mandatory Access Control
-      rules: []
-      status: pending
-    - id: ac-3.4
-      title: Discretionary Access Control
-      rules: []
-      status: pending
-    - id: ac-3.5
-      title: Security-relevant Information
-      rules: []
-      status: pending
-    - id: ac-3.6
-      title: Protection of User and System Information
-      rules: []
-      status: pending
-    - id: ac-3.7
-      title: Role-based Access Control
-      rules: []
-      status: pending
-    - id: ac-3.8
-      title: Revocation of Access Authorizations
-      rules: []
-      status: pending
-    - id: ac-3.9
-      title: Controlled Release
-      rules: []
-      status: pending
-    - id: ac-3.10
-      title: Audited Override of Access Control Mechanisms
-      rules: []
-      status: pending
-    - id: ac-3.11
-      title: Restrict Access to Specific Information Types
-      rules: []
-      status: pending
-    - id: ac-3.12
-      title: Assert and Enforce Application Access
-      rules: []
-      status: pending
-    - id: ac-3.13
-      title: Attribute-based Access Control
-      rules: []
-      status: pending
-    - id: ac-3.14
-      title: Individual Access
-      rules: []
-      status: pending
-    - id: ac-3.15
-      title: Discretionary and Mandatory Access Control
-      rules: []
-      status: pending
+      controls:
+          - id: ac-3.1
+            title: Restricted Access to Privileged Functions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.2
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.3
+            title: Mandatory Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.4
+            title: Discretionary Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.5
+            title: Security-relevant Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.6
+            title: Protection of User and System Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.7
+            title: Role-based Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.8
+            title: Revocation of Access Authorizations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.9
+            title: Controlled Release
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.10
+            title: Audited Override of Access Control Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.11
+            title: Restrict Access to Specific Information Types
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.12
+            title: Assert and Enforce Application Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.13
+            title: Attribute-based Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.14
+            title: Individual Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-3.15
+            title: Discretionary and Mandatory Access Control
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-4
       title: Information Flow Enforcement
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-4.1
-      title: Object Security and Privacy Attributes
-      rules: []
-      status: pending
-    - id: ac-4.2
-      title: Processing Domains
-      rules: []
-      status: pending
-    - id: ac-4.3
-      title: Dynamic Information Flow Control
-      rules: []
-      status: pending
-    - id: ac-4.4
-      title: Flow Control of Encrypted Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-4.5
-      title: Embedded Data Types
-      rules: []
-      status: pending
-    - id: ac-4.6
-      title: Metadata
-      rules: []
-      status: pending
-    - id: ac-4.7
-      title: One-way Flow Mechanisms
-      rules: []
-      status: pending
-    - id: ac-4.8
-      title: Security and Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.9
-      title: Human Reviews
-      rules: []
-      status: pending
-    - id: ac-4.10
-      title: Enable and Disable Security or Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.11
-      title: Configuration of Security or Privacy Policy Filters
-      rules: []
-      status: pending
-    - id: ac-4.12
-      title: Data Type Identifiers
-      rules: []
-      status: pending
-    - id: ac-4.13
-      title: Decomposition into Policy-relevant Subcomponents
-      rules: []
-      status: pending
-    - id: ac-4.14
-      title: Security or Privacy Policy Filter Constraints
-      rules: []
-      status: pending
-    - id: ac-4.15
-      title: Detection of Unsanctioned Information
-      rules: []
-      status: pending
-    - id: ac-4.16
-      title: Information Transfers on Interconnected Systems
-      rules: []
-      status: pending
-    - id: ac-4.17
-      title: Domain Authentication
-      rules: []
-      status: pending
-    - id: ac-4.18
-      title: Security Attribute Binding
-      rules: []
-      status: pending
-    - id: ac-4.19
-      title: Validation of Metadata
-      rules: []
-      status: pending
-    - id: ac-4.20
-      title: Approved Solutions
-      rules: []
-      status: pending
-    - id: ac-4.21
-      title: Physical or Logical Separation of Information Flows
-      rules: []
-      status: pending
-    - id: ac-4.22
-      title: Access Only
-      rules: []
-      status: pending
-    - id: ac-4.23
-      title: Modify Non-releasable Information
-      rules: []
-      status: pending
-    - id: ac-4.24
-      title: Internal Normalized Format
-      rules: []
-      status: pending
-    - id: ac-4.25
-      title: Data Sanitization
-      rules: []
-      status: pending
-    - id: ac-4.26
-      title: Audit Filtering Actions
-      rules: []
-      status: pending
-    - id: ac-4.27
-      title: Redundant/Independent Filtering Mechanisms
-      rules: []
-      status: pending
-    - id: ac-4.28
-      title: Linear Filter Pipelines
-      rules: []
-      status: pending
-    - id: ac-4.29
-      title: Filter Orchestration Engines
-      rules: []
-      status: pending
-    - id: ac-4.30
-      title: Filter Mechanisms Using Multiple Processes
-      rules: []
-      status: pending
-    - id: ac-4.31
-      title: Failed Content Transfer Prevention
-      rules: []
-      status: pending
-    - id: ac-4.32
-      title: Process Requirements for Information Transfer
-      rules: []
-      status: pending
+      controls:
+          - id: ac-4.1
+            title: Object Security and Privacy Attributes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.2
+            title: Processing Domains
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.3
+            title: Dynamic Information Flow Control
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.4
+            title: Flow Control of Encrypted Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-4.5
+            title: Embedded Data Types
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.6
+            title: Metadata
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.7
+            title: One-way Flow Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.8
+            title: Security and Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.9
+            title: Human Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.10
+            title: Enable and Disable Security or Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.11
+            title: Configuration of Security or Privacy Policy Filters
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.12
+            title: Data Type Identifiers
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.13
+            title: Decomposition into Policy-relevant Subcomponents
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.14
+            title: Security or Privacy Policy Filter Constraints
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.15
+            title: Detection of Unsanctioned Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.16
+            title: Information Transfers on Interconnected Systems
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.17
+            title: Domain Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.18
+            title: Security Attribute Binding
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.19
+            title: Validation of Metadata
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.20
+            title: Approved Solutions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.21
+            title: Physical or Logical Separation of Information Flows
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.22
+            title: Access Only
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.23
+            title: Modify Non-releasable Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.24
+            title: Internal Normalized Format
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.25
+            title: Data Sanitization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.26
+            title: Audit Filtering Actions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.27
+            title: Redundant/Independent Filtering Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.28
+            title: Linear Filter Pipelines
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.29
+            title: Filter Orchestration Engines
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.30
+            title: Filter Mechanisms Using Multiple Processes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.31
+            title: Failed Content Transfer Prevention
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-4.32
+            title: Process Requirements for Information Transfer
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-5
       title: Separation of Duties
       levels:
@@ -426,61 +531,69 @@ controls:
           - sudo_remove_no_authenticate
           - sudo_remove_nopasswd
       status: automated
-    - id: ac-6.1
-      title: Authorize Access to Security Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.2
-      title: Non-privileged Access for Nonsecurity Functions
-      levels:
-          - moderate
-      rules:
-          - package_sudo_installed
-      status: automated
-    - id: ac-6.3
-      title: Network Access to Privileged Commands
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-6.4
-      title: Separate Processing Domains
-      rules: []
-      status: pending
-    - id: ac-6.5
-      title: Privileged Accounts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.6
-      title: Privileged Access by Non-organizational Users
-      rules: []
-      status: pending
-    - id: ac-6.7
-      title: Review of User Privileges
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.8
-      title: Privilege Levels for Code Execution
-      rules: []
-      status: pending
-    - id: ac-6.9
-      title: Log Use of Privileged Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-6.10
-      title: Prohibit Non-privileged Users from Executing Privileged Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-6.1
+            title: Authorize Access to Security Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.2
+            title: Non-privileged Access for Nonsecurity Functions
+            levels:
+                - moderate
+            rules:
+                - package_sudo_installed
+            status: automated
+          - id: ac-6.3
+            title: Network Access to Privileged Commands
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-6.4
+            title: Separate Processing Domains
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.5
+            title: Privileged Accounts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.6
+            title: Privileged Access by Non-organizational Users
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.7
+            title: Review of User Privileges
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.8
+            title: Privilege Levels for Code Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-6.9
+            title: Log Use of Privileged Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-6.10
+            title: Prohibit Non-privileged Users from Executing Privileged
+                Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-7
       title: Unsuccessful Logon Attempts
       levels:
@@ -496,22 +609,31 @@ controls:
           - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - var_accounts_passwords_pam_faillock_unlock_time=900
       status: automated
-    - id: ac-7.1
-      title: Automatic Account Lock
-      rules: []
-      status: pending
-    - id: ac-7.2
-      title: Purge or Wipe Mobile Device
-      rules: []
-      status: pending
-    - id: ac-7.3
-      title: Biometric Attempt Limiting
-      rules: []
-      status: pending
-    - id: ac-7.4
-      title: Use of Alternate Authentication Factor
-      rules: []
-      status: pending
+      controls:
+          - id: ac-7.1
+            title: Automatic Account Lock
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.2
+            title: Purge or Wipe Mobile Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.3
+            title: Biometric Attempt Limiting
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-7.4
+            title: Use of Alternate Authentication Factor
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-8
       title: System Use Notification
       levels:
@@ -524,22 +646,23 @@ controls:
       title: Previous Logon Notification
       rules: []
       status: pending
-    - id: ac-9.1
-      title: Unsuccessful Logons
-      rules: []
-      status: pending
-    - id: ac-9.2
-      title: Successful and Unsuccessful Logons
-      rules: []
-      status: pending
-    - id: ac-9.3
-      title: Notification of Account Changes
-      rules: []
-      status: pending
-    - id: ac-9.4
-      title: Additional Logon Information
-      rules: []
-      status: pending
+      controls:
+          - id: ac-9.1
+            title: Unsuccessful Logons
+            rules: []
+            status: pending
+          - id: ac-9.2
+            title: Successful and Unsuccessful Logons
+            rules: []
+            status: pending
+          - id: ac-9.3
+            title: Notification of Account Changes
+            rules: []
+            status: pending
+          - id: ac-9.4
+            title: Additional Logon Information
+            rules: []
+            status: pending
     - id: ac-10
       title: Concurrent Session Control
       levels:
@@ -557,30 +680,38 @@ controls:
           - dconf_gnome_session_idle_user_locks
           - var_screensaver_lock_delay=5_seconds
       status: automated
-    - id: ac-11.1
-      title: Pattern-hiding Displays
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-11.1
+            title: Pattern-hiding Displays
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-12
       title: Session Termination
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-12.1
-      title: User-initiated Logouts
-      rules: []
-      status: pending
-    - id: ac-12.2
-      title: Termination Message
-      rules: []
-      status: pending
-    - id: ac-12.3
-      title: Timeout Warning Message
-      rules: []
-      status: pending
+      controls:
+          - id: ac-12.1
+            title: User-initiated Logouts
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-12.2
+            title: Termination Message
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-12.3
+            title: Timeout Warning Message
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-13
       title: Supervision and Review — Access Control
       rules: []
@@ -591,10 +722,13 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ac-14.1
-      title: Necessary Uses
-      rules: []
-      status: pending
+      controls:
+          - id: ac-14.1
+            title: Necessary Uses
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-15
       title: Automated Marking
       rules: []
@@ -603,46 +737,47 @@ controls:
       title: Security and Privacy Attributes
       rules: []
       status: pending
-    - id: ac-16.1
-      title: Dynamic Attribute Association
-      rules: []
-      status: pending
-    - id: ac-16.2
-      title: Attribute Value Changes by Authorized Individuals
-      rules: []
-      status: pending
-    - id: ac-16.3
-      title: Maintenance of Attribute Associations by System
-      rules: []
-      status: pending
-    - id: ac-16.4
-      title: Association of Attributes by Authorized Individuals
-      rules: []
-      status: pending
-    - id: ac-16.5
-      title: Attribute Displays on Objects to Be Output
-      rules: []
-      status: pending
-    - id: ac-16.6
-      title: Maintenance of Attribute Association
-      rules: []
-      status: pending
-    - id: ac-16.7
-      title: Consistent Attribute Interpretation
-      rules: []
-      status: pending
-    - id: ac-16.8
-      title: Association Techniques and Technologies
-      rules: []
-      status: pending
-    - id: ac-16.9
-      title: Attribute Reassignment — Regrading Mechanisms
-      rules: []
-      status: pending
-    - id: ac-16.10
-      title: Attribute Configuration by Authorized Individuals
-      rules: []
-      status: pending
+      controls:
+          - id: ac-16.1
+            title: Dynamic Attribute Association
+            rules: []
+            status: pending
+          - id: ac-16.2
+            title: Attribute Value Changes by Authorized Individuals
+            rules: []
+            status: pending
+          - id: ac-16.3
+            title: Maintenance of Attribute Associations by System
+            rules: []
+            status: pending
+          - id: ac-16.4
+            title: Association of Attributes by Authorized Individuals
+            rules: []
+            status: pending
+          - id: ac-16.5
+            title: Attribute Displays on Objects to Be Output
+            rules: []
+            status: pending
+          - id: ac-16.6
+            title: Maintenance of Attribute Association
+            rules: []
+            status: pending
+          - id: ac-16.7
+            title: Consistent Attribute Interpretation
+            rules: []
+            status: pending
+          - id: ac-16.8
+            title: Association Techniques and Technologies
+            rules: []
+            status: pending
+          - id: ac-16.9
+            title: Attribute Reassignment — Regrading Mechanisms
+            rules: []
+            status: pending
+          - id: ac-16.10
+            title: Attribute Configuration by Authorized Individuals
+            rules: []
+            status: pending
     - id: ac-17
       title: Remote Access
       levels:
@@ -650,54 +785,67 @@ controls:
       rules:
           - configure_custom_crypto_policy_cis
       status: automated
-    - id: ac-17.1
-      title: Monitoring and Control
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.2
-      title: Protection of Confidentiality and Integrity Using Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.3
-      title: Managed Access Control Points
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.4
-      title: Privileged Commands and Access
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-17.5
-      title: Monitoring for Unauthorized Connections
-      rules: []
-      status: pending
-    - id: ac-17.6
-      title: Protection of Mechanism Information
-      rules: []
-      status: pending
-    - id: ac-17.7
-      title: Additional Protection for Security Function Access
-      rules: []
-      status: pending
-    - id: ac-17.8
-      title: Disable Nonsecure Network Protocols
-      rules: []
-      status: pending
-    - id: ac-17.9
-      title: Disconnect or Disable Access
-      rules: []
-      status: pending
-    - id: ac-17.10
-      title: Authenticate Remote Commands
-      rules: []
-      status: pending
+      controls:
+          - id: ac-17.1
+            title: Monitoring and Control
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.2
+            title: Protection of Confidentiality and Integrity Using Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.3
+            title: Managed Access Control Points
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.4
+            title: Privileged Commands and Access
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-17.5
+            title: Monitoring for Unauthorized Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.6
+            title: Protection of Mechanism Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.7
+            title: Additional Protection for Security Function Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.8
+            title: Disable Nonsecure Network Protocols
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.9
+            title: Disconnect or Disable Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-17.10
+            title: Authenticate Remote Commands
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-18
       title: Wireless Access
       levels:
@@ -705,106 +853,130 @@ controls:
       rules:
           - wireless_disable_interfaces
       status: automated
-    - id: ac-18.1
-      title: Authentication and Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-18.2
-      title: Monitoring Unauthorized Connections
-      rules: []
-      status: pending
-    - id: ac-18.3
-      title: Disable Wireless Networking
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-18.4
-      title: Restrict Configurations by Users
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ac-18.5
-      title: Antennas and Transmission Power Levels
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ac-18.1
+            title: Authentication and Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-18.2
+            title: Monitoring Unauthorized Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-18.3
+            title: Disable Wireless Networking
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-18.4
+            title: Restrict Configurations by Users
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ac-18.5
+            title: Antennas and Transmission Power Levels
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ac-19
       title: Access Control for Mobile Devices
       levels:
           - low
       rules: []
       status: pending
-    - id: ac-19.1
-      title: Use of Writable and Portable Storage Devices
-      rules: []
-      status: pending
-    - id: ac-19.2
-      title: Use of Personally Owned Portable Storage Devices
-      rules: []
-      status: pending
-    - id: ac-19.3
-      title: Use of Portable Storage Devices with No Identifiable Owner
-      rules: []
-      status: pending
-    - id: ac-19.4
-      title: Restrictions for Classified Information
-      rules: []
-      status: pending
-    - id: ac-19.5
-      title: Full Device or Container-based Encryption
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ac-19.1
+            title: Use of Writable and Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.2
+            title: Use of Personally Owned Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.3
+            title: Use of Portable Storage Devices with No Identifiable Owner
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.4
+            title: Restrictions for Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-19.5
+            title: Full Device or Container-based Encryption
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ac-20
       title: Use of External Systems
       levels:
           - low
       rules: []
       status: pending
-    - id: ac-20.1
-      title: Limits on Authorized Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-20.2
-      title: Portable Storage Devices — Restricted Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ac-20.3
-      title: Non-organizationally Owned Systems — Restricted Use
-      rules: []
-      status: pending
-    - id: ac-20.4
-      title: Network Accessible Storage Devices — Prohibited Use
-      rules: []
-      status: pending
-    - id: ac-20.5
-      title: Portable Storage Devices — Prohibited Use
-      rules: []
-      status: pending
+      controls:
+          - id: ac-20.1
+            title: Limits on Authorized Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-20.2
+            title: Portable Storage Devices — Restricted Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ac-20.3
+            title: Non-organizationally Owned Systems — Restricted Use
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-20.4
+            title: Network Accessible Storage Devices — Prohibited Use
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ac-20.5
+            title: Portable Storage Devices — Prohibited Use
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ac-21
       title: Information Sharing
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ac-21.1
-      title: Automated Decision Support
-      rules: []
-      status: pending
-    - id: ac-21.2
-      title: Information Search and Retrieval
-      rules: []
-      status: pending
+      controls:
+          - id: ac-21.1
+            title: Automated Decision Support
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ac-21.2
+            title: Information Search and Retrieval
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ac-22
       title: Publicly Accessible Content
       levels:
@@ -819,14 +991,15 @@ controls:
       title: Access Control Decisions
       rules: []
       status: pending
-    - id: ac-24.1
-      title: Transmit Access Authorization Information
-      rules: []
-      status: pending
-    - id: ac-24.2
-      title: No User or Process Identity
-      rules: []
-      status: pending
+      controls:
+          - id: ac-24.1
+            title: Transmit Access Authorization Information
+            rules: []
+            status: pending
+          - id: ac-24.2
+            title: No User or Process Identity
+            rules: []
+            status: pending
     - id: ac-25
       title: Reference Monitor
       rules: []

--- a/products/rhel9/controls/nist_800_53/at.yml
+++ b/products/rhel9/controls/nist_800_53/at.yml
@@ -12,60 +12,80 @@ controls:
           - low
       rules: []
       status: pending
-    - id: at-2.1
-      title: Practical Exercises
-      rules: []
-      status: pending
-    - id: at-2.2
-      title: Insider Threat
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: at-2.3
-      title: Social Engineering and Mining
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: at-2.4
-      title: Suspicious Communications and Anomalous System Behavior
-      rules: []
-      status: pending
-    - id: at-2.5
-      title: Advanced Persistent Threat
-      rules: []
-      status: pending
-    - id: at-2.6
-      title: Cyber Threat Environment
-      rules: []
-      status: pending
+      controls:
+          - id: at-2.1
+            title: Practical Exercises
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.2
+            title: Insider Threat
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: at-2.3
+            title: Social Engineering and Mining
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: at-2.4
+            title: Suspicious Communications and Anomalous System Behavior
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.5
+            title: Advanced Persistent Threat
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-2.6
+            title: Cyber Threat Environment
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: at-3
       title: Role-based Training
       levels:
           - low
       rules: []
       status: pending
-    - id: at-3.1
-      title: Environmental Controls
-      rules: []
-      status: pending
-    - id: at-3.2
-      title: Physical Security Controls
-      rules: []
-      status: pending
-    - id: at-3.3
-      title: Practical Exercises
-      rules: []
-      status: pending
-    - id: at-3.4
-      title: Suspicious Communications and Anomalous System Behavior
-      rules: []
-      status: pending
-    - id: at-3.5
-      title: Processing Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: at-3.1
+            title: Environmental Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.2
+            title: Physical Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.3
+            title: Practical Exercises
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.4
+            title: Suspicious Communications and Anomalous System Behavior
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: at-3.5
+            title: Processing Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: at-4
       title: Training Records
       levels:

--- a/products/rhel9/controls/nist_800_53/au.yml
+++ b/products/rhel9/controls/nist_800_53/au.yml
@@ -35,22 +35,31 @@ controls:
           - var_auditd_admin_space_left_action=cis_rhel9
           - var_auditd_space_left_action=cis_rhel9
       status: automated
-    - id: au-2.1
-      title: Compilation of Audit Records from Multiple Sources
-      rules: []
-      status: pending
-    - id: au-2.2
-      title: Selection of Audit Events by Component
-      rules: []
-      status: pending
-    - id: au-2.3
-      title: Reviews and Updates
-      rules: []
-      status: pending
-    - id: au-2.4
-      title: Privileged Functions
-      rules: []
-      status: pending
+      controls:
+          - id: au-2.1
+            title: Compilation of Audit Records from Multiple Sources
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.2
+            title: Selection of Audit Events by Component
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.3
+            title: Reviews and Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-2.4
+            title: Privileged Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-3
       title: Content of Audit Records
       levels:
@@ -121,20 +130,25 @@ controls:
           - sshd_max_auth_tries_value=4
           - var_multiple_time_servers=rhel
       status: automated
-    - id: au-3.1
-      title: Additional Audit Information
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-3.2
-      title: Centralized Management of Planned Audit Record Content
-      rules: []
-      status: pending
-    - id: au-3.3
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
+      controls:
+          - id: au-3.1
+            title: Additional Audit Information
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-3.2
+            title: Centralized Management of Planned Audit Record Content
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-3.3
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-4
       title: Audit Log Storage Capacity
       levels:
@@ -142,10 +156,13 @@ controls:
       rules:
           - journald_compress
       status: automated
-    - id: au-4.1
-      title: Transfer to Alternate Storage
-      rules: []
-      status: pending
+      controls:
+          - id: au-4.1
+            title: Transfer to Alternate Storage
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-5
       title: Response to Audit Logging Process Failures
       levels:
@@ -157,100 +174,123 @@ controls:
           - var_auditd_disk_error_action=cis_rhel9
           - var_auditd_disk_full_action=cis_rhel9
       status: automated
-    - id: au-5.1
-      title: Storage Capacity Warning
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-5.2
-      title: Real-time Alerts
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-5.3
-      title: Configurable Traffic Volume Thresholds
-      rules: []
-      status: pending
-    - id: au-5.4
-      title: Shutdown on Failure
-      rules: []
-      status: pending
-    - id: au-5.5
-      title: Alternate Audit Logging Capability
-      rules: []
-      status: pending
+      controls:
+          - id: au-5.1
+            title: Storage Capacity Warning
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-5.2
+            title: Real-time Alerts
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-5.3
+            title: Configurable Traffic Volume Thresholds
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-5.4
+            title: Shutdown on Failure
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-5.5
+            title: Alternate Audit Logging Capability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-6
       title: Audit Record Review, Analysis, and Reporting
       levels:
           - low
       rules: []
       status: pending
-    - id: au-6.1
-      title: Automated Process Integration
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-6.2
-      title: Automated Security Alerts
-      rules: []
-      status: pending
-    - id: au-6.3
-      title: Correlate Audit Record Repositories
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-6.4
-      title: Central Review and Analysis
-      rules: []
-      status: pending
-    - id: au-6.5
-      title: Integrated Analysis of Audit Records
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-6.6
-      title: Correlation with Physical Monitoring
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-6.7
-      title: Permitted Actions
-      rules: []
-      status: pending
-    - id: au-6.8
-      title: Full Text Analysis of Privileged Commands
-      rules: []
-      status: pending
-    - id: au-6.9
-      title: Correlation with Information from Nontechnical Sources
-      rules: []
-      status: pending
-    - id: au-6.10
-      title: Audit Level Adjustment
-      rules: []
-      status: pending
+      controls:
+          - id: au-6.1
+            title: Automated Process Integration
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-6.2
+            title: Automated Security Alerts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.3
+            title: Correlate Audit Record Repositories
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-6.4
+            title: Central Review and Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.5
+            title: Integrated Analysis of Audit Records
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-6.6
+            title: Correlation with Physical Monitoring
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-6.7
+            title: Permitted Actions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.8
+            title: Full Text Analysis of Privileged Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.9
+            title: Correlation with Information from Nontechnical Sources
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-6.10
+            title: Audit Level Adjustment
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-7
       title: Audit Record Reduction and Report Generation
       levels:
           - moderate
       rules: []
       status: pending
-    - id: au-7.1
-      title: Automatic Processing
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: au-7.2
-      title: Automatic Sort and Search
-      rules: []
-      status: pending
+      controls:
+          - id: au-7.1
+            title: Automatic Processing
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: au-7.2
+            title: Automatic Sort and Search
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: au-8
       title: Time Stamps
       levels:
@@ -261,14 +301,19 @@ controls:
           - var_auditd_max_log_file=6
           - var_auditd_max_log_file_action=keep_logs
       status: automated
-    - id: au-8.1
-      title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
-    - id: au-8.2
-      title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      controls:
+          - id: au-8.1
+            title: Synchronization with Authoritative Time Source
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-8.2
+            title: Secondary Authoritative Time Source
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-9
       title: Protection of Audit Information
       levels:
@@ -279,79 +324,102 @@ controls:
           - file_ownership_audit_binaries
           - file_ownership_audit_configuration
       status: automated
-    - id: au-9.1
-      title: Hardware Write-once Media
-      rules: []
-      status: pending
-    - id: au-9.2
-      title: Store on Separate Physical Systems or Components
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-9.3
-      title: Cryptographic Protection
-      levels:
-          - high
-      rules:
-          - aide_check_audit_tools
-      status: automated
-    - id: au-9.4
-      title: Access by Subset of Privileged Users
-      levels:
-          - moderate
-      rules:
-          - file_group_ownership_var_log_audit
-          - file_permissions_var_log_audit
-      status: automated
-    - id: au-9.5
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: au-9.6
-      title: Read-only Access
-      rules: []
-      status: pending
-    - id: au-9.7
-      title: Store on Component with Different Operating System
-      rules: []
-      status: pending
+      controls:
+          - id: au-9.1
+            title: Hardware Write-once Media
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.2
+            title: Store on Separate Physical Systems or Components
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-9.3
+            title: Cryptographic Protection
+            levels:
+                - high
+            rules:
+                - aide_check_audit_tools
+            status: automated
+          - id: au-9.4
+            title: Access by Subset of Privileged Users
+            levels:
+                - moderate
+            rules:
+                - file_group_ownership_var_log_audit
+                - file_permissions_var_log_audit
+            status: automated
+          - id: au-9.5
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.6
+            title: Read-only Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-9.7
+            title: Store on Component with Different Operating System
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-10
       title: Non-repudiation
       levels:
           - high
       rules: []
       status: pending
-    - id: au-10.1
-      title: Association of Identities
-      rules: []
-      status: pending
-    - id: au-10.2
-      title: Validate Binding of Information Producer Identity
-      rules: []
-      status: pending
-    - id: au-10.3
-      title: Chain of Custody
-      rules: []
-      status: pending
-    - id: au-10.4
-      title: Validate Binding of Information Reviewer Identity
-      rules: []
-      status: pending
-    - id: au-10.5
-      title: Digital Signatures
-      rules: []
-      status: pending
+      controls:
+          - id: au-10.1
+            title: Association of Identities
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.2
+            title: Validate Binding of Information Producer Identity
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.3
+            title: Chain of Custody
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.4
+            title: Validate Binding of Information Reviewer Identity
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: au-10.5
+            title: Digital Signatures
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: au-11
       title: Audit Record Retention
       levels:
           - low
       rules: []
       status: pending
-    - id: au-11.1
-      title: Long-term Retrieval Capability
-      rules: []
-      status: pending
+      controls:
+          - id: au-11.1
+            title: Long-term Retrieval Capability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-12
       title: Audit Record Generation
       levels:
@@ -404,58 +472,65 @@ controls:
           - grub2_audit_argument
           - service_auditd_enabled
       status: automated
-    - id: au-12.1
-      title: System-wide and Time-correlated Audit Trail
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-12.2
-      title: Standardized Formats
-      rules: []
-      status: pending
-    - id: au-12.3
-      title: Changes by Authorized Individuals
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: au-12.4
-      title: Query Parameter Audits of Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: au-12.1
+            title: System-wide and Time-correlated Audit Trail
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-12.2
+            title: Standardized Formats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: au-12.3
+            title: Changes by Authorized Individuals
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: au-12.4
+            title: Query Parameter Audits of Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: au-13
       title: Monitoring for Information Disclosure
       rules: []
       status: pending
-    - id: au-13.1
-      title: Use of Automated Tools
-      rules: []
-      status: pending
-    - id: au-13.2
-      title: Review of Monitored Sites
-      rules: []
-      status: pending
-    - id: au-13.3
-      title: Unauthorized Replication of Information
-      rules: []
-      status: pending
+      controls:
+          - id: au-13.1
+            title: Use of Automated Tools
+            rules: []
+            status: pending
+          - id: au-13.2
+            title: Review of Monitored Sites
+            rules: []
+            status: pending
+          - id: au-13.3
+            title: Unauthorized Replication of Information
+            rules: []
+            status: pending
     - id: au-14
       title: Session Audit
       rules: []
       status: pending
-    - id: au-14.1
-      title: System Start-up
-      rules: []
-      status: pending
-    - id: au-14.2
-      title: Capture and Record Content
-      rules: []
-      status: pending
-    - id: au-14.3
-      title: Remote Viewing and Listening
-      rules: []
-      status: pending
+      controls:
+          - id: au-14.1
+            title: System Start-up
+            rules: []
+            status: pending
+          - id: au-14.2
+            title: Capture and Record Content
+            rules: []
+            status: pending
+          - id: au-14.3
+            title: Remote Viewing and Listening
+            rules: []
+            status: pending
     - id: au-15
       title: Alternate Audit Logging Capability
       rules: []
@@ -464,15 +539,16 @@ controls:
       title: Cross-organizational Audit Logging
       rules: []
       status: pending
-    - id: au-16.1
-      title: Identity Preservation
-      rules: []
-      status: pending
-    - id: au-16.2
-      title: Sharing of Audit Information
-      rules: []
-      status: pending
-    - id: au-16.3
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: au-16.1
+            title: Identity Preservation
+            rules: []
+            status: pending
+          - id: au-16.2
+            title: Sharing of Audit Information
+            rules: []
+            status: pending
+          - id: au-16.3
+            title: Disassociability
+            rules: []
+            status: pending

--- a/products/rhel9/controls/nist_800_53/ca.yml
+++ b/products/rhel9/controls/nist_800_53/ca.yml
@@ -12,58 +12,74 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ca-2.1
-      title: Independent Assessors
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ca-2.2
-      title: Specialized Assessments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-2.3
-      title: Leveraging Results from External Organizations
-      rules: []
-      status: pending
+      controls:
+          - id: ca-2.1
+            title: Independent Assessors
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ca-2.2
+            title: Specialized Assessments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-2.3
+            title: Leveraging Results from External Organizations
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-3
       title: Information Exchange
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-3.1
-      title: Unclassified National Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.2
-      title: Classified National Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.3
-      title: Unclassified Non-national Security System Connections
-      rules: []
-      status: pending
-    - id: ca-3.4
-      title: Connections to Public Networks
-      rules: []
-      status: pending
-    - id: ca-3.5
-      title: Restrictions on External System Connections
-      rules: []
-      status: pending
-    - id: ca-3.6
-      title: Transfer Authorizations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-3.7
-      title: Transitive Information Exchanges
-      rules: []
-      status: pending
+      controls:
+          - id: ca-3.1
+            title: Unclassified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.2
+            title: Classified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.3
+            title: Unclassified Non-national Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.4
+            title: Connections to Public Networks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.5
+            title: Restrictions on External System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-3.6
+            title: Transfer Authorizations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-3.7
+            title: Transitive Information Exchanges
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-4
       title: Security Certification
       rules: []
@@ -74,78 +90,100 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ca-5.1
-      title: Automation Support for Accuracy and Currency
-      rules: []
-      status: pending
+      controls:
+          - id: ca-5.1
+            title: Automation Support for Accuracy and Currency
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-6
       title: Authorization
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-6.1
-      title: Joint Authorization — Intra-organization
-      rules: []
-      status: pending
-    - id: ca-6.2
-      title: Joint Authorization — Inter-organization
-      rules: []
-      status: pending
+      controls:
+          - id: ca-6.1
+            title: Joint Authorization — Intra-organization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-6.2
+            title: Joint Authorization — Inter-organization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-7
       title: Continuous Monitoring
       levels:
           - low
       rules: []
       status: pending
-    - id: ca-7.1
-      title: Independent Assessment
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ca-7.2
-      title: Types of Assessments
-      rules: []
-      status: pending
-    - id: ca-7.3
-      title: Trend Analyses
-      rules: []
-      status: pending
-    - id: ca-7.4
-      title: Risk Monitoring
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ca-7.5
-      title: Consistency Analysis
-      rules: []
-      status: pending
-    - id: ca-7.6
-      title: Automation Support for Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: ca-7.1
+            title: Independent Assessment
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ca-7.2
+            title: Types of Assessments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.3
+            title: Trend Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.4
+            title: Risk Monitoring
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ca-7.5
+            title: Consistency Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ca-7.6
+            title: Automation Support for Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ca-8
       title: Penetration Testing
       levels:
           - high
       rules: []
       status: pending
-    - id: ca-8.1
-      title: Independent Penetration Testing Agent or Team
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ca-8.2
-      title: Red Team Exercises
-      rules: []
-      status: pending
-    - id: ca-8.3
-      title: Facility Penetration Testing
-      rules: []
-      status: pending
+      controls:
+          - id: ca-8.1
+            title: Independent Penetration Testing Agent or Team
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ca-8.2
+            title: Red Team Exercises
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: ca-8.3
+            title: Facility Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: ca-9
       title: Internal System Connections
       levels:
@@ -156,7 +194,10 @@ controls:
           - package_firewalld_installed
           - package_nftables_installed
       status: automated
-    - id: ca-9.1
-      title: Compliance Checks
-      rules: []
-      status: pending
+      controls:
+          - id: ca-9.1
+            title: Compliance Checks
+            rules: []
+            status: pending
+            levels:
+                - low

--- a/products/rhel9/controls/nist_800_53/cm.yml
+++ b/products/rhel9/controls/nist_800_53/cm.yml
@@ -75,140 +75,173 @@ controls:
           - low
       rules: []
       status: pending
-    - id: cm-2.1
-      title: Reviews and Updates
-      rules: []
-      status: pending
-    - id: cm-2.2
-      title: Automation Support for Accuracy and Currency
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-2.3
-      title: Retention of Previous Configurations
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-2.4
-      title: Unauthorized Software
-      rules: []
-      status: pending
-    - id: cm-2.5
-      title: Authorized Software
-      rules: []
-      status: pending
-    - id: cm-2.6
-      title: Development and Test Environments
-      rules: []
-      status: pending
-    - id: cm-2.7
-      title: Configure Systems and Components for High-risk Areas
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-2.1
+            title: Reviews and Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.2
+            title: Automation Support for Accuracy and Currency
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-2.3
+            title: Retention of Previous Configurations
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-2.4
+            title: Unauthorized Software
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.5
+            title: Authorized Software
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.6
+            title: Development and Test Environments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-2.7
+            title: Configure Systems and Components for High-risk Areas
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-3
       title: Configuration Change Control
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-3.1
-      title: Automated Documentation, Notification, and Prohibition of Changes
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-3.2
-      title: Testing, Validation, and Documentation of Changes
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-3.3
-      title: Automated Change Implementation
-      rules: []
-      status: pending
-    - id: cm-3.4
-      title: Security and Privacy Representatives
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-3.5
-      title: Automated Security Response
-      rules: []
-      status: pending
-    - id: cm-3.6
-      title: Cryptography Management
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-3.7
-      title: Review System Changes
-      rules: []
-      status: pending
-    - id: cm-3.8
-      title: Prevent or Restrict Configuration Changes
-      rules: []
-      status: pending
+      controls:
+          - id: cm-3.1
+            title: Automated Documentation, Notification, and Prohibition of
+                Changes
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-3.2
+            title: Testing, Validation, and Documentation of Changes
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-3.3
+            title: Automated Change Implementation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.4
+            title: Security and Privacy Representatives
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-3.5
+            title: Automated Security Response
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.6
+            title: Cryptography Management
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-3.7
+            title: Review System Changes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cm-3.8
+            title: Prevent or Restrict Configuration Changes
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cm-4
       title: Impact Analyses
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-4.1
-      title: Separate Test Environments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-4.2
-      title: Verification of Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-4.1
+            title: Separate Test Environments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-4.2
+            title: Verification of Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-5
       title: Access Restrictions for Change
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-5.1
-      title: Automated Access Enforcement and Audit Records
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-5.2
-      title: Review System Changes
-      rules: []
-      status: pending
-    - id: cm-5.3
-      title: Signed Components
-      rules: []
-      status: pending
-    - id: cm-5.4
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: cm-5.5
-      title: Privilege Limitation for Production and Operation
-      rules: []
-      status: pending
-    - id: cm-5.6
-      title: Limit Library Privileges
-      rules: []
-      status: pending
-    - id: cm-5.7
-      title: Automatic Implementation of Security Safeguards
-      rules: []
-      status: pending
+      controls:
+          - id: cm-5.1
+            title: Automated Access Enforcement and Audit Records
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-5.2
+            title: Review System Changes
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.3
+            title: Signed Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.4
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.5
+            title: Privilege Limitation for Production and Operation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.6
+            title: Limit Library Privileges
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-5.7
+            title: Automatic Implementation of Security Safeguards
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-6
       title: Configuration Settings
       levels:
@@ -306,26 +339,31 @@ controls:
           - var_authselect_profile=sssd
           - var_sshd_set_login_grace_time=60
       status: automated
-    - id: cm-6.1
-      title: Automated Management, Application, and Verification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-6.2
-      title: Respond to Unauthorized Changes
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-6.3
-      title: Unauthorized Change Detection
-      rules: []
-      status: pending
-    - id: cm-6.4
-      title: Conformance Demonstration
-      rules: []
-      status: pending
+      controls:
+          - id: cm-6.1
+            title: Automated Management, Application, and Verification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-6.2
+            title: Respond to Unauthorized Changes
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-6.3
+            title: Unauthorized Change Detection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-6.4
+            title: Conformance Demonstration
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-7
       title: Least Functionality
       levels:
@@ -383,118 +421,148 @@ controls:
           - wireless_disable_interfaces
           - var_postfix_inet_interfaces=loopback-only
       status: automated
-    - id: cm-7.1
-      title: Periodic Review
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.2
-      title: Prevent Program Execution
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.3
-      title: Registration Compliance
-      rules: []
-      status: pending
-    - id: cm-7.4
-      title: Unauthorized Software — Deny-by-exception
-      rules: []
-      status: pending
-    - id: cm-7.5
-      title: Authorized Software — Allow-by-exception
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-7.6
-      title: Confined Environments with Limited Privileges
-      rules: []
-      status: pending
-    - id: cm-7.7
-      title: Code Execution in Protected Environments
-      rules: []
-      status: pending
-    - id: cm-7.8
-      title: Binary or Machine Executable Code
-      rules: []
-      status: pending
-    - id: cm-7.9
-      title: Prohibiting The Use of Unauthorized Hardware
-      rules: []
-      status: pending
+      controls:
+          - id: cm-7.1
+            title: Periodic Review
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.2
+            title: Prevent Program Execution
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.3
+            title: Registration Compliance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.4
+            title: Unauthorized Software — Deny-by-exception
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.5
+            title: Authorized Software — Allow-by-exception
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-7.6
+            title: Confined Environments with Limited Privileges
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.7
+            title: Code Execution in Protected Environments
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.8
+            title: Binary or Machine Executable Code
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-7.9
+            title: Prohibiting The Use of Unauthorized Hardware
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-8
       title: System Component Inventory
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-8.1
-      title: Updates During Installation and Removal
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-8.2
-      title: Automated Maintenance
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-8.3
-      title: Automated Unauthorized Component Detection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cm-8.4
-      title: Accountability Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cm-8.5
-      title: No Duplicate Accounting of Components
-      rules: []
-      status: pending
-    - id: cm-8.6
-      title: Assessed Configurations and Approved Deviations
-      rules: []
-      status: pending
-    - id: cm-8.7
-      title: Centralized Repository
-      rules: []
-      status: pending
-    - id: cm-8.8
-      title: Automated Location Tracking
-      rules: []
-      status: pending
-    - id: cm-8.9
-      title: Assignment of Components to Systems
-      rules: []
-      status: pending
+      controls:
+          - id: cm-8.1
+            title: Updates During Installation and Removal
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-8.2
+            title: Automated Maintenance
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-8.3
+            title: Automated Unauthorized Component Detection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cm-8.4
+            title: Accountability Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cm-8.5
+            title: No Duplicate Accounting of Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.6
+            title: Assessed Configurations and Approved Deviations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.7
+            title: Centralized Repository
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.8
+            title: Automated Location Tracking
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-8.9
+            title: Assignment of Components to Systems
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-9
       title: Configuration Management Plan
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-9.1
-      title: Assignment of Responsibility
-      rules: []
-      status: pending
+      controls:
+          - id: cm-9.1
+            title: Assignment of Responsibility
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cm-10
       title: Software Usage Restrictions
       levels:
           - low
       rules: []
       status: pending
-    - id: cm-10.1
-      title: Open-source Software
-      rules: []
-      status: pending
+      controls:
+          - id: cm-10.1
+            title: Open-source Software
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-11
       title: User-installed Software
       levels:
@@ -503,30 +571,38 @@ controls:
           - package_xorg-x11-server-common_removed
           - xwindows_runlevel_target
       status: automated
-    - id: cm-11.1
-      title: Alerts for Unauthorized Installations
-      rules: []
-      status: pending
-    - id: cm-11.2
-      title: Software Installation with Privileged Status
-      rules: []
-      status: pending
-    - id: cm-11.3
-      title: Automated Enforcement and Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: cm-11.1
+            title: Alerts for Unauthorized Installations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-11.2
+            title: Software Installation with Privileged Status
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cm-11.3
+            title: Automated Enforcement and Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cm-12
       title: Information Location
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cm-12.1
-      title: Automated Tools to Support Information Location
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cm-12.1
+            title: Automated Tools to Support Information Location
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cm-13
       title: Data Action Mapping
       rules: []

--- a/products/rhel9/controls/nist_800_53/cp.yml
+++ b/products/rhel9/controls/nist_800_53/cp.yml
@@ -12,94 +12,111 @@ controls:
           - low
       rules: []
       status: pending
-    - id: cp-2.1
-      title: Coordinate with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-2.2
-      title: Capacity Planning
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-2.3
-      title: Resume Mission and Business Functions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-2.4
-      title: Resume All Mission and Business Functions
-      rules: []
-      status: pending
-    - id: cp-2.5
-      title: Continue Mission and Business Functions
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-2.6
-      title: Alternate Processing and Storage Sites
-      rules: []
-      status: pending
-    - id: cp-2.7
-      title: Coordinate with External Service Providers
-      rules: []
-      status: pending
-    - id: cp-2.8
-      title: Identify Critical Assets
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-2.1
+            title: Coordinate with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-2.2
+            title: Capacity Planning
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-2.3
+            title: Resume Mission and Business Functions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-2.4
+            title: Resume All Mission and Business Functions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.5
+            title: Continue Mission and Business Functions
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-2.6
+            title: Alternate Processing and Storage Sites
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.7
+            title: Coordinate with External Service Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-2.8
+            title: Identify Critical Assets
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-3
       title: Contingency Training
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-3.1
-      title: Simulated Events
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-3.2
-      title: Mechanisms Used in Training Environments
-      rules: []
-      status: pending
+      controls:
+          - id: cp-3.1
+            title: Simulated Events
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-3.2
+            title: Mechanisms Used in Training Environments
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-4
       title: Contingency Plan Testing
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-4.1
-      title: Coordinate with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-4.2
-      title: Alternate Processing Site
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-4.3
-      title: Automated Testing
-      rules: []
-      status: pending
-    - id: cp-4.4
-      title: Full Recovery and Reconstitution
-      rules: []
-      status: pending
-    - id: cp-4.5
-      title: Self-challenge
-      rules: []
-      status: pending
+      controls:
+          - id: cp-4.1
+            title: Coordinate with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-4.2
+            title: Alternate Processing Site
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-4.3
+            title: Automated Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-4.4
+            title: Full Recovery and Reconstitution
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-4.5
+            title: Self-challenge
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-5
       title: Contingency Plan Update
       rules: []
@@ -110,178 +127,203 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: cp-6.1
-      title: Separation from Primary Site
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-6.2
-      title: Recovery Time and Recovery Point Objectives
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-6.3
-      title: Accessibility
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-6.1
+            title: Separation from Primary Site
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-6.2
+            title: Recovery Time and Recovery Point Objectives
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-6.3
+            title: Accessibility
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-7
       title: Alternate Processing Site
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cp-7.1
-      title: Separation from Primary Site
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.2
-      title: Accessibility
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.3
-      title: Priority of Service
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-7.4
-      title: Preparation for Use
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-7.5
-      title: Equivalent Information Security Safeguards
-      rules: []
-      status: pending
-    - id: cp-7.6
-      title: Inability to Return to Primary Site
-      rules: []
-      status: pending
+      controls:
+          - id: cp-7.1
+            title: Separation from Primary Site
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.2
+            title: Accessibility
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.3
+            title: Priority of Service
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-7.4
+            title: Preparation for Use
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-7.5
+            title: Equivalent Information Security Safeguards
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: cp-7.6
+            title: Inability to Return to Primary Site
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cp-8
       title: Telecommunications Services
       levels:
           - moderate
       rules: []
       status: pending
-    - id: cp-8.1
-      title: Priority of Service Provisions
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-8.2
-      title: Single Points of Failure
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-8.3
-      title: Separation of Primary and Alternate Providers
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-8.4
-      title: Provider Contingency Plan
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-8.5
-      title: Alternate Telecommunication Service Testing
-      rules: []
-      status: pending
+      controls:
+          - id: cp-8.1
+            title: Priority of Service Provisions
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-8.2
+            title: Single Points of Failure
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-8.3
+            title: Separation of Primary and Alternate Providers
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-8.4
+            title: Provider Contingency Plan
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-8.5
+            title: Alternate Telecommunication Service Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: cp-9
       title: System Backup
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-9.1
-      title: Testing for Reliability and Integrity
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-9.2
-      title: Test Restoration Using Sampling
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.3
-      title: Separate Storage for Critical Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.4
-      title: Protection from Unauthorized Modification
-      rules: []
-      status: pending
-    - id: cp-9.5
-      title: Transfer to Alternate Storage Site
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-9.6
-      title: Redundant Secondary System
-      rules: []
-      status: pending
-    - id: cp-9.7
-      title: Dual Authorization for Deletion or Destruction
-      rules: []
-      status: pending
-    - id: cp-9.8
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: cp-9.1
+            title: Testing for Reliability and Integrity
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-9.2
+            title: Test Restoration Using Sampling
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.3
+            title: Separate Storage for Critical Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.4
+            title: Protection from Unauthorized Modification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.5
+            title: Transfer to Alternate Storage Site
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-9.6
+            title: Redundant Secondary System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.7
+            title: Dual Authorization for Deletion or Destruction
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-9.8
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: cp-10
       title: System Recovery and Reconstitution
       levels:
           - low
       rules: []
       status: pending
-    - id: cp-10.1
-      title: Contingency Plan Testing
-      rules: []
-      status: pending
-    - id: cp-10.2
-      title: Transaction Recovery
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: cp-10.3
-      title: Compensating Security Controls
-      rules: []
-      status: pending
-    - id: cp-10.4
-      title: Restore Within Time Period
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: cp-10.5
-      title: Failover Capability
-      rules: []
-      status: pending
-    - id: cp-10.6
-      title: Component Protection
-      rules: []
-      status: pending
+      controls:
+          - id: cp-10.1
+            title: Contingency Plan Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.2
+            title: Transaction Recovery
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: cp-10.3
+            title: Compensating Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.4
+            title: Restore Within Time Period
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: cp-10.5
+            title: Failover Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: cp-10.6
+            title: Component Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: cp-11
       title: Alternate Communications Protocols
       rules: []

--- a/products/rhel9/controls/nist_800_53/ia.yml
+++ b/products/rhel9/controls/nist_800_53/ia.yml
@@ -13,68 +13,85 @@ controls:
       rules:
           - account_unique_id
       status: automated
-    - id: ia-2.1
-      title: Multi-factor Authentication to Privileged Accounts
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.2
-      title: Multi-factor Authentication to Non-privileged Accounts
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.3
-      title: Local Access to Privileged Accounts
-      rules: []
-      status: pending
-    - id: ia-2.4
-      title: Local Access to Non-privileged Accounts
-      rules: []
-      status: pending
-    - id: ia-2.5
-      title: Individual Authentication with Group Authentication
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ia-2.6
-      title: Access to Accounts —separate Device
-      rules: []
-      status: pending
-    - id: ia-2.7
-      title: Network Access to Non-privileged Accounts — Separate Device
-      rules: []
-      status: pending
-    - id: ia-2.8
-      title: Access to Accounts — Replay Resistant
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.9
-      title: Network Access to Non-privileged Accounts — Replay Resistant
-      rules: []
-      status: pending
-    - id: ia-2.10
-      title: Single Sign-on
-      rules: []
-      status: pending
-    - id: ia-2.11
-      title: Remote Access — Separate Device
-      rules: []
-      status: pending
-    - id: ia-2.12
-      title: Acceptance of PIV Credentials
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-2.13
-      title: Out-of-band Authentication
-      rules: []
-      status: pending
+      controls:
+          - id: ia-2.1
+            title: Multi-factor Authentication to Privileged Accounts
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.2
+            title: Multi-factor Authentication to Non-privileged Accounts
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.3
+            title: Local Access to Privileged Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.4
+            title: Local Access to Non-privileged Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.5
+            title: Individual Authentication with Group Authentication
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ia-2.6
+            title: Access to Accounts —separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.7
+            title: Network Access to Non-privileged Accounts — Separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.8
+            title: Access to Accounts — Replay Resistant
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.9
+            title: Network Access to Non-privileged Accounts — Replay Resistant
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.10
+            title: Single Sign-on
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.11
+            title: Remote Access — Separate Device
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-2.12
+            title: Acceptance of PIV Credentials
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-2.13
+            title: Out-of-band Authentication
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-3
       title: Device Identification and Authentication
       levels:
@@ -84,22 +101,31 @@ controls:
           - dconf_gnome_disable_automount_open
           - kernel_module_usb-storage_disabled
       status: automated
-    - id: ia-3.1
-      title: Cryptographic Bidirectional Authentication
-      rules: []
-      status: pending
-    - id: ia-3.2
-      title: Cryptographic Bidirectional Network Authentication
-      rules: []
-      status: pending
-    - id: ia-3.3
-      title: Dynamic Address Allocation
-      rules: []
-      status: pending
-    - id: ia-3.4
-      title: Device Attestation
-      rules: []
-      status: pending
+      controls:
+          - id: ia-3.1
+            title: Cryptographic Bidirectional Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.2
+            title: Cryptographic Bidirectional Network Authentication
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.3
+            title: Dynamic Address Allocation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-3.4
+            title: Device Attestation
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ia-4
       title: Identifier Management
       levels:
@@ -109,44 +135,61 @@ controls:
           - accounts_set_post_pw_existing
           - var_account_disable_post_pw_expiration=45
       status: automated
-    - id: ia-4.1
-      title: Prohibit Account Identifiers as Public Identifiers
-      rules: []
-      status: pending
-    - id: ia-4.2
-      title: Supervisor Authorization
-      rules: []
-      status: pending
-    - id: ia-4.3
-      title: Multiple Forms of Certification
-      rules: []
-      status: pending
-    - id: ia-4.4
-      title: Identify User Status
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-4.5
-      title: Dynamic Management
-      rules: []
-      status: pending
-    - id: ia-4.6
-      title: Cross-organization Management
-      rules: []
-      status: pending
-    - id: ia-4.7
-      title: In-person Registration
-      rules: []
-      status: pending
-    - id: ia-4.8
-      title: Pairwise Pseudonymous Identifiers
-      rules: []
-      status: pending
-    - id: ia-4.9
-      title: Attribute Maintenance and Protection
-      rules: []
-      status: pending
+      controls:
+          - id: ia-4.1
+            title: Prohibit Account Identifiers as Public Identifiers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.2
+            title: Supervisor Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.3
+            title: Multiple Forms of Certification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.4
+            title: Identify User Status
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-4.5
+            title: Dynamic Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.6
+            title: Cross-organization Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.7
+            title: In-person Registration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.8
+            title: Pairwise Pseudonymous Identifiers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-4.9
+            title: Attribute Maintenance and Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-5
       title: Authenticator Management
       levels:
@@ -184,89 +227,120 @@ controls:
           - var_password_pam_minclass=4
           - var_password_pam_minlen=14
       status: automated
-    - id: ia-5.1
-      title: Password-based Authentication
-      levels:
-          - low
-      rules:
-          - accounts_password_pam_pwhistory_remember_password_auth
-          - accounts_password_pam_pwhistory_remember_system_auth
-          - accounts_password_pam_unix_no_remember
-          - var_password_pam_remember=24
-          - var_password_pam_remember_control_flag=requisite_or_required
-      status: automated
-    - id: ia-5.2
-      title: Public Key-based Authentication
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-5.3
-      title: In-person or Trusted External Party Registration
-      rules: []
-      status: pending
-    - id: ia-5.4
-      title: Automated Support for Password Strength Determination
-      rules: []
-      status: pending
-    - id: ia-5.5
-      title: Change Authenticators Prior to Delivery
-      rules: []
-      status: pending
-    - id: ia-5.6
-      title: Protection of Authenticators
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-5.7
-      title: No Embedded Unencrypted Static Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.8
-      title: Multiple System Accounts
-      rules: []
-      status: pending
-    - id: ia-5.9
-      title: Federated Credential Management
-      rules: []
-      status: pending
-    - id: ia-5.10
-      title: Dynamic Credential Binding
-      rules: []
-      status: pending
-    - id: ia-5.11
-      title: Hardware Token-based Authentication
-      rules: []
-      status: pending
-    - id: ia-5.12
-      title: Biometric Authentication Performance
-      rules: []
-      status: pending
-    - id: ia-5.13
-      title: Expiration of Cached Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.14
-      title: Managing Content of PKI Trust Stores
-      rules: []
-      status: pending
-    - id: ia-5.15
-      title: GSA-approved Products and Services
-      rules: []
-      status: pending
-    - id: ia-5.16
-      title: In-person or Trusted External Party Authenticator Issuance
-      rules: []
-      status: pending
-    - id: ia-5.17
-      title: Presentation Attack Detection for Biometric Authenticators
-      rules: []
-      status: pending
-    - id: ia-5.18
-      title: Password Managers
-      rules: []
-      status: pending
+      controls:
+          - id: ia-5.1
+            title: Password-based Authentication
+            levels:
+                - low
+            rules:
+                - accounts_password_pam_pwhistory_remember_password_auth
+                - accounts_password_pam_pwhistory_remember_system_auth
+                - accounts_password_pam_unix_no_remember
+                - var_password_pam_remember=24
+                - var_password_pam_remember_control_flag=requisite_or_required
+            status: automated
+          - id: ia-5.2
+            title: Public Key-based Authentication
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-5.3
+            title: In-person or Trusted External Party Registration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.4
+            title: Automated Support for Password Strength Determination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.5
+            title: Change Authenticators Prior to Delivery
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.6
+            title: Protection of Authenticators
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-5.7
+            title: No Embedded Unencrypted Static Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.8
+            title: Multiple System Accounts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.9
+            title: Federated Credential Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.10
+            title: Dynamic Credential Binding
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.11
+            title: Hardware Token-based Authentication
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.12
+            title: Biometric Authentication Performance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.13
+            title: Expiration of Cached Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.14
+            title: Managing Content of PKI Trust Stores
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.15
+            title: GSA-approved Products and Services
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.16
+            title: In-person or Trusted External Party Authenticator Issuance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.17
+            title: Presentation Attack Detection for Biometric Authenticators
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-5.18
+            title: Password Managers
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-6
       title: Authentication Feedback
       levels:
@@ -285,48 +359,56 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ia-8.1
-      title: Acceptance of PIV Credentials from Other Agencies
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.2
-      title: Acceptance of External Authenticators
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.3
-      title: Use of FICAM-approved Products
-      rules: []
-      status: pending
-    - id: ia-8.4
-      title: Use of Defined Profiles
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ia-8.5
-      title: Acceptance of PIV-I Credentials
-      rules: []
-      status: pending
-    - id: ia-8.6
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: ia-8.1
+            title: Acceptance of PIV Credentials from Other Agencies
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.2
+            title: Acceptance of External Authenticators
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.3
+            title: Use of FICAM-approved Products
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-8.4
+            title: Use of Defined Profiles
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ia-8.5
+            title: Acceptance of PIV-I Credentials
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ia-8.6
+            title: Disassociability
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ia-9
       title: Service Identification and Authentication
       rules: []
       status: pending
-    - id: ia-9.1
-      title: Information Exchange
-      rules: []
-      status: pending
-    - id: ia-9.2
-      title: Transmission of Decisions
-      rules: []
-      status: pending
+      controls:
+          - id: ia-9.1
+            title: Information Exchange
+            rules: []
+            status: pending
+          - id: ia-9.2
+            title: Transmission of Decisions
+            rules: []
+            status: pending
     - id: ia-10
       title: Adaptive Authentication
       rules: []
@@ -345,51 +427,57 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: ia-12.1
-      title: Supervisor Authorization
-      rules: []
-      status: pending
-    - id: ia-12.2
-      title: Identity Evidence
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.3
-      title: Identity Evidence Validation and Verification
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.4
-      title: In-person Validation and Verification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ia-12.5
-      title: Address Confirmation
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ia-12.6
-      title: Accept Externally-proofed Identities
-      rules: []
-      status: pending
+      controls:
+          - id: ia-12.1
+            title: Supervisor Authorization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ia-12.2
+            title: Identity Evidence
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.3
+            title: Identity Evidence Validation and Verification
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.4
+            title: In-person Validation and Verification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ia-12.5
+            title: Address Confirmation
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ia-12.6
+            title: Accept Externally-proofed Identities
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ia-13
       title: Identity Providers and Authorization Servers
       rules: []
       status: pending
-    - id: ia-13.1
-      title: Protection of Cryptographic Keys
-      rules: []
-      status: pending
-    - id: ia-13.2
-      title: Verification of Identity Assertions and Access Tokens
-      rules: []
-      status: pending
-    - id: ia-13.3
-      title: Token Management
-      rules: []
-      status: pending
+      controls:
+          - id: ia-13.1
+            title: Protection of Cryptographic Keys
+            rules: []
+            status: pending
+          - id: ia-13.2
+            title: Verification of Identity Assertions and Access Tokens
+            rules: []
+            status: pending
+          - id: ia-13.3
+            title: Token Management
+            rules: []
+            status: pending

--- a/products/rhel9/controls/nist_800_53/ir.yml
+++ b/products/rhel9/controls/nist_800_53/ir.yml
@@ -12,194 +12,239 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ir-2.1
-      title: Simulated Events
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-2.2
-      title: Automated Training Environments
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-2.3
-      title: Breach
-      rules: []
-      status: pending
+      controls:
+          - id: ir-2.1
+            title: Simulated Events
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-2.2
+            title: Automated Training Environments
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-2.3
+            title: Breach
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-3
       title: Incident Response Testing
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ir-3.1
-      title: Automated Testing
-      rules: []
-      status: pending
-    - id: ir-3.2
-      title: Coordination with Related Plans
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-3.3
-      title: Continuous Improvement
-      rules: []
-      status: pending
+      controls:
+          - id: ir-3.1
+            title: Automated Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ir-3.2
+            title: Coordination with Related Plans
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-3.3
+            title: Continuous Improvement
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ir-4
       title: Incident Handling
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-4.1
-      title: Automated Incident Handling Processes
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-4.2
-      title: Dynamic Reconfiguration
-      rules: []
-      status: pending
-    - id: ir-4.3
-      title: Continuity of Operations
-      rules: []
-      status: pending
-    - id: ir-4.4
-      title: Information Correlation
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-4.5
-      title: Automatic Disabling of System
-      rules: []
-      status: pending
-    - id: ir-4.6
-      title: Insider Threats
-      rules: []
-      status: pending
-    - id: ir-4.7
-      title: Insider Threats — Intra-organization Coordination
-      rules: []
-      status: pending
-    - id: ir-4.8
-      title: Correlation with External Organizations
-      rules: []
-      status: pending
-    - id: ir-4.9
-      title: Dynamic Response Capability
-      rules: []
-      status: pending
-    - id: ir-4.10
-      title: Supply Chain Coordination
-      rules: []
-      status: pending
-    - id: ir-4.11
-      title: Integrated Incident Response Team
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ir-4.12
-      title: Malicious Code and Forensic Analysis
-      rules: []
-      status: pending
-    - id: ir-4.13
-      title: Behavior Analysis
-      rules: []
-      status: pending
-    - id: ir-4.14
-      title: Security Operations Center
-      rules: []
-      status: pending
-    - id: ir-4.15
-      title: Public Relations and Reputation Repair
-      rules: []
-      status: pending
+      controls:
+          - id: ir-4.1
+            title: Automated Incident Handling Processes
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-4.2
+            title: Dynamic Reconfiguration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.3
+            title: Continuity of Operations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.4
+            title: Information Correlation
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-4.5
+            title: Automatic Disabling of System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.6
+            title: Insider Threats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.7
+            title: Insider Threats — Intra-organization Coordination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.8
+            title: Correlation with External Organizations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.9
+            title: Dynamic Response Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.10
+            title: Supply Chain Coordination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.11
+            title: Integrated Incident Response Team
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ir-4.12
+            title: Malicious Code and Forensic Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.13
+            title: Behavior Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.14
+            title: Security Operations Center
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-4.15
+            title: Public Relations and Reputation Repair
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-5
       title: Incident Monitoring
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-5.1
-      title: Automated Tracking, Data Collection, and Analysis
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ir-5.1
+            title: Automated Tracking, Data Collection, and Analysis
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ir-6
       title: Incident Reporting
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-6.1
-      title: Automated Reporting
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-6.2
-      title: Vulnerabilities Related to Incidents
-      rules: []
-      status: pending
-    - id: ir-6.3
-      title: Supply Chain Coordination
-      levels:
-          - moderate
-      rules: []
-      status: pending
+      controls:
+          - id: ir-6.1
+            title: Automated Reporting
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-6.2
+            title: Vulnerabilities Related to Incidents
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ir-6.3
+            title: Supply Chain Coordination
+            levels:
+                - moderate
+            rules: []
+            status: pending
     - id: ir-7
       title: Incident Response Assistance
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-7.1
-      title: Automation Support for Availability of Information and Support
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ir-7.2
-      title: Coordination with External Providers
-      rules: []
-      status: pending
+      controls:
+          - id: ir-7.1
+            title: Automation Support for Availability of Information and
+                Support
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ir-7.2
+            title: Coordination with External Providers
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-8
       title: Incident Response Plan
       levels:
           - low
       rules: []
       status: pending
-    - id: ir-8.1
-      title: Breaches
-      rules: []
-      status: pending
+      controls:
+          - id: ir-8.1
+            title: Breaches
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ir-9
       title: Information Spillage Response
       rules: []
       status: pending
-    - id: ir-9.1
-      title: Responsible Personnel
-      rules: []
-      status: pending
-    - id: ir-9.2
-      title: Training
-      rules: []
-      status: pending
-    - id: ir-9.3
-      title: Post-spill Operations
-      rules: []
-      status: pending
-    - id: ir-9.4
-      title: Exposure to Unauthorized Personnel
-      rules: []
-      status: pending
+      controls:
+          - id: ir-9.1
+            title: Responsible Personnel
+            rules: []
+            status: pending
+          - id: ir-9.2
+            title: Training
+            rules: []
+            status: pending
+          - id: ir-9.3
+            title: Post-spill Operations
+            rules: []
+            status: pending
+          - id: ir-9.4
+            title: Exposure to Unauthorized Personnel
+            rules: []
+            status: pending
     - id: ir-10
       title: Integrated Information Security Analysis Team
       rules: []

--- a/products/rhel9/controls/nist_800_53/ma.yml
+++ b/products/rhel9/controls/nist_800_53/ma.yml
@@ -12,134 +12,173 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ma-2.1
-      title: Record Content
-      rules: []
-      status: pending
-    - id: ma-2.2
-      title: Automated Maintenance Activities
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ma-2.1
+            title: Record Content
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-2.2
+            title: Automated Maintenance Activities
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ma-3
       title: Maintenance Tools
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ma-3.1
-      title: Inspect Tools
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.2
-      title: Inspect Media
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.3
-      title: Prevent Unauthorized Removal
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ma-3.4
-      title: Restricted Tool Use
-      rules: []
-      status: pending
-    - id: ma-3.5
-      title: Execution with Privilege
-      rules: []
-      status: pending
-    - id: ma-3.6
-      title: Software Updates and Patches
-      rules: []
-      status: pending
+      controls:
+          - id: ma-3.1
+            title: Inspect Tools
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.2
+            title: Inspect Media
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.3
+            title: Prevent Unauthorized Removal
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ma-3.4
+            title: Restricted Tool Use
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-3.5
+            title: Execution with Privilege
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-3.6
+            title: Software Updates and Patches
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ma-4
       title: Nonlocal Maintenance
       levels:
           - low
       rules: []
       status: pending
-    - id: ma-4.1
-      title: Logging and Review
-      rules: []
-      status: pending
-    - id: ma-4.2
-      title: Document Nonlocal Maintenance
-      rules: []
-      status: pending
-    - id: ma-4.3
-      title: Comparable Security and Sanitization
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ma-4.4
-      title: Authentication and Separation of Maintenance Sessions
-      rules: []
-      status: pending
-    - id: ma-4.5
-      title: Approvals and Notifications
-      rules: []
-      status: pending
-    - id: ma-4.6
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: ma-4.7
-      title: Disconnect Verification
-      rules: []
-      status: pending
+      controls:
+          - id: ma-4.1
+            title: Logging and Review
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.2
+            title: Document Nonlocal Maintenance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.3
+            title: Comparable Security and Sanitization
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ma-4.4
+            title: Authentication and Separation of Maintenance Sessions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.5
+            title: Approvals and Notifications
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.6
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-4.7
+            title: Disconnect Verification
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ma-5
       title: Maintenance Personnel
       levels:
           - low
       rules: []
       status: pending
-    - id: ma-5.1
-      title: Individuals Without Appropriate Access
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ma-5.2
-      title: Security Clearances for Classified Systems
-      rules: []
-      status: pending
-    - id: ma-5.3
-      title: Citizenship Requirements for Classified Systems
-      rules: []
-      status: pending
-    - id: ma-5.4
-      title: Foreign Nationals
-      rules: []
-      status: pending
-    - id: ma-5.5
-      title: Non-system Maintenance
-      rules: []
-      status: pending
+      controls:
+          - id: ma-5.1
+            title: Individuals Without Appropriate Access
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ma-5.2
+            title: Security Clearances for Classified Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.3
+            title: Citizenship Requirements for Classified Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.4
+            title: Foreign Nationals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ma-5.5
+            title: Non-system Maintenance
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ma-6
       title: Timely Maintenance
       levels:
           - moderate
       rules: []
       status: pending
-    - id: ma-6.1
-      title: Preventive Maintenance
-      rules: []
-      status: pending
-    - id: ma-6.2
-      title: Predictive Maintenance
-      rules: []
-      status: pending
-    - id: ma-6.3
-      title: Automated Support for Predictive Maintenance
-      rules: []
-      status: pending
+      controls:
+          - id: ma-6.1
+            title: Preventive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-6.2
+            title: Predictive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: ma-6.3
+            title: Automated Support for Predictive Maintenance
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: ma-7
       title: Field Maintenance
       rules: []

--- a/products/rhel9/controls/nist_800_53/mp.yml
+++ b/products/rhel9/controls/nist_800_53/mp.yml
@@ -12,14 +12,19 @@ controls:
           - low
       rules: []
       status: pending
-    - id: mp-2.1
-      title: Automated Restricted Access
-      rules: []
-      status: pending
-    - id: mp-2.2
-      title: Cryptographic Protection
-      rules: []
-      status: pending
+      controls:
+          - id: mp-2.1
+            title: Automated Restricted Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-2.2
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-3
       title: Media Marking
       levels:
@@ -32,111 +37,142 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: mp-4.1
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: mp-4.2
-      title: Automated Restricted Access
-      rules: []
-      status: pending
+      controls:
+          - id: mp-4.1
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-4.2
+            title: Automated Restricted Access
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: mp-5
       title: Media Transport
       levels:
           - moderate
       rules: []
       status: pending
-    - id: mp-5.1
-      title: Protection Outside of Controlled Areas
-      rules: []
-      status: pending
-    - id: mp-5.2
-      title: Documentation of Activities
-      rules: []
-      status: pending
-    - id: mp-5.3
-      title: Custodians
-      rules: []
-      status: pending
-    - id: mp-5.4
-      title: Cryptographic Protection
-      rules: []
-      status: pending
+      controls:
+          - id: mp-5.1
+            title: Protection Outside of Controlled Areas
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.2
+            title: Documentation of Activities
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.3
+            title: Custodians
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: mp-5.4
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: mp-6
       title: Media Sanitization
       levels:
           - low
       rules: []
       status: pending
-    - id: mp-6.1
-      title: Review, Approve, Track, Document, and Verify
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.2
-      title: Equipment Testing
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.3
-      title: Nondestructive Techniques
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: mp-6.4
-      title: Controlled Unclassified Information
-      rules: []
-      status: pending
-    - id: mp-6.5
-      title: Classified Information
-      rules: []
-      status: pending
-    - id: mp-6.6
-      title: Media Destruction
-      rules: []
-      status: pending
-    - id: mp-6.7
-      title: Dual Authorization
-      rules: []
-      status: pending
-    - id: mp-6.8
-      title: Remote Purging or Wiping of Information
-      rules: []
-      status: pending
+      controls:
+          - id: mp-6.1
+            title: Review, Approve, Track, Document, and Verify
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.2
+            title: Equipment Testing
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.3
+            title: Nondestructive Techniques
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: mp-6.4
+            title: Controlled Unclassified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.5
+            title: Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.6
+            title: Media Destruction
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.7
+            title: Dual Authorization
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-6.8
+            title: Remote Purging or Wiping of Information
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-7
       title: Media Use
       levels:
           - low
       rules: []
       status: pending
-    - id: mp-7.1
-      title: Prohibit Use Without Owner
-      rules: []
-      status: pending
-    - id: mp-7.2
-      title: Prohibit Use of Sanitization-resistant Media
-      rules: []
-      status: pending
+      controls:
+          - id: mp-7.1
+            title: Prohibit Use Without Owner
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: mp-7.2
+            title: Prohibit Use of Sanitization-resistant Media
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: mp-8
       title: Media Downgrading
       rules: []
       status: pending
-    - id: mp-8.1
-      title: Documentation of Process
-      rules: []
-      status: pending
-    - id: mp-8.2
-      title: Equipment Testing
-      rules: []
-      status: pending
-    - id: mp-8.3
-      title: Controlled Unclassified Information
-      rules: []
-      status: pending
-    - id: mp-8.4
-      title: Classified Information
-      rules: []
-      status: pending
+      controls:
+          - id: mp-8.1
+            title: Documentation of Process
+            rules: []
+            status: pending
+          - id: mp-8.2
+            title: Equipment Testing
+            rules: []
+            status: pending
+          - id: mp-8.3
+            title: Controlled Unclassified Information
+            rules: []
+            status: pending
+          - id: mp-8.4
+            title: Classified Information
+            rules: []
+            status: pending

--- a/products/rhel9/controls/nist_800_53/pe.yml
+++ b/products/rhel9/controls/nist_800_53/pe.yml
@@ -12,58 +12,80 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pe-2.1
-      title: Access by Position or Role
-      rules: []
-      status: pending
-    - id: pe-2.2
-      title: Two Forms of Identification
-      rules: []
-      status: pending
-    - id: pe-2.3
-      title: Restrict Unescorted Access
-      rules: []
-      status: pending
+      controls:
+          - id: pe-2.1
+            title: Access by Position or Role
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-2.2
+            title: Two Forms of Identification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-2.3
+            title: Restrict Unescorted Access
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-3
       title: Physical Access Control
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-3.1
-      title: System Access
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-3.2
-      title: Facility and Systems
-      rules: []
-      status: pending
-    - id: pe-3.3
-      title: Continuous Guards
-      rules: []
-      status: pending
-    - id: pe-3.4
-      title: Lockable Casings
-      rules: []
-      status: pending
-    - id: pe-3.5
-      title: Tamper Protection
-      rules: []
-      status: pending
-    - id: pe-3.6
-      title: Facility Penetration Testing
-      rules: []
-      status: pending
-    - id: pe-3.7
-      title: Physical Barriers
-      rules: []
-      status: pending
-    - id: pe-3.8
-      title: Access Control Vestibules
-      rules: []
-      status: pending
+      controls:
+          - id: pe-3.1
+            title: System Access
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-3.2
+            title: Facility and Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.3
+            title: Continuous Guards
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.4
+            title: Lockable Casings
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.5
+            title: Tamper Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.6
+            title: Facility Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.7
+            title: Physical Barriers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-3.8
+            title: Access Control Vestibules
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-4
       title: Access Control for Transmission
       levels:
@@ -76,44 +98,56 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: pe-5.1
-      title: Access to Output by Authorized Individuals
-      rules: []
-      status: pending
-    - id: pe-5.2
-      title: Link to Individual Identity
-      rules: []
-      status: pending
-    - id: pe-5.3
-      title: Marking Output Devices
-      rules: []
-      status: pending
+      controls:
+          - id: pe-5.1
+            title: Access to Output by Authorized Individuals
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-5.2
+            title: Link to Individual Identity
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-5.3
+            title: Marking Output Devices
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-6
       title: Monitoring Physical Access
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-6.1
-      title: Intrusion Alarms and Surveillance Equipment
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: pe-6.2
-      title: Automated Intrusion Recognition and Responses
-      rules: []
-      status: pending
-    - id: pe-6.3
-      title: Video Surveillance
-      rules: []
-      status: pending
-    - id: pe-6.4
-      title: Monitoring Physical Access to Systems
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: pe-6.1
+            title: Intrusion Alarms and Surveillance Equipment
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: pe-6.2
+            title: Automated Intrusion Recognition and Responses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-6.3
+            title: Video Surveillance
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-6.4
+            title: Monitoring Physical Access to Systems
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: pe-7
       title: Visitor Control
       rules: []
@@ -124,122 +158,152 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pe-8.1
-      title: Automated Records Maintenance and Review
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-8.2
-      title: Physical Access Records
-      rules: []
-      status: pending
-    - id: pe-8.3
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
+      controls:
+          - id: pe-8.1
+            title: Automated Records Maintenance and Review
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-8.2
+            title: Physical Access Records
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-8.3
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-9
       title: Power Equipment and Cabling
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-9.1
-      title: Redundant Cabling
-      rules: []
-      status: pending
-    - id: pe-9.2
-      title: Automatic Voltage Controls
-      rules: []
-      status: pending
+      controls:
+          - id: pe-9.1
+            title: Redundant Cabling
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pe-9.2
+            title: Automatic Voltage Controls
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-10
       title: Emergency Shutoff
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-10.1
-      title: Accidental and Unauthorized Activation
-      rules: []
-      status: pending
+      controls:
+          - id: pe-10.1
+            title: Accidental and Unauthorized Activation
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-11
       title: Emergency Power
       levels:
           - moderate
       rules: []
       status: pending
-    - id: pe-11.1
-      title: Alternate Power Supply — Minimal Operational Capability
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-11.2
-      title: Alternate Power Supply — Self-contained
-      rules: []
-      status: pending
+      controls:
+          - id: pe-11.1
+            title: Alternate Power Supply — Minimal Operational Capability
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-11.2
+            title: Alternate Power Supply — Self-contained
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pe-12
       title: Emergency Lighting
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-12.1
-      title: Essential Mission and Business Functions
-      rules: []
-      status: pending
+      controls:
+          - id: pe-12.1
+            title: Essential Mission and Business Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-13
       title: Fire Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-13.1
-      title: Detection Systems — Automatic Activation and Notification
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: pe-13.2
-      title: Suppression Systems — Automatic Activation and Notification
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: pe-13.3
-      title: Automatic Fire Suppression
-      rules: []
-      status: pending
-    - id: pe-13.4
-      title: Inspections
-      rules: []
-      status: pending
+      controls:
+          - id: pe-13.1
+            title: Detection Systems — Automatic Activation and Notification
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: pe-13.2
+            title: Suppression Systems — Automatic Activation and Notification
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: pe-13.3
+            title: Automatic Fire Suppression
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-13.4
+            title: Inspections
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-14
       title: Environmental Controls
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-14.1
-      title: Automatic Controls
-      rules: []
-      status: pending
-    - id: pe-14.2
-      title: Monitoring with Alarms and Notifications
-      rules: []
-      status: pending
+      controls:
+          - id: pe-14.1
+            title: Automatic Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pe-14.2
+            title: Monitoring with Alarms and Notifications
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pe-15
       title: Water Damage Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: pe-15.1
-      title: Automation Support
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: pe-15.1
+            title: Automation Support
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: pe-16
       title: Delivery and Removal
       levels:
@@ -258,18 +322,22 @@ controls:
           - high
       rules: []
       status: pending
-    - id: pe-18.1
-      title: Facility Site
-      rules: []
-      status: pending
+      controls:
+          - id: pe-18.1
+            title: Facility Site
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: pe-19
       title: Information Leakage
       rules: []
       status: pending
-    - id: pe-19.1
-      title: National Emissions Policies and Procedures
-      rules: []
-      status: pending
+      controls:
+          - id: pe-19.1
+            title: National Emissions Policies and Procedures
+            rules: []
+            status: pending
     - id: pe-20
       title: Asset Monitoring and Tracking
       rules: []

--- a/products/rhel9/controls/nist_800_53/pl.yml
+++ b/products/rhel9/controls/nist_800_53/pl.yml
@@ -12,18 +12,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pl-2.1
-      title: Concept of Operations
-      rules: []
-      status: pending
-    - id: pl-2.2
-      title: Functional Architecture
-      rules: []
-      status: pending
-    - id: pl-2.3
-      title: Plan and Coordinate with Other Organizational Entities
-      rules: []
-      status: pending
+      controls:
+          - id: pl-2.1
+            title: Concept of Operations
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pl-2.2
+            title: Functional Architecture
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: pl-2.3
+            title: Plan and Coordinate with Other Organizational Entities
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: pl-3
       title: System Security Plan Update
       rules: []
@@ -34,12 +41,13 @@ controls:
           - low
       rules: []
       status: pending
-    - id: pl-4.1
-      title: Social Media and External Site/Application Usage Restrictions
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: pl-4.1
+            title: Social Media and External Site/Application Usage Restrictions
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: pl-5
       title: Privacy Impact Assessment
       rules: []
@@ -58,14 +66,19 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: pl-8.1
-      title: Defense in Depth
-      rules: []
-      status: pending
-    - id: pl-8.2
-      title: Supplier Diversity
-      rules: []
-      status: pending
+      controls:
+          - id: pl-8.1
+            title: Defense in Depth
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: pl-8.2
+            title: Supplier Diversity
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: pl-9
       title: Central Management
       rules: []

--- a/products/rhel9/controls/nist_800_53/pm.yml
+++ b/products/rhel9/controls/nist_800_53/pm.yml
@@ -20,10 +20,11 @@ controls:
       title: System Inventory
       rules: []
       status: pending
-    - id: pm-5.1
-      title: Inventory of Personally Identifiable Information
-      rules: []
-      status: pending
+      controls:
+          - id: pm-5.1
+            title: Inventory of Personally Identifiable Information
+            rules: []
+            status: pending
     - id: pm-6
       title: Measures of Performance
       rules: []
@@ -32,10 +33,11 @@ controls:
       title: Enterprise Architecture
       rules: []
       status: pending
-    - id: pm-7.1
-      title: Offloading
-      rules: []
-      status: pending
+      controls:
+          - id: pm-7.1
+            title: Offloading
+            rules: []
+            status: pending
     - id: pm-8
       title: Critical Infrastructure Plan
       rules: []
@@ -72,10 +74,11 @@ controls:
       title: Threat Awareness Program
       rules: []
       status: pending
-    - id: pm-16.1
-      title: Automated Means for Sharing Threat Intelligence
-      rules: []
-      status: pending
+      controls:
+          - id: pm-16.1
+            title: Automated Means for Sharing Threat Intelligence
+            rules: []
+            status: pending
     - id: pm-17
       title: Protecting Controlled Unclassified Information on External Systems
       rules: []
@@ -92,10 +95,12 @@ controls:
       title: Dissemination of Privacy Program Information
       rules: []
       status: pending
-    - id: pm-20.1
-      title: Privacy Policies on Websites, Applications, and Digital Services
-      rules: []
-      status: pending
+      controls:
+          - id: pm-20.1
+            title: Privacy Policies on Websites, Applications, and Digital
+                Services
+            rules: []
+            status: pending
     - id: pm-21
       title: Accounting of Disclosures
       rules: []
@@ -113,8 +118,8 @@ controls:
       rules: []
       status: pending
     - id: pm-25
-      title: Minimization of Personally Identifiable Information Used in Testing, Training, and
-          Research
+      title: Minimization of Personally Identifiable Information Used in
+          Testing, Training, and Research
       rules: []
       status: pending
     - id: pm-26
@@ -137,10 +142,11 @@ controls:
       title: Supply Chain Risk Management Strategy
       rules: []
       status: pending
-    - id: pm-30.1
-      title: Suppliers of Critical or Mission-essential Items
-      rules: []
-      status: pending
+      controls:
+          - id: pm-30.1
+            title: Suppliers of Critical or Mission-essential Items
+            rules: []
+            status: pending
     - id: pm-31
       title: Continuous Monitoring Strategy
       rules: []

--- a/products/rhel9/controls/nist_800_53/ps.yml
+++ b/products/rhel9/controls/nist_800_53/ps.yml
@@ -18,38 +18,50 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ps-3.1
-      title: Classified Information
-      rules: []
-      status: pending
-    - id: ps-3.2
-      title: Formal Indoctrination
-      rules: []
-      status: pending
-    - id: ps-3.3
-      title: Information Requiring Special Protective Measures
-      rules: []
-      status: pending
-    - id: ps-3.4
-      title: Citizenship Requirements
-      rules: []
-      status: pending
+      controls:
+          - id: ps-3.1
+            title: Classified Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.2
+            title: Formal Indoctrination
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.3
+            title: Information Requiring Special Protective Measures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-3.4
+            title: Citizenship Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ps-4
       title: Personnel Termination
       levels:
           - low
       rules: []
       status: pending
-    - id: ps-4.1
-      title: Post-employment Requirements
-      rules: []
-      status: pending
-    - id: ps-4.2
-      title: Automated Actions
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: ps-4.1
+            title: Post-employment Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-4.2
+            title: Automated Actions
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: ps-5
       title: Personnel Transfer
       levels:
@@ -62,18 +74,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ps-6.1
-      title: Information Requiring Special Protection
-      rules: []
-      status: pending
-    - id: ps-6.2
-      title: Classified Information Requiring Special Protection
-      rules: []
-      status: pending
-    - id: ps-6.3
-      title: Post-employment Requirements
-      rules: []
-      status: pending
+      controls:
+          - id: ps-6.1
+            title: Information Requiring Special Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-6.2
+            title: Classified Information Requiring Special Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ps-6.3
+            title: Post-employment Requirements
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ps-7
       title: External Personnel Security
       levels:

--- a/products/rhel9/controls/nist_800_53/pt.yml
+++ b/products/rhel9/controls/nist_800_53/pt.yml
@@ -8,78 +8,84 @@ controls:
       title: Authority to Process Personally Identifiable Information
       rules: []
       status: pending
-    - id: pt-2.1
-      title: Data Tagging
-      rules: []
-      status: pending
-    - id: pt-2.2
-      title: Automation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-2.1
+            title: Data Tagging
+            rules: []
+            status: pending
+          - id: pt-2.2
+            title: Automation
+            rules: []
+            status: pending
     - id: pt-3
       title: Personally Identifiable Information Processing Purposes
       rules: []
       status: pending
-    - id: pt-3.1
-      title: Data Tagging
-      rules: []
-      status: pending
-    - id: pt-3.2
-      title: Automation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-3.1
+            title: Data Tagging
+            rules: []
+            status: pending
+          - id: pt-3.2
+            title: Automation
+            rules: []
+            status: pending
     - id: pt-4
       title: Consent
       rules: []
       status: pending
-    - id: pt-4.1
-      title: Tailored Consent
-      rules: []
-      status: pending
-    - id: pt-4.2
-      title: Just-in-time Consent
-      rules: []
-      status: pending
-    - id: pt-4.3
-      title: Revocation
-      rules: []
-      status: pending
+      controls:
+          - id: pt-4.1
+            title: Tailored Consent
+            rules: []
+            status: pending
+          - id: pt-4.2
+            title: Just-in-time Consent
+            rules: []
+            status: pending
+          - id: pt-4.3
+            title: Revocation
+            rules: []
+            status: pending
     - id: pt-5
       title: Privacy Notice
       rules: []
       status: pending
-    - id: pt-5.1
-      title: Just-in-time Notice
-      rules: []
-      status: pending
-    - id: pt-5.2
-      title: Privacy Act Statements
-      rules: []
-      status: pending
+      controls:
+          - id: pt-5.1
+            title: Just-in-time Notice
+            rules: []
+            status: pending
+          - id: pt-5.2
+            title: Privacy Act Statements
+            rules: []
+            status: pending
     - id: pt-6
       title: System of Records Notice
       rules: []
       status: pending
-    - id: pt-6.1
-      title: Routine Uses
-      rules: []
-      status: pending
-    - id: pt-6.2
-      title: Exemption Rules
-      rules: []
-      status: pending
+      controls:
+          - id: pt-6.1
+            title: Routine Uses
+            rules: []
+            status: pending
+          - id: pt-6.2
+            title: Exemption Rules
+            rules: []
+            status: pending
     - id: pt-7
       title: Specific Categories of Personally Identifiable Information
       rules: []
       status: pending
-    - id: pt-7.1
-      title: Social Security Numbers
-      rules: []
-      status: pending
-    - id: pt-7.2
-      title: First Amendment Information
-      rules: []
-      status: pending
+      controls:
+          - id: pt-7.1
+            title: Social Security Numbers
+            rules: []
+            status: pending
+          - id: pt-7.2
+            title: First Amendment Information
+            rules: []
+            status: pending
     - id: pt-8
       title: Computer Matching Requirements
       rules: []

--- a/products/rhel9/controls/nist_800_53/ra.yml
+++ b/products/rhel9/controls/nist_800_53/ra.yml
@@ -12,34 +12,44 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ra-2.1
-      title: Impact-level Prioritization
-      rules: []
-      status: pending
+      controls:
+          - id: ra-2.1
+            title: Impact-level Prioritization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ra-3
       title: Risk Assessment
       levels:
           - low
       rules: []
       status: pending
-    - id: ra-3.1
-      title: Supply Chain Risk Assessment
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ra-3.2
-      title: Use of All-source Intelligence
-      rules: []
-      status: pending
-    - id: ra-3.3
-      title: Dynamic Threat Awareness
-      rules: []
-      status: pending
-    - id: ra-3.4
-      title: Predictive Cyber Analytics
-      rules: []
-      status: pending
+      controls:
+          - id: ra-3.1
+            title: Supply Chain Risk Assessment
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ra-3.2
+            title: Use of All-source Intelligence
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-3.3
+            title: Dynamic Threat Awareness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-3.4
+            title: Predictive Cyber Analytics
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: ra-4
       title: Risk Assessment Update
       rules: []
@@ -50,58 +60,74 @@ controls:
           - low
       rules: []
       status: pending
-    - id: ra-5.1
-      title: Update Tool Capability
-      rules: []
-      status: pending
-    - id: ra-5.2
-      title: Update Vulnerabilities to Be Scanned
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: ra-5.3
-      title: Breadth and Depth of Coverage
-      rules: []
-      status: pending
-    - id: ra-5.4
-      title: Discoverable Information
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: ra-5.5
-      title: Privileged Access
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: ra-5.6
-      title: Automated Trend Analyses
-      rules: []
-      status: pending
-    - id: ra-5.7
-      title: Automated Detection and Notification of Unauthorized Components
-      rules: []
-      status: pending
-    - id: ra-5.8
-      title: Review Historic Audit Logs
-      rules: []
-      status: pending
-    - id: ra-5.9
-      title: Penetration Testing and Analyses
-      rules: []
-      status: pending
-    - id: ra-5.10
-      title: Correlate Scanning Information
-      rules: []
-      status: pending
-    - id: ra-5.11
-      title: Public Disclosure Program
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: ra-5.1
+            title: Update Tool Capability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.2
+            title: Update Vulnerabilities to Be Scanned
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: ra-5.3
+            title: Breadth and Depth of Coverage
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.4
+            title: Discoverable Information
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: ra-5.5
+            title: Privileged Access
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: ra-5.6
+            title: Automated Trend Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.7
+            title: Automated Detection and Notification of Unauthorized
+                Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.8
+            title: Review Historic Audit Logs
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.9
+            title: Penetration Testing and Analyses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.10
+            title: Correlate Scanning Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: ra-5.11
+            title: Public Disclosure Program
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: ra-6
       title: Technical Surveillance Countermeasures Survey
       rules: []

--- a/products/rhel9/controls/nist_800_53/sa.yml
+++ b/products/rhel9/controls/nist_800_53/sa.yml
@@ -18,108 +18,141 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sa-3.1
-      title: Manage Preproduction Environment
-      rules: []
-      status: pending
-    - id: sa-3.2
-      title: Use of Live or Operational Data
-      rules: []
-      status: pending
-    - id: sa-3.3
-      title: Technology Refresh
-      rules: []
-      status: pending
+      controls:
+          - id: sa-3.1
+            title: Manage Preproduction Environment
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-3.2
+            title: Use of Live or Operational Data
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-3.3
+            title: Technology Refresh
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-4
       title: Acquisition Process
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-4.1
-      title: Functional Properties of Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.2
-      title: Design and Implementation Information for Controls
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.3
-      title: Development Methods, Techniques, and Practices
-      rules: []
-      status: pending
-    - id: sa-4.4
-      title: Assignment of Components to Systems
-      rules: []
-      status: pending
-    - id: sa-4.5
-      title: System, Component, and Service Configurations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sa-4.6
-      title: Use of Information Assurance Products
-      rules: []
-      status: pending
-    - id: sa-4.7
-      title: 'NIAP-approved Protection Profiles '
-      rules: []
-      status: pending
-    - id: sa-4.8
-      title: Continuous Monitoring Plan for Controls
-      rules: []
-      status: pending
-    - id: sa-4.9
-      title: Functions, Ports, Protocols, and Services in Use
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-4.10
-      title: Use of Approved PIV Products
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sa-4.11
-      title: System of Records
-      rules: []
-      status: pending
-    - id: sa-4.12
-      title: Data Ownership
-      rules: []
-      status: pending
+      controls:
+          - id: sa-4.1
+            title: Functional Properties of Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.2
+            title: Design and Implementation Information for Controls
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.3
+            title: Development Methods, Techniques, and Practices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.4
+            title: Assignment of Components to Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.5
+            title: System, Component, and Service Configurations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sa-4.6
+            title: Use of Information Assurance Products
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.7
+            title: 'NIAP-approved Protection Profiles '
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.8
+            title: Continuous Monitoring Plan for Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.9
+            title: Functions, Ports, Protocols, and Services in Use
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-4.10
+            title: Use of Approved PIV Products
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sa-4.11
+            title: System of Records
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-4.12
+            title: Data Ownership
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-5
       title: System Documentation
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-5.1
-      title: Functional Properties of Security Controls
-      rules: []
-      status: pending
-    - id: sa-5.2
-      title: Security-relevant External System Interfaces
-      rules: []
-      status: pending
-    - id: sa-5.3
-      title: High-level Design
-      rules: []
-      status: pending
-    - id: sa-5.4
-      title: Low-level Design
-      rules: []
-      status: pending
-    - id: sa-5.5
-      title: Source Code
-      rules: []
-      status: pending
+      controls:
+          - id: sa-5.1
+            title: Functional Properties of Security Controls
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.2
+            title: Security-relevant External System Interfaces
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.3
+            title: High-level Design
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.4
+            title: Low-level Design
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-5.5
+            title: Source Code
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-6
       title: Software Usage Restrictions
       rules: []
@@ -134,318 +167,436 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sa-8.1
-      title: Clear Abstractions
-      rules: []
-      status: pending
-    - id: sa-8.2
-      title: Least Common Mechanism
-      rules: []
-      status: pending
-    - id: sa-8.3
-      title: Modularity and Layering
-      rules: []
-      status: pending
-    - id: sa-8.4
-      title: Partially Ordered Dependencies
-      rules: []
-      status: pending
-    - id: sa-8.5
-      title: Efficiently Mediated Access
-      rules: []
-      status: pending
-    - id: sa-8.6
-      title: Minimized Sharing
-      rules: []
-      status: pending
-    - id: sa-8.7
-      title: Reduced Complexity
-      rules: []
-      status: pending
-    - id: sa-8.8
-      title: Secure Evolvability
-      rules: []
-      status: pending
-    - id: sa-8.9
-      title: Trusted Components
-      rules: []
-      status: pending
-    - id: sa-8.10
-      title: Hierarchical Trust
-      rules: []
-      status: pending
-    - id: sa-8.11
-      title: Inverse Modification Threshold
-      rules: []
-      status: pending
-    - id: sa-8.12
-      title: Hierarchical Protection
-      rules: []
-      status: pending
-    - id: sa-8.13
-      title: Minimized Security Elements
-      rules: []
-      status: pending
-    - id: sa-8.14
-      title: Least Privilege
-      rules: []
-      status: pending
-    - id: sa-8.15
-      title: Predicate Permission
-      rules: []
-      status: pending
-    - id: sa-8.16
-      title: Self-reliant Trustworthiness
-      rules: []
-      status: pending
-    - id: sa-8.17
-      title: Secure Distributed Composition
-      rules: []
-      status: pending
-    - id: sa-8.18
-      title: Trusted Communications Channels
-      rules: []
-      status: pending
-    - id: sa-8.19
-      title: Continuous Protection
-      rules: []
-      status: pending
-    - id: sa-8.20
-      title: Secure Metadata Management
-      rules: []
-      status: pending
-    - id: sa-8.21
-      title: Self-analysis
-      rules: []
-      status: pending
-    - id: sa-8.22
-      title: Accountability and Traceability
-      rules: []
-      status: pending
-    - id: sa-8.23
-      title: Secure Defaults
-      rules: []
-      status: pending
-    - id: sa-8.24
-      title: Secure Failure and Recovery
-      rules: []
-      status: pending
-    - id: sa-8.25
-      title: Economic Security
-      rules: []
-      status: pending
-    - id: sa-8.26
-      title: Performance Security
-      rules: []
-      status: pending
-    - id: sa-8.27
-      title: Human Factored Security
-      rules: []
-      status: pending
-    - id: sa-8.28
-      title: Acceptable Security
-      rules: []
-      status: pending
-    - id: sa-8.29
-      title: Repeatable and Documented Procedures
-      rules: []
-      status: pending
-    - id: sa-8.30
-      title: Procedural Rigor
-      rules: []
-      status: pending
-    - id: sa-8.31
-      title: Secure System Modification
-      rules: []
-      status: pending
-    - id: sa-8.32
-      title: Sufficient Documentation
-      rules: []
-      status: pending
-    - id: sa-8.33
-      title: Minimization
-      rules: []
-      status: pending
+      controls:
+          - id: sa-8.1
+            title: Clear Abstractions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.2
+            title: Least Common Mechanism
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.3
+            title: Modularity and Layering
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.4
+            title: Partially Ordered Dependencies
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.5
+            title: Efficiently Mediated Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.6
+            title: Minimized Sharing
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.7
+            title: Reduced Complexity
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.8
+            title: Secure Evolvability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.9
+            title: Trusted Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.10
+            title: Hierarchical Trust
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.11
+            title: Inverse Modification Threshold
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.12
+            title: Hierarchical Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.13
+            title: Minimized Security Elements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.14
+            title: Least Privilege
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.15
+            title: Predicate Permission
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.16
+            title: Self-reliant Trustworthiness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.17
+            title: Secure Distributed Composition
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.18
+            title: Trusted Communications Channels
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.19
+            title: Continuous Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.20
+            title: Secure Metadata Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.21
+            title: Self-analysis
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.22
+            title: Accountability and Traceability
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.23
+            title: Secure Defaults
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.24
+            title: Secure Failure and Recovery
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.25
+            title: Economic Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.26
+            title: Performance Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.27
+            title: Human Factored Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.28
+            title: Acceptable Security
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.29
+            title: Repeatable and Documented Procedures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.30
+            title: Procedural Rigor
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.31
+            title: Secure System Modification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.32
+            title: Sufficient Documentation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-8.33
+            title: Minimization
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-9
       title: External System Services
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-9.1
-      title: Risk Assessments and Organizational Approvals
-      rules: []
-      status: pending
-    - id: sa-9.2
-      title: Identification of Functions, Ports, Protocols, and Services
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-9.3
-      title: Establish and Maintain Trust Relationship with Providers
-      rules: []
-      status: pending
-    - id: sa-9.4
-      title: Consistent Interests of Consumers and Providers
-      rules: []
-      status: pending
-    - id: sa-9.5
-      title: Processing, Storage, and Service Location
-      rules: []
-      status: pending
-    - id: sa-9.6
-      title: Organization-controlled Cryptographic Keys
-      rules: []
-      status: pending
-    - id: sa-9.7
-      title: Organization-controlled Integrity Checking
-      rules: []
-      status: pending
-    - id: sa-9.8
-      title: Processing and Storage Location — U.S. Jurisdiction
-      rules: []
-      status: pending
+      controls:
+          - id: sa-9.1
+            title: Risk Assessments and Organizational Approvals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.2
+            title: Identification of Functions, Ports, Protocols, and Services
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-9.3
+            title: Establish and Maintain Trust Relationship with Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.4
+            title: Consistent Interests of Consumers and Providers
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.5
+            title: Processing, Storage, and Service Location
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.6
+            title: Organization-controlled Cryptographic Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.7
+            title: Organization-controlled Integrity Checking
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sa-9.8
+            title: Processing and Storage Location — U.S. Jurisdiction
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-10
       title: Developer Configuration Management
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-10.1
-      title: Software and Firmware Integrity Verification
-      rules: []
-      status: pending
-    - id: sa-10.2
-      title: Alternative Configuration Management Processes
-      rules: []
-      status: pending
-    - id: sa-10.3
-      title: Hardware Integrity Verification
-      rules: []
-      status: pending
-    - id: sa-10.4
-      title: Trusted Generation
-      rules: []
-      status: pending
-    - id: sa-10.5
-      title: Mapping Integrity for Version Control
-      rules: []
-      status: pending
-    - id: sa-10.6
-      title: Trusted Distribution
-      rules: []
-      status: pending
-    - id: sa-10.7
-      title: Security and Privacy Representatives
-      rules: []
-      status: pending
+      controls:
+          - id: sa-10.1
+            title: Software and Firmware Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.2
+            title: Alternative Configuration Management Processes
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.3
+            title: Hardware Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.4
+            title: Trusted Generation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.5
+            title: Mapping Integrity for Version Control
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.6
+            title: Trusted Distribution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-10.7
+            title: Security and Privacy Representatives
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-11
       title: Developer Testing and Evaluation
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-11.1
-      title: Static Code Analysis
-      rules: []
-      status: pending
-    - id: sa-11.2
-      title: Threat Modeling and Vulnerability Analyses
-      rules: []
-      status: pending
-    - id: sa-11.3
-      title: Independent Verification of Assessment Plans and Evidence
-      rules: []
-      status: pending
-    - id: sa-11.4
-      title: Manual Code Reviews
-      rules: []
-      status: pending
-    - id: sa-11.5
-      title: Penetration Testing
-      rules: []
-      status: pending
-    - id: sa-11.6
-      title: Attack Surface Reviews
-      rules: []
-      status: pending
-    - id: sa-11.7
-      title: Verify Scope of Testing and Evaluation
-      rules: []
-      status: pending
-    - id: sa-11.8
-      title: Dynamic Code Analysis
-      rules: []
-      status: pending
-    - id: sa-11.9
-      title: Interactive Application Security Testing
-      rules: []
-      status: pending
+      controls:
+          - id: sa-11.1
+            title: Static Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.2
+            title: Threat Modeling and Vulnerability Analyses
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.3
+            title: Independent Verification of Assessment Plans and Evidence
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.4
+            title: Manual Code Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.5
+            title: Penetration Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.6
+            title: Attack Surface Reviews
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.7
+            title: Verify Scope of Testing and Evaluation
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.8
+            title: Dynamic Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-11.9
+            title: Interactive Application Security Testing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-12
       title: Supply Chain Protection
       rules: []
       status: pending
-    - id: sa-12.1
-      title: Acquisition Strategies / Tools / Methods
-      rules: []
-      status: pending
-    - id: sa-12.2
-      title: Supplier Reviews
-      rules: []
-      status: pending
-    - id: sa-12.3
-      title: Trusted Shipping and Warehousing
-      rules: []
-      status: pending
-    - id: sa-12.4
-      title: Diversity of Suppliers
-      rules: []
-      status: pending
-    - id: sa-12.5
-      title: Limitation of Harm
-      rules: []
-      status: pending
-    - id: sa-12.6
-      title: Minimizing Procurement Time
-      rules: []
-      status: pending
-    - id: sa-12.7
-      title: Assessments Prior to Selection / Acceptance / Update
-      rules: []
-      status: pending
-    - id: sa-12.8
-      title: Use of All-source Intelligence
-      rules: []
-      status: pending
-    - id: sa-12.9
-      title: Operations Security
-      rules: []
-      status: pending
-    - id: sa-12.10
-      title: Validate as Genuine and Not Altered
-      rules: []
-      status: pending
-    - id: sa-12.11
-      title: Penetration Testing / Analysis of Elements, Processes, and Actors
-      rules: []
-      status: pending
-    - id: sa-12.12
-      title: Inter-organizational Agreements
-      rules: []
-      status: pending
-    - id: sa-12.13
-      title: Critical Information System Components
-      rules: []
-      status: pending
-    - id: sa-12.14
-      title: Identity and Traceability
-      rules: []
-      status: pending
-    - id: sa-12.15
-      title: Processes to Address Weaknesses or Deficiencies
-      rules: []
-      status: pending
+      controls:
+          - id: sa-12.1
+            title: Acquisition Strategies / Tools / Methods
+            rules: []
+            status: pending
+          - id: sa-12.2
+            title: Supplier Reviews
+            rules: []
+            status: pending
+          - id: sa-12.3
+            title: Trusted Shipping and Warehousing
+            rules: []
+            status: pending
+          - id: sa-12.4
+            title: Diversity of Suppliers
+            rules: []
+            status: pending
+          - id: sa-12.5
+            title: Limitation of Harm
+            rules: []
+            status: pending
+          - id: sa-12.6
+            title: Minimizing Procurement Time
+            rules: []
+            status: pending
+          - id: sa-12.7
+            title: Assessments Prior to Selection / Acceptance / Update
+            rules: []
+            status: pending
+          - id: sa-12.8
+            title: Use of All-source Intelligence
+            rules: []
+            status: pending
+          - id: sa-12.9
+            title: Operations Security
+            rules: []
+            status: pending
+          - id: sa-12.10
+            title: Validate as Genuine and Not Altered
+            rules: []
+            status: pending
+          - id: sa-12.11
+            title: Penetration Testing / Analysis of Elements, Processes, and
+                Actors
+            rules: []
+            status: pending
+          - id: sa-12.12
+            title: Inter-organizational Agreements
+            rules: []
+            status: pending
+          - id: sa-12.13
+            title: Critical Information System Components
+            rules: []
+            status: pending
+          - id: sa-12.14
+            title: Identity and Traceability
+            rules: []
+            status: pending
+          - id: sa-12.15
+            title: Processes to Address Weaknesses or Deficiencies
+            rules: []
+            status: pending
     - id: sa-13
       title: Trustworthiness
       rules: []
@@ -454,70 +605,96 @@ controls:
       title: Criticality Analysis
       rules: []
       status: pending
-    - id: sa-14.1
-      title: Critical Components with No Viable Alternative Sourcing
-      rules: []
-      status: pending
+      controls:
+          - id: sa-14.1
+            title: Critical Components with No Viable Alternative Sourcing
+            rules: []
+            status: pending
     - id: sa-15
       title: Development Process, Standards, and Tools
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sa-15.1
-      title: Quality Metrics
-      rules: []
-      status: pending
-    - id: sa-15.2
-      title: Security and Privacy Tracking Tools
-      rules: []
-      status: pending
-    - id: sa-15.3
-      title: Criticality Analysis
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sa-15.4
-      title: Threat Modeling and Vulnerability Analysis
-      rules: []
-      status: pending
-    - id: sa-15.5
-      title: Attack Surface Reduction
-      rules: []
-      status: pending
-    - id: sa-15.6
-      title: Continuous Improvement
-      rules: []
-      status: pending
-    - id: sa-15.7
-      title: Automated Vulnerability Analysis
-      rules: []
-      status: pending
-    - id: sa-15.8
-      title: Reuse of Threat and Vulnerability Information
-      rules: []
-      status: pending
-    - id: sa-15.9
-      title: Use of Live Data
-      rules: []
-      status: pending
-    - id: sa-15.10
-      title: Incident Response Plan
-      rules: []
-      status: pending
-    - id: sa-15.11
-      title: Archive System or Component
-      rules: []
-      status: pending
-    - id: sa-15.12
-      title: Minimize Personally Identifiable Information
-      rules: []
-      status: pending
-    - id: sa-15.13
-      title: Logging Syntax
-      rules: []
-      status: pending
+      controls:
+          - id: sa-15.1
+            title: Quality Metrics
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.2
+            title: Security and Privacy Tracking Tools
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.3
+            title: Criticality Analysis
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sa-15.4
+            title: Threat Modeling and Vulnerability Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.5
+            title: Attack Surface Reduction
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.6
+            title: Continuous Improvement
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.7
+            title: Automated Vulnerability Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.8
+            title: Reuse of Threat and Vulnerability Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.9
+            title: Use of Live Data
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.10
+            title: Incident Response Plan
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.11
+            title: Archive System or Component
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.12
+            title: Minimize Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sa-15.13
+            title: Logging Syntax
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sa-16
       title: Developer-provided Training
       levels:
@@ -530,74 +707,95 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sa-17.1
-      title: Formal Policy Model
-      rules: []
-      status: pending
-    - id: sa-17.2
-      title: Security-relevant Components
-      rules: []
-      status: pending
-    - id: sa-17.3
-      title: Formal Correspondence
-      rules: []
-      status: pending
-    - id: sa-17.4
-      title: Informal Correspondence
-      rules: []
-      status: pending
-    - id: sa-17.5
-      title: Conceptually Simple Design
-      rules: []
-      status: pending
-    - id: sa-17.6
-      title: Structure for Testing
-      rules: []
-      status: pending
-    - id: sa-17.7
-      title: Structure for Least Privilege
-      rules: []
-      status: pending
-    - id: sa-17.8
-      title: Orchestration
-      rules: []
-      status: pending
-    - id: sa-17.9
-      title: Design Diversity
-      rules: []
-      status: pending
+      controls:
+          - id: sa-17.1
+            title: Formal Policy Model
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.2
+            title: Security-relevant Components
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.3
+            title: Formal Correspondence
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.4
+            title: Informal Correspondence
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.5
+            title: Conceptually Simple Design
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.6
+            title: Structure for Testing
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.7
+            title: Structure for Least Privilege
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.8
+            title: Orchestration
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sa-17.9
+            title: Design Diversity
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sa-18
       title: Tamper Resistance and Detection
       rules: []
       status: pending
-    - id: sa-18.1
-      title: Multiple Phases of System Development Life Cycle
-      rules: []
-      status: pending
-    - id: sa-18.2
-      title: Inspection of Systems or Components
-      rules: []
-      status: pending
+      controls:
+          - id: sa-18.1
+            title: Multiple Phases of System Development Life Cycle
+            rules: []
+            status: pending
+          - id: sa-18.2
+            title: Inspection of Systems or Components
+            rules: []
+            status: pending
     - id: sa-19
       title: Component Authenticity
       rules: []
       status: pending
-    - id: sa-19.1
-      title: Anti-counterfeit Training
-      rules: []
-      status: pending
-    - id: sa-19.2
-      title: Configuration Control for Component Service and Repair
-      rules: []
-      status: pending
-    - id: sa-19.3
-      title: Component Disposal
-      rules: []
-      status: pending
-    - id: sa-19.4
-      title: Anti-counterfeit Scanning
-      rules: []
-      status: pending
+      controls:
+          - id: sa-19.1
+            title: Anti-counterfeit Training
+            rules: []
+            status: pending
+          - id: sa-19.2
+            title: Configuration Control for Component Service and Repair
+            rules: []
+            status: pending
+          - id: sa-19.3
+            title: Component Disposal
+            rules: []
+            status: pending
+          - id: sa-19.4
+            title: Anti-counterfeit Scanning
+            rules: []
+            status: pending
     - id: sa-20
       title: Customized Development of Critical Components
       rules: []
@@ -608,20 +806,26 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sa-21.1
-      title: Validation of Screening
-      rules: []
-      status: pending
+      controls:
+          - id: sa-21.1
+            title: Validation of Screening
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sa-22
       title: Unsupported System Components
       levels:
           - low
       rules: []
       status: pending
-    - id: sa-22.1
-      title: Alternative Sources for Continued Support
-      rules: []
-      status: pending
+      controls:
+          - id: sa-22.1
+            title: Alternative Sources for Continued Support
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sa-23
       title: Specialization
       rules: []

--- a/products/rhel9/controls/nist_800_53/sc.yml
+++ b/products/rhel9/controls/nist_800_53/sc.yml
@@ -12,14 +12,19 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-2.1
-      title: Interfaces for Non-privileged Users
-      rules: []
-      status: pending
-    - id: sc-2.2
-      title: Disassociability
-      rules: []
-      status: pending
+      controls:
+          - id: sc-2.1
+            title: Interfaces for Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-2.2
+            title: Disassociability
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-3
       title: Security Function Isolation
       levels:
@@ -30,26 +35,37 @@ controls:
           - var_selinux_policy_name=targeted
           - var_selinux_state=enforcing
       status: automated
-    - id: sc-3.1
-      title: Hardware Separation
-      rules: []
-      status: pending
-    - id: sc-3.2
-      title: Access and Flow Control Functions
-      rules: []
-      status: pending
-    - id: sc-3.3
-      title: Minimize Nonsecurity Functionality
-      rules: []
-      status: pending
-    - id: sc-3.4
-      title: Module Coupling and Cohesiveness
-      rules: []
-      status: pending
-    - id: sc-3.5
-      title: Layered Structures
-      rules: []
-      status: pending
+      controls:
+          - id: sc-3.1
+            title: Hardware Separation
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.2
+            title: Access and Flow Control Functions
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.3
+            title: Minimize Nonsecurity Functionality
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.4
+            title: Module Coupling and Cohesiveness
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: sc-3.5
+            title: Layered Structures
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: sc-4
       title: Information in Shared System Resources
       levels:
@@ -58,14 +74,19 @@ controls:
           - dir_perms_world_writable_sticky_bits
           - file_permissions_unauthorized_world_writable
       status: automated
-    - id: sc-4.1
-      title: Security Levels
-      rules: []
-      status: pending
-    - id: sc-4.2
-      title: Multilevel or Periods Processing
-      rules: []
-      status: pending
+      controls:
+          - id: sc-4.1
+            title: Security Levels
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-4.2
+            title: Multilevel or Periods Processing
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-5
       title: Denial-of-service Protection
       levels:
@@ -73,18 +94,25 @@ controls:
       rules:
           - sysctl_net_ipv4_tcp_syncookies
       status: automated
-    - id: sc-5.1
-      title: Restrict Ability to Attack Other Systems
-      rules: []
-      status: pending
-    - id: sc-5.2
-      title: Capacity, Bandwidth, and Redundancy
-      rules: []
-      status: pending
-    - id: sc-5.3
-      title: Detection and Monitoring
-      rules: []
-      status: pending
+      controls:
+          - id: sc-5.1
+            title: Restrict Ability to Attack Other Systems
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-5.2
+            title: Capacity, Bandwidth, and Redundancy
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-5.3
+            title: Detection and Monitoring
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-6
       title: Resource Availability
       rules: []
@@ -96,136 +124,183 @@ controls:
       rules:
           - service_firewalld_enabled
       status: automated
-    - id: sc-7.1
-      title: Physically Separated Subnetworks
-      rules: []
-      status: pending
-    - id: sc-7.2
-      title: Public Access
-      rules: []
-      status: pending
-    - id: sc-7.3
-      title: Access Points
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.4
-      title: External Telecommunications Services
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.5
-      title: Deny by Default — Allow by Exception
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.6
-      title: Response to Recognized Failures
-      rules: []
-      status: pending
-    - id: sc-7.7
-      title: Split Tunneling for Remote Devices
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.8
-      title: Route Traffic to Authenticated Proxy Servers
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-7.9
-      title: Restrict Threatening Outgoing Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-7.10
-      title: Prevent Exfiltration
-      rules: []
-      status: pending
-    - id: sc-7.11
-      title: Restrict Incoming Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-7.12
-      title: Host-based Protection
-      rules: []
-      status: pending
-    - id: sc-7.13
-      title: Isolation of Security Tools, Mechanisms, and Support Components
-      rules: []
-      status: pending
-    - id: sc-7.14
-      title: Protect Against Unauthorized Physical Connections
-      rules: []
-      status: pending
-    - id: sc-7.15
-      title: Networked Privileged Accesses
-      rules: []
-      status: pending
-    - id: sc-7.16
-      title: Prevent Discovery of System Components
-      rules: []
-      status: pending
-    - id: sc-7.17
-      title: Automated Enforcement of Protocol Formats
-      rules: []
-      status: pending
-    - id: sc-7.18
-      title: Fail Secure
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-7.19
-      title: Block Communication from Non-organizationally Configured Hosts
-      rules: []
-      status: pending
-    - id: sc-7.20
-      title: Dynamic Isolation and Segregation
-      rules: []
-      status: pending
-    - id: sc-7.21
-      title: Isolation of System Components
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-7.22
-      title: Separate Subnets for Connecting to Different Security Domains
-      rules: []
-      status: pending
-    - id: sc-7.23
-      title: Disable Sender Feedback on Protocol Validation Failure
-      rules: []
-      status: pending
-    - id: sc-7.24
-      title: Personally Identifiable Information
-      rules: []
-      status: pending
-    - id: sc-7.25
-      title: Unclassified National Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.26
-      title: Classified National Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.27
-      title: Unclassified Non-national Security System Connections
-      rules: []
-      status: pending
-    - id: sc-7.28
-      title: Connections to Public Networks
-      rules: []
-      status: pending
-    - id: sc-7.29
-      title: Separate Subnets to Isolate Functions
-      rules: []
-      status: pending
+      controls:
+          - id: sc-7.1
+            title: Physically Separated Subnetworks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.2
+            title: Public Access
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.3
+            title: Access Points
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.4
+            title: External Telecommunications Services
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.5
+            title: Deny by Default — Allow by Exception
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.6
+            title: Response to Recognized Failures
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.7
+            title: Split Tunneling for Remote Devices
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.8
+            title: Route Traffic to Authenticated Proxy Servers
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-7.9
+            title: Restrict Threatening Outgoing Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.10
+            title: Prevent Exfiltration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.11
+            title: Restrict Incoming Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.12
+            title: Host-based Protection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.13
+            title: Isolation of Security Tools, Mechanisms, and Support
+                Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.14
+            title: Protect Against Unauthorized Physical Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.15
+            title: Networked Privileged Accesses
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.16
+            title: Prevent Discovery of System Components
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.17
+            title: Automated Enforcement of Protocol Formats
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.18
+            title: Fail Secure
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-7.19
+            title: Block Communication from Non-organizationally Configured
+                Hosts
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.20
+            title: Dynamic Isolation and Segregation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.21
+            title: Isolation of System Components
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-7.22
+            title: Separate Subnets for Connecting to Different Security Domains
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.23
+            title: Disable Sender Feedback on Protocol Validation Failure
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.24
+            title: Personally Identifiable Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.25
+            title: Unclassified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.26
+            title: Classified National Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.27
+            title: Unclassified Non-national Security System Connections
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.28
+            title: Connections to Public Networks
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-7.29
+            title: Separate Subnets to Isolate Functions
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-8
       title: Transmission Confidentiality and Integrity
       levels:
@@ -233,28 +308,37 @@ controls:
       rules:
           - configure_custom_crypto_policy_cis
       status: automated
-    - id: sc-8.1
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-8.2
-      title: Pre- and Post-transmission Handling
-      rules: []
-      status: pending
-    - id: sc-8.3
-      title: Cryptographic Protection for Message Externals
-      rules: []
-      status: pending
-    - id: sc-8.4
-      title: Conceal or Randomize Communications
-      rules: []
-      status: pending
-    - id: sc-8.5
-      title: Protected Distribution System
-      rules: []
-      status: pending
+      controls:
+          - id: sc-8.1
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-8.2
+            title: Pre- and Post-transmission Handling
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.3
+            title: Cryptographic Protection for Message Externals
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.4
+            title: Conceal or Randomize Communications
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-8.5
+            title: Protected Distribution System
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-9
       title: Transmission Confidentiality
       rules: []
@@ -269,64 +353,85 @@ controls:
       title: Trusted Path
       rules: []
       status: pending
-    - id: sc-11.1
-      title: Irrefutable Communications Path
-      rules: []
-      status: pending
+      controls:
+          - id: sc-11.1
+            title: Irrefutable Communications Path
+            rules: []
+            status: pending
     - id: sc-12
       title: Cryptographic Key Establishment and Management
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-12.1
-      title: Availability
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: sc-12.2
-      title: Symmetric Keys
-      rules: []
-      status: pending
-    - id: sc-12.3
-      title: Asymmetric Keys
-      rules: []
-      status: pending
-    - id: sc-12.4
-      title: PKI Certificates
-      rules: []
-      status: pending
-    - id: sc-12.5
-      title: PKI Certificates / Hardware Tokens
-      rules: []
-      status: pending
-    - id: sc-12.6
-      title: Physical Control of Keys
-      rules: []
-      status: pending
+      controls:
+          - id: sc-12.1
+            title: Availability
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: sc-12.2
+            title: Symmetric Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.3
+            title: Asymmetric Keys
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.4
+            title: PKI Certificates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.5
+            title: PKI Certificates / Hardware Tokens
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-12.6
+            title: Physical Control of Keys
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-13
       title: Cryptographic Protection
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-13.1
-      title: FIPS-validated Cryptography
-      rules: []
-      status: pending
-    - id: sc-13.2
-      title: NSA-approved Cryptography
-      rules: []
-      status: pending
-    - id: sc-13.3
-      title: Individuals Without Formal Access Approvals
-      rules: []
-      status: pending
-    - id: sc-13.4
-      title: Digital Signatures
-      rules: []
-      status: pending
+      controls:
+          - id: sc-13.1
+            title: FIPS-validated Cryptography
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.2
+            title: NSA-approved Cryptography
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.3
+            title: Individuals Without Formal Access Approvals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-13.4
+            title: Digital Signatures
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-14
       title: Public Access Protections
       rules: []
@@ -337,38 +442,48 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-15.1
-      title: Physical or Logical Disconnect
-      rules: []
-      status: pending
-    - id: sc-15.2
-      title: Blocking Inbound and Outbound Communications Traffic
-      rules: []
-      status: pending
-    - id: sc-15.3
-      title: Disabling and Removal in Secure Work Areas
-      rules: []
-      status: pending
-    - id: sc-15.4
-      title: Explicitly Indicate Current Participants
-      rules: []
-      status: pending
+      controls:
+          - id: sc-15.1
+            title: Physical or Logical Disconnect
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.2
+            title: Blocking Inbound and Outbound Communications Traffic
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.3
+            title: Disabling and Removal in Secure Work Areas
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-15.4
+            title: Explicitly Indicate Current Participants
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-16
       title: Transmission of Security and Privacy Attributes
       rules: []
       status: pending
-    - id: sc-16.1
-      title: Integrity Verification
-      rules: []
-      status: pending
-    - id: sc-16.2
-      title: Anti-spoofing Mechanisms
-      rules: []
-      status: pending
-    - id: sc-16.3
-      title: Cryptographic Binding
-      rules: []
-      status: pending
+      controls:
+          - id: sc-16.1
+            title: Integrity Verification
+            rules: []
+            status: pending
+          - id: sc-16.2
+            title: Anti-spoofing Mechanisms
+            rules: []
+            status: pending
+          - id: sc-16.3
+            title: Cryptographic Binding
+            rules: []
+            status: pending
     - id: sc-17
       title: Public Key Infrastructure Certificates
       levels:
@@ -381,26 +496,37 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-18.1
-      title: Identify Unacceptable Code and Take Corrective Actions
-      rules: []
-      status: pending
-    - id: sc-18.2
-      title: Acquisition, Development, and Use
-      rules: []
-      status: pending
-    - id: sc-18.3
-      title: Prevent Downloading and Execution
-      rules: []
-      status: pending
-    - id: sc-18.4
-      title: Prevent Automatic Execution
-      rules: []
-      status: pending
-    - id: sc-18.5
-      title: Allow Execution Only in Confined Environments
-      rules: []
-      status: pending
+      controls:
+          - id: sc-18.1
+            title: Identify Unacceptable Code and Take Corrective Actions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.2
+            title: Acquisition, Development, and Use
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.3
+            title: Prevent Downloading and Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.4
+            title: Prevent Automatic Execution
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-18.5
+            title: Allow Execution Only in Confined Environments
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-19
       title: Voice Over Internet Protocol
       rules: []
@@ -411,24 +537,33 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-20.1
-      title: Child Subspaces
-      rules: []
-      status: pending
-    - id: sc-20.2
-      title: Data Origin and Integrity
-      rules: []
-      status: pending
+      controls:
+          - id: sc-20.1
+            title: Child Subspaces
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-20.2
+            title: Data Origin and Integrity
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-21
-      title: Secure Name/Address Resolution Service (Recursive or Caching Resolver)
+      title: Secure Name/Address Resolution Service (Recursive or Caching
+          Resolver)
       levels:
           - low
       rules: []
       status: pending
-    - id: sc-21.1
-      title: Data Origin and Integrity
-      rules: []
-      status: pending
+      controls:
+          - id: sc-21.1
+            title: Data Origin and Integrity
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-22
       title: Architecture and Provisioning for Name/Address Resolution Service
       levels:
@@ -441,26 +576,37 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-23.1
-      title: Invalidate Session Identifiers at Logout
-      rules: []
-      status: pending
-    - id: sc-23.2
-      title: User-initiated Logouts and Message Displays
-      rules: []
-      status: pending
-    - id: sc-23.3
-      title: Unique System-generated Session Identifiers
-      rules: []
-      status: pending
-    - id: sc-23.4
-      title: Unique Session Identifiers with Randomization
-      rules: []
-      status: pending
-    - id: sc-23.5
-      title: Allowed Certificate Authorities
-      rules: []
-      status: pending
+      controls:
+          - id: sc-23.1
+            title: Invalidate Session Identifiers at Logout
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.2
+            title: User-initiated Logouts and Message Displays
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.3
+            title: Unique System-generated Session Identifiers
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.4
+            title: Unique Session Identifiers with Randomization
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-23.5
+            title: Allowed Certificate Authorities
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-24
       title: Fail in Known State
       levels:
@@ -476,10 +622,11 @@ controls:
       title: Decoys
       rules: []
       status: pending
-    - id: sc-26.1
-      title: Detection of Malicious Code
-      rules: []
-      status: pending
+      controls:
+          - id: sc-26.1
+            title: Detection of Malicious Code
+            rules: []
+            status: pending
     - id: sc-27
       title: Platform-independent Applications
       rules: []
@@ -490,76 +637,85 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: sc-28.1
-      title: Cryptographic Protection
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: sc-28.2
-      title: Offline Storage
-      rules: []
-      status: pending
-    - id: sc-28.3
-      title: Cryptographic Keys
-      rules: []
-      status: pending
+      controls:
+          - id: sc-28.1
+            title: Cryptographic Protection
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: sc-28.2
+            title: Offline Storage
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: sc-28.3
+            title: Cryptographic Keys
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sc-29
       title: Heterogeneity
       rules: []
       status: pending
-    - id: sc-29.1
-      title: Virtualization Techniques
-      rules: []
-      status: pending
+      controls:
+          - id: sc-29.1
+            title: Virtualization Techniques
+            rules: []
+            status: pending
     - id: sc-30
       title: Concealment and Misdirection
       rules: []
       status: pending
-    - id: sc-30.1
-      title: Virtualization Techniques
-      rules: []
-      status: pending
-    - id: sc-30.2
-      title: Randomness
-      rules: []
-      status: pending
-    - id: sc-30.3
-      title: Change Processing and Storage Locations
-      rules: []
-      status: pending
-    - id: sc-30.4
-      title: Misleading Information
-      rules: []
-      status: pending
-    - id: sc-30.5
-      title: Concealment of System Components
-      rules: []
-      status: pending
+      controls:
+          - id: sc-30.1
+            title: Virtualization Techniques
+            rules: []
+            status: pending
+          - id: sc-30.2
+            title: Randomness
+            rules: []
+            status: pending
+          - id: sc-30.3
+            title: Change Processing and Storage Locations
+            rules: []
+            status: pending
+          - id: sc-30.4
+            title: Misleading Information
+            rules: []
+            status: pending
+          - id: sc-30.5
+            title: Concealment of System Components
+            rules: []
+            status: pending
     - id: sc-31
       title: Covert Channel Analysis
       rules: []
       status: pending
-    - id: sc-31.1
-      title: Test Covert Channels for Exploitability
-      rules: []
-      status: pending
-    - id: sc-31.2
-      title: Maximum Bandwidth
-      rules: []
-      status: pending
-    - id: sc-31.3
-      title: Measure Bandwidth in Operational Environments
-      rules: []
-      status: pending
+      controls:
+          - id: sc-31.1
+            title: Test Covert Channels for Exploitability
+            rules: []
+            status: pending
+          - id: sc-31.2
+            title: Maximum Bandwidth
+            rules: []
+            status: pending
+          - id: sc-31.3
+            title: Measure Bandwidth in Operational Environments
+            rules: []
+            status: pending
     - id: sc-32
       title: System Partitioning
       rules: []
       status: pending
-    - id: sc-32.1
-      title: Separate Physical Domains for Privileged Functions
-      rules: []
-      status: pending
+      controls:
+          - id: sc-32.1
+            title: Separate Physical Domains for Privileged Functions
+            rules: []
+            status: pending
     - id: sc-33
       title: Transmission Preparation Integrity
       rules: []
@@ -568,18 +724,19 @@ controls:
       title: Non-modifiable Executable Programs
       rules: []
       status: pending
-    - id: sc-34.1
-      title: No Writable Storage
-      rules: []
-      status: pending
-    - id: sc-34.2
-      title: Integrity Protection on Read-only Media
-      rules: []
-      status: pending
-    - id: sc-34.3
-      title: Hardware-based Protection
-      rules: []
-      status: pending
+      controls:
+          - id: sc-34.1
+            title: No Writable Storage
+            rules: []
+            status: pending
+          - id: sc-34.2
+            title: Integrity Protection on Read-only Media
+            rules: []
+            status: pending
+          - id: sc-34.3
+            title: Hardware-based Protection
+            rules: []
+            status: pending
     - id: sc-35
       title: External Malicious Code Identification
       rules: []
@@ -588,22 +745,24 @@ controls:
       title: Distributed Processing and Storage
       rules: []
       status: pending
-    - id: sc-36.1
-      title: Polling Techniques
-      rules: []
-      status: pending
-    - id: sc-36.2
-      title: Synchronization
-      rules: []
-      status: pending
+      controls:
+          - id: sc-36.1
+            title: Polling Techniques
+            rules: []
+            status: pending
+          - id: sc-36.2
+            title: Synchronization
+            rules: []
+            status: pending
     - id: sc-37
       title: Out-of-band Channels
       rules: []
       status: pending
-    - id: sc-37.1
-      title: Ensure Delivery and Transmission
-      rules: []
-      status: pending
+      controls:
+          - id: sc-37.1
+            title: Ensure Delivery and Transmission
+            rules: []
+            status: pending
     - id: sc-38
       title: Operations Security
       rules: []
@@ -614,34 +773,40 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sc-39.1
-      title: Hardware Separation
-      rules: []
-      status: pending
-    - id: sc-39.2
-      title: Separate Execution Domain Per Thread
-      rules: []
-      status: pending
+      controls:
+          - id: sc-39.1
+            title: Hardware Separation
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sc-39.2
+            title: Separate Execution Domain Per Thread
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sc-40
       title: Wireless Link Protection
       rules: []
       status: pending
-    - id: sc-40.1
-      title: Electromagnetic Interference
-      rules: []
-      status: pending
-    - id: sc-40.2
-      title: Reduce Detection Potential
-      rules: []
-      status: pending
-    - id: sc-40.3
-      title: Imitative or Manipulative Communications Deception
-      rules: []
-      status: pending
-    - id: sc-40.4
-      title: Signal Parameter Identification
-      rules: []
-      status: pending
+      controls:
+          - id: sc-40.1
+            title: Electromagnetic Interference
+            rules: []
+            status: pending
+          - id: sc-40.2
+            title: Reduce Detection Potential
+            rules: []
+            status: pending
+          - id: sc-40.3
+            title: Imitative or Manipulative Communications Deception
+            rules: []
+            status: pending
+          - id: sc-40.4
+            title: Signal Parameter Identification
+            rules: []
+            status: pending
     - id: sc-41
       title: Port and I/O Device Access
       rules: []
@@ -650,26 +815,27 @@ controls:
       title: Sensor Capability and Data
       rules: []
       status: pending
-    - id: sc-42.1
-      title: Reporting to Authorized Individuals or Roles
-      rules: []
-      status: pending
-    - id: sc-42.2
-      title: Authorized Use
-      rules: []
-      status: pending
-    - id: sc-42.3
-      title: Prohibit Use of Devices
-      rules: []
-      status: pending
-    - id: sc-42.4
-      title: Notice of Collection
-      rules: []
-      status: pending
-    - id: sc-42.5
-      title: Collection Minimization
-      rules: []
-      status: pending
+      controls:
+          - id: sc-42.1
+            title: Reporting to Authorized Individuals or Roles
+            rules: []
+            status: pending
+          - id: sc-42.2
+            title: Authorized Use
+            rules: []
+            status: pending
+          - id: sc-42.3
+            title: Prohibit Use of Devices
+            rules: []
+            status: pending
+          - id: sc-42.4
+            title: Notice of Collection
+            rules: []
+            status: pending
+          - id: sc-42.5
+            title: Collection Minimization
+            rules: []
+            status: pending
     - id: sc-43
       title: Usage Restrictions
       rules: []
@@ -682,14 +848,15 @@ controls:
       title: System Time Synchronization
       rules: []
       status: pending
-    - id: sc-45.1
-      title: Synchronization with Authoritative Time Source
-      rules: []
-      status: pending
-    - id: sc-45.2
-      title: Secondary Authoritative Time Source
-      rules: []
-      status: pending
+      controls:
+          - id: sc-45.1
+            title: Synchronization with Authoritative Time Source
+            rules: []
+            status: pending
+          - id: sc-45.2
+            title: Secondary Authoritative Time Source
+            rules: []
+            status: pending
     - id: sc-46
       title: Cross Domain Policy Enforcement
       rules: []
@@ -702,10 +869,11 @@ controls:
       title: Sensor Relocation
       rules: []
       status: pending
-    - id: sc-48.1
-      title: Dynamic Relocation of Sensors or Monitoring Capabilities
-      rules: []
-      status: pending
+      controls:
+          - id: sc-48.1
+            title: Dynamic Relocation of Sensors or Monitoring Capabilities
+            rules: []
+            status: pending
     - id: sc-49
       title: Hardware-enforced Separation and Policy Enforcement
       rules: []

--- a/products/rhel9/controls/nist_800_53/si.yml
+++ b/products/rhel9/controls/nist_800_53/si.yml
@@ -15,36 +15,49 @@ controls:
           - ensure_gpgcheck_never_disabled
           - ensure_redhat_gpgkey_installed
       status: automated
-    - id: si-2.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-2.2
-      title: Automated Flaw Remediation Status
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-2.3
-      title: Time to Remediate Flaws and Benchmarks for Corrective Actions
-      rules: []
-      status: pending
-    - id: si-2.4
-      title: Automated Patch Management Tools
-      rules: []
-      status: pending
-    - id: si-2.5
-      title: Automatic Software and Firmware Updates
-      rules: []
-      status: pending
-    - id: si-2.6
-      title: Removal of Previous Versions of Software and Firmware
-      rules: []
-      status: pending
-    - id: si-2.7
-      title: Root Cause Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-2.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.2
+            title: Automated Flaw Remediation Status
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-2.3
+            title: Time to Remediate Flaws and Benchmarks for Corrective Actions
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.4
+            title: Automated Patch Management Tools
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.5
+            title: Automatic Software and Firmware Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.6
+            title: Removal of Previous Versions of Software and Firmware
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-2.7
+            title: Root Cause Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-3
       title: Malicious Code Protection
       levels:
@@ -53,46 +66,67 @@ controls:
           - kernel_module_usb-storage_disabled
           - service_autofs_disabled
       status: automated
-    - id: si-3.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-3.2
-      title: Automatic Updates
-      rules: []
-      status: pending
-    - id: si-3.3
-      title: Non-privileged Users
-      rules: []
-      status: pending
-    - id: si-3.4
-      title: Updates Only by Privileged Users
-      rules: []
-      status: pending
-    - id: si-3.5
-      title: Portable Storage Devices
-      rules: []
-      status: pending
-    - id: si-3.6
-      title: Testing and Verification
-      rules: []
-      status: pending
-    - id: si-3.7
-      title: Nonsignature-based Detection
-      rules: []
-      status: pending
-    - id: si-3.8
-      title: Detect Unauthorized Commands
-      rules: []
-      status: pending
-    - id: si-3.9
-      title: Authenticate Remote Commands
-      rules: []
-      status: pending
-    - id: si-3.10
-      title: Malicious Code Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-3.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.2
+            title: Automatic Updates
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.3
+            title: Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.4
+            title: Updates Only by Privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.5
+            title: Portable Storage Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.6
+            title: Testing and Verification
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.7
+            title: Nonsignature-based Detection
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.8
+            title: Detect Unauthorized Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.9
+            title: Authenticate Remote Commands
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-3.10
+            title: Malicious Code Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-4
       title: System Monitoring
       levels:
@@ -104,256 +138,329 @@ controls:
           - kernel_module_tipc_disabled
           - service_avahi-daemon_disabled
       status: automated
-    - id: si-4.1
-      title: System-wide Intrusion Detection System
-      rules: []
-      status: pending
-    - id: si-4.2
-      title: Automated Tools and Mechanisms for Real-time Analysis
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.3
-      title: Automated Tool and Mechanism Integration
-      rules: []
-      status: pending
-    - id: si-4.4
-      title: Inbound and Outbound Communications Traffic
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.5
-      title: System-generated Alerts
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-4.6
-      title: Restrict Non-privileged Users
-      rules: []
-      status: pending
-    - id: si-4.7
-      title: Automated Response to Suspicious Events
-      rules: []
-      status: pending
-    - id: si-4.8
-      title: Protection of Monitoring Information
-      rules: []
-      status: pending
-    - id: si-4.9
-      title: Testing of Monitoring Tools and Mechanisms
-      rules: []
-      status: pending
-    - id: si-4.10
-      title: Visibility of Encrypted Communications
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.11
-      title: Analyze Communications Traffic Anomalies
-      rules: []
-      status: pending
-    - id: si-4.12
-      title: Automated Organization-generated Alerts
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.13
-      title: Analyze Traffic and Event Patterns
-      rules: []
-      status: pending
-    - id: si-4.14
-      title: Wireless Intrusion Detection
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.15
-      title: Wireless to Wireline Communications
-      rules: []
-      status: pending
-    - id: si-4.16
-      title: Correlate Monitoring Information
-      rules: []
-      status: pending
-    - id: si-4.17
-      title: Integrated Situational Awareness
-      rules: []
-      status: pending
-    - id: si-4.18
-      title: Analyze Traffic and Covert Exfiltration
-      rules: []
-      status: pending
-    - id: si-4.19
-      title: Risk for Individuals
-      rules: []
-      status: pending
-    - id: si-4.20
-      title: Privileged Users
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.21
-      title: Probationary Periods
-      rules: []
-      status: pending
-    - id: si-4.22
-      title: Unauthorized Network Services
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-4.23
-      title: Host-based Devices
-      rules: []
-      status: pending
-    - id: si-4.24
-      title: Indicators of Compromise
-      rules: []
-      status: pending
-    - id: si-4.25
-      title: Optimize Network Traffic Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: si-4.1
+            title: System-wide Intrusion Detection System
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.2
+            title: Automated Tools and Mechanisms for Real-time Analysis
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.3
+            title: Automated Tool and Mechanism Integration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.4
+            title: Inbound and Outbound Communications Traffic
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.5
+            title: System-generated Alerts
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-4.6
+            title: Restrict Non-privileged Users
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.7
+            title: Automated Response to Suspicious Events
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.8
+            title: Protection of Monitoring Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.9
+            title: Testing of Monitoring Tools and Mechanisms
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.10
+            title: Visibility of Encrypted Communications
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.11
+            title: Analyze Communications Traffic Anomalies
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.12
+            title: Automated Organization-generated Alerts
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.13
+            title: Analyze Traffic and Event Patterns
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.14
+            title: Wireless Intrusion Detection
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.15
+            title: Wireless to Wireline Communications
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.16
+            title: Correlate Monitoring Information
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.17
+            title: Integrated Situational Awareness
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.18
+            title: Analyze Traffic and Covert Exfiltration
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.19
+            title: Risk for Individuals
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.20
+            title: Privileged Users
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.21
+            title: Probationary Periods
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.22
+            title: Unauthorized Network Services
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-4.23
+            title: Host-based Devices
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.24
+            title: Indicators of Compromise
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-4.25
+            title: Optimize Network Traffic Analysis
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-5
       title: Security Alerts, Advisories, and Directives
       levels:
           - low
       rules: []
       status: pending
-    - id: si-5.1
-      title: Automated Alerts and Advisories
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: si-5.1
+            title: Automated Alerts and Advisories
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: si-6
       title: Security and Privacy Function Verification
       levels:
           - high
       rules: []
       status: pending
-    - id: si-6.1
-      title: Notification of Failed Security Tests
-      rules: []
-      status: pending
-    - id: si-6.2
-      title: Automation Support for Distributed Testing
-      rules: []
-      status: pending
-    - id: si-6.3
-      title: Report Verification Results
-      rules: []
-      status: pending
+      controls:
+          - id: si-6.1
+            title: Notification of Failed Security Tests
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: si-6.2
+            title: Automation Support for Distributed Testing
+            rules: []
+            status: pending
+            levels:
+                - high
+          - id: si-6.3
+            title: Report Verification Results
+            rules: []
+            status: pending
+            levels:
+                - high
     - id: si-7
       title: Software, Firmware, and Information Integrity
       levels:
           - moderate
       rules: []
       status: pending
-    - id: si-7.1
-      title: Integrity Checks
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-7.2
-      title: Automated Notifications of Integrity Violations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.3
-      title: Centrally Managed Integrity Tools
-      rules: []
-      status: pending
-    - id: si-7.4
-      title: Tamper-evident Packaging
-      rules: []
-      status: pending
-    - id: si-7.5
-      title: Automated Response to Integrity Violations
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.6
-      title: Cryptographic Protection
-      rules: []
-      status: pending
-    - id: si-7.7
-      title: Integration of Detection and Response
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-7.8
-      title: Auditing Capability for Significant Events
-      rules: []
-      status: pending
-    - id: si-7.9
-      title: Verify Boot Process
-      rules: []
-      status: pending
-    - id: si-7.10
-      title: Protection of Boot Firmware
-      rules: []
-      status: pending
-    - id: si-7.11
-      title: Confined Environments with Limited Privileges
-      rules: []
-      status: pending
-    - id: si-7.12
-      title: Integrity Verification
-      rules: []
-      status: pending
-    - id: si-7.13
-      title: Code Execution in Protected Environments
-      rules: []
-      status: pending
-    - id: si-7.14
-      title: Binary or Machine Executable Code
-      rules: []
-      status: pending
-    - id: si-7.15
-      title: Code Authentication
-      levels:
-          - high
-      rules: []
-      status: pending
-    - id: si-7.16
-      title: Time Limit on Process Execution Without Supervision
-      rules: []
-      status: pending
-    - id: si-7.17
-      title: Runtime Application Self-protection
-      rules: []
-      status: pending
+      controls:
+          - id: si-7.1
+            title: Integrity Checks
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-7.2
+            title: Automated Notifications of Integrity Violations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.3
+            title: Centrally Managed Integrity Tools
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.4
+            title: Tamper-evident Packaging
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.5
+            title: Automated Response to Integrity Violations
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.6
+            title: Cryptographic Protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.7
+            title: Integration of Detection and Response
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-7.8
+            title: Auditing Capability for Significant Events
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.9
+            title: Verify Boot Process
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.10
+            title: Protection of Boot Firmware
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.11
+            title: Confined Environments with Limited Privileges
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.12
+            title: Integrity Verification
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.13
+            title: Code Execution in Protected Environments
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.14
+            title: Binary or Machine Executable Code
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.15
+            title: Code Authentication
+            levels:
+                - high
+            rules: []
+            status: pending
+          - id: si-7.16
+            title: Time Limit on Process Execution Without Supervision
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-7.17
+            title: Runtime Application Self-protection
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-8
       title: Spam Protection
       levels:
           - moderate
       rules: []
       status: pending
-    - id: si-8.1
-      title: Central Management
-      rules: []
-      status: pending
-    - id: si-8.2
-      title: Automatic Updates
-      levels:
-          - moderate
-      rules: []
-      status: pending
-    - id: si-8.3
-      title: Continuous Learning Capability
-      rules: []
-      status: pending
+      controls:
+          - id: si-8.1
+            title: Central Management
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-8.2
+            title: Automatic Updates
+            levels:
+                - moderate
+            rules: []
+            status: pending
+          - id: si-8.3
+            title: Continuous Learning Capability
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-9
       title: Information Input Restrictions
       rules: []
@@ -364,30 +471,43 @@ controls:
           - moderate
       rules: []
       status: pending
-    - id: si-10.1
-      title: Manual Override Capability
-      rules: []
-      status: pending
-    - id: si-10.2
-      title: Review and Resolve Errors
-      rules: []
-      status: pending
-    - id: si-10.3
-      title: Predictable Behavior
-      rules: []
-      status: pending
-    - id: si-10.4
-      title: Timing Interactions
-      rules: []
-      status: pending
-    - id: si-10.5
-      title: Restrict Inputs to Trusted Sources and Approved Formats
-      rules: []
-      status: pending
-    - id: si-10.6
-      title: Injection Prevention
-      rules: []
-      status: pending
+      controls:
+          - id: si-10.1
+            title: Manual Override Capability
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.2
+            title: Review and Resolve Errors
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.3
+            title: Predictable Behavior
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.4
+            title: Timing Interactions
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.5
+            title: Restrict Inputs to Trusted Sources and Approved Formats
+            rules: []
+            status: pending
+            levels:
+                - moderate
+          - id: si-10.6
+            title: Injection Prevention
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: si-11
       title: Error Handling
       levels:
@@ -400,58 +520,68 @@ controls:
           - low
       rules: []
       status: pending
-    - id: si-12.1
-      title: Limit Personally Identifiable Information Elements
-      rules: []
-      status: pending
-    - id: si-12.2
-      title: Minimize Personally Identifiable Information in Testing, Training, and Research
-      rules: []
-      status: pending
-    - id: si-12.3
-      title: Information Disposal
-      rules: []
-      status: pending
+      controls:
+          - id: si-12.1
+            title: Limit Personally Identifiable Information Elements
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-12.2
+            title: Minimize Personally Identifiable Information in Testing,
+                Training, and Research
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: si-12.3
+            title: Information Disposal
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: si-13
       title: Predictable Failure Prevention
       rules: []
       status: pending
-    - id: si-13.1
-      title: Transferring Component Responsibilities
-      rules: []
-      status: pending
-    - id: si-13.2
-      title: Time Limit on Process Execution Without Supervision
-      rules: []
-      status: pending
-    - id: si-13.3
-      title: Manual Transfer Between Components
-      rules: []
-      status: pending
-    - id: si-13.4
-      title: Standby Component Installation and Notification
-      rules: []
-      status: pending
-    - id: si-13.5
-      title: Failover Capability
-      rules: []
-      status: pending
+      controls:
+          - id: si-13.1
+            title: Transferring Component Responsibilities
+            rules: []
+            status: pending
+          - id: si-13.2
+            title: Time Limit on Process Execution Without Supervision
+            rules: []
+            status: pending
+          - id: si-13.3
+            title: Manual Transfer Between Components
+            rules: []
+            status: pending
+          - id: si-13.4
+            title: Standby Component Installation and Notification
+            rules: []
+            status: pending
+          - id: si-13.5
+            title: Failover Capability
+            rules: []
+            status: pending
     - id: si-14
       title: Non-persistence
       rules: []
       status: pending
-    - id: si-14.1
-      title: Refresh from Trusted Sources
-      rules: []
-      status: pending
-    - id: si-14.2
-      title: Non-persistent Information
-      rules: []
-      status: pending
-    - id: si-14.3
-      title: Non-persistent Connectivity
-      rules: []
-      status: pending
+      controls:
+          - id: si-14.1
+            title: Refresh from Trusted Sources
+            rules: []
+            status: pending
+          - id: si-14.2
+            title: Non-persistent Information
+            rules: []
+            status: pending
+          - id: si-14.3
+            title: Non-persistent Connectivity
+            rules: []
+            status: pending
     - id: si-15
       title: Information Output Filtering
       rules: []
@@ -471,62 +601,65 @@ controls:
       title: Personally Identifiable Information Quality Operations
       rules: []
       status: pending
-    - id: si-18.1
-      title: Automation Support
-      rules: []
-      status: pending
-    - id: si-18.2
-      title: Data Tags
-      rules: []
-      status: pending
-    - id: si-18.3
-      title: Collection
-      rules: []
-      status: pending
-    - id: si-18.4
-      title: Individual Requests
-      rules: []
-      status: pending
-    - id: si-18.5
-      title: Notice of Correction or Deletion
-      rules: []
-      status: pending
+      controls:
+          - id: si-18.1
+            title: Automation Support
+            rules: []
+            status: pending
+          - id: si-18.2
+            title: Data Tags
+            rules: []
+            status: pending
+          - id: si-18.3
+            title: Collection
+            rules: []
+            status: pending
+          - id: si-18.4
+            title: Individual Requests
+            rules: []
+            status: pending
+          - id: si-18.5
+            title: Notice of Correction or Deletion
+            rules: []
+            status: pending
     - id: si-19
       title: De-identification
       rules: []
       status: pending
-    - id: si-19.1
-      title: Collection
-      rules: []
-      status: pending
-    - id: si-19.2
-      title: Archiving
-      rules: []
-      status: pending
-    - id: si-19.3
-      title: Release
-      rules: []
-      status: pending
-    - id: si-19.4
-      title: Removal, Masking, Encryption, Hashing, or Replacement of Direct Identifiers
-      rules: []
-      status: pending
-    - id: si-19.5
-      title: Statistical Disclosure Control
-      rules: []
-      status: pending
-    - id: si-19.6
-      title: Differential Privacy
-      rules: []
-      status: pending
-    - id: si-19.7
-      title: Validated Algorithms and Software
-      rules: []
-      status: pending
-    - id: si-19.8
-      title: Motivated Intruder
-      rules: []
-      status: pending
+      controls:
+          - id: si-19.1
+            title: Collection
+            rules: []
+            status: pending
+          - id: si-19.2
+            title: Archiving
+            rules: []
+            status: pending
+          - id: si-19.3
+            title: Release
+            rules: []
+            status: pending
+          - id: si-19.4
+            title: Removal, Masking, Encryption, Hashing, or Replacement of
+                Direct Identifiers
+            rules: []
+            status: pending
+          - id: si-19.5
+            title: Statistical Disclosure Control
+            rules: []
+            status: pending
+          - id: si-19.6
+            title: Differential Privacy
+            rules: []
+            status: pending
+          - id: si-19.7
+            title: Validated Algorithms and Software
+            rules: []
+            status: pending
+          - id: si-19.8
+            title: Motivated Intruder
+            rules: []
+            status: pending
     - id: si-20
       title: Tainting
       rules: []

--- a/products/rhel9/controls/nist_800_53/sr.yml
+++ b/products/rhel9/controls/nist_800_53/sr.yml
@@ -12,74 +12,92 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sr-2.1
-      title: Establish SCRM Team
-      levels:
-          - low
-      rules: []
-      status: pending
+      controls:
+          - id: sr-2.1
+            title: Establish SCRM Team
+            levels:
+                - low
+            rules: []
+            status: pending
     - id: sr-3
       title: Supply Chain Controls and Processes
       levels:
           - low
       rules: []
       status: pending
-    - id: sr-3.1
-      title: Diverse Supply Base
-      rules: []
-      status: pending
-    - id: sr-3.2
-      title: Limitation of Harm
-      rules: []
-      status: pending
-    - id: sr-3.3
-      title: Sub-tier Flow Down
-      rules: []
-      status: pending
+      controls:
+          - id: sr-3.1
+            title: Diverse Supply Base
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-3.2
+            title: Limitation of Harm
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-3.3
+            title: Sub-tier Flow Down
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-4
       title: Provenance
       rules: []
       status: pending
-    - id: sr-4.1
-      title: Identity
-      rules: []
-      status: pending
-    - id: sr-4.2
-      title: Track and Trace
-      rules: []
-      status: pending
-    - id: sr-4.3
-      title: Validate as Genuine and Not Altered
-      rules: []
-      status: pending
-    - id: sr-4.4
-      title: Supply Chain Integrity — Pedigree
-      rules: []
-      status: pending
+      controls:
+          - id: sr-4.1
+            title: Identity
+            rules: []
+            status: pending
+          - id: sr-4.2
+            title: Track and Trace
+            rules: []
+            status: pending
+          - id: sr-4.3
+            title: Validate as Genuine and Not Altered
+            rules: []
+            status: pending
+          - id: sr-4.4
+            title: Supply Chain Integrity — Pedigree
+            rules: []
+            status: pending
     - id: sr-5
       title: Acquisition Strategies, Tools, and Methods
       levels:
           - low
       rules: []
       status: pending
-    - id: sr-5.1
-      title: Adequate Supply
-      rules: []
-      status: pending
-    - id: sr-5.2
-      title: Assessments Prior to Selection, Acceptance, Modification, or Update
-      rules: []
-      status: pending
+      controls:
+          - id: sr-5.1
+            title: Adequate Supply
+            rules: []
+            status: pending
+            levels:
+                - low
+          - id: sr-5.2
+            title: Assessments Prior to Selection, Acceptance, Modification, or
+                Update
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-6
       title: Supplier Assessments and Reviews
       levels:
           - moderate
       rules: []
       status: pending
-    - id: sr-6.1
-      title: Testing and Analysis
-      rules: []
-      status: pending
+      controls:
+          - id: sr-6.1
+            title: Testing and Analysis
+            rules: []
+            status: pending
+            levels:
+                - moderate
     - id: sr-7
       title: Supply Chain Operations Security
       rules: []
@@ -96,12 +114,13 @@ controls:
           - high
       rules: []
       status: pending
-    - id: sr-9.1
-      title: Multiple Stages of System Development Life Cycle
-      levels:
-          - high
-      rules: []
-      status: pending
+      controls:
+          - id: sr-9.1
+            title: Multiple Stages of System Development Life Cycle
+            levels:
+                - high
+            rules: []
+            status: pending
     - id: sr-10
       title: Inspection of Systems or Components
       levels:
@@ -114,22 +133,25 @@ controls:
           - low
       rules: []
       status: pending
-    - id: sr-11.1
-      title: Anti-counterfeit Training
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sr-11.2
-      title: Configuration Control for Component Service and Repair
-      levels:
-          - low
-      rules: []
-      status: pending
-    - id: sr-11.3
-      title: Anti-counterfeit Scanning
-      rules: []
-      status: pending
+      controls:
+          - id: sr-11.1
+            title: Anti-counterfeit Training
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sr-11.2
+            title: Configuration Control for Component Service and Repair
+            levels:
+                - low
+            rules: []
+            status: pending
+          - id: sr-11.3
+            title: Anti-counterfeit Scanning
+            rules: []
+            status: pending
+            levels:
+                - low
     - id: sr-12
       title: Component Disposal
       levels:

--- a/utils/nist_sync/generate_nist_viewer.py
+++ b/utils/nist_sync/generate_nist_viewer.py
@@ -87,6 +87,23 @@ def load_oscal_catalog(data_dir: Path) -> Dict[str, Any]:
     return controls_map
 
 
+def _flatten_controls(controls_list, parent_id=None):
+    """Recursively flatten nested controls, adding parent_id and enhancements info."""
+    result = []
+    for ctrl in controls_list:
+        ctrl_copy = dict(ctrl)
+        if parent_id:
+            ctrl_copy['parent_id'] = parent_id
+        nested = ctrl_copy.pop('controls', None)
+        if nested:
+            ctrl_copy['enhancements'] = [str(c.get('id', '')) for c in nested]
+            result.append(ctrl_copy)
+            result.extend(_flatten_controls(nested, parent_id=str(ctrl.get('id', ''))))
+        else:
+            result.append(ctrl_copy)
+    return result
+
+
 def load_product_controls(product: str, repo_root: Path) -> Dict[str, Any]:
     """Load control files for a product."""
     controls_dir = repo_root / 'products' / product / 'controls' / 'nist_800_53'
@@ -101,12 +118,12 @@ def load_product_controls(product: str, repo_root: Path) -> Dict[str, Any]:
     if metadata_file.exists():
         metadata = load_yaml(metadata_file)
 
-    # Load all family files
+    # Load all family files, flattening nested enhancements
     controls = []
     for family_file in sorted(controls_dir.glob('*.yml')):
         family_data = load_yaml(family_file)
         if 'controls' in family_data:
-            controls.extend(family_data['controls'])
+            controls.extend(_flatten_controls(family_data['controls']))
 
     return {
         'product': product,
@@ -235,6 +252,11 @@ def merge_control_data(product_controls: Dict[str, Any], oscal_controls: Dict[st
             'is_not_applicable': control.get('status') == 'not applicable',
         }
 
+        if control.get('parent_id'):
+            merged_control['parent_id'] = control['parent_id']
+        if control.get('enhancements'):
+            merged_control['enhancements'] = control['enhancements']
+
         merged.append(merged_control)
 
     return merged
@@ -361,8 +383,12 @@ def generate_viewer_data(products: List[str], repo_root: Path) -> Dict[str, Any]
     stats = {}
     for product, data in products_data.items():
         controls = data['controls']
+        base = [c for c in controls if not c.get('parent_id')]
+        enhancements = [c for c in controls if c.get('parent_id')]
         stats[product] = {
             'total': len(controls),
+            'base_controls': len(base),
+            'enhancement_controls': len(enhancements),
             'automated': sum(1 for c in controls if c['is_automated']),
             'manual': sum(1 for c in controls if c['is_manual']),
             'pending': sum(1 for c in controls if c['is_pending']),
@@ -371,6 +397,10 @@ def generate_viewer_data(products: List[str], repo_root: Path) -> Dict[str, Any]
             'not_applicable': sum(1 for c in controls if c['is_not_applicable']),
             'with_rules': sum(1 for c in controls if c['has_rules']),
             'without_rules': sum(1 for c in controls if not c['has_rules']),
+            'base_automated': sum(1 for c in base if c['is_automated']),
+            'base_pending': sum(1 for c in base if c['is_pending']),
+            'enh_automated': sum(1 for c in enhancements if c['is_automated']),
+            'enh_pending': sum(1 for c in enhancements if c['is_pending']),
         }
 
     # Build component statistics per product

--- a/utils/nist_sync/sync_nist_split.py
+++ b/utils/nist_sync/sync_nist_split.py
@@ -542,7 +542,32 @@ class NISTSplitSync:
             })
             print(f"  Added {len(unmapped_item_names)} unmapped CIS items ({len(unmapped_items_full)} total assignments) to 'other' family")
 
-        print(f"  Generated {sum(len(c) for c in controls_by_family.values())} controls across {len(controls_by_family)} families")
+        # Nest enhancements under their parent base controls
+        total_nested = 0
+        total_levels_inherited = 0
+        for family, controls_list in controls_by_family.items():
+            base_controls = []
+            enhancement_map = defaultdict(list)
+            for ctrl in controls_list:
+                if '.' in ctrl['id']:
+                    parent_id = ctrl['id'].rsplit('.', 1)[0]
+                    enhancement_map[parent_id].append(ctrl)
+                else:
+                    base_controls.append(ctrl)
+            for base in base_controls:
+                enhancements = enhancement_map.get(base['id'], [])
+                if enhancements:
+                    base_levels = base.get('levels', [])
+                    for enh in enhancements:
+                        if ('levels' not in enh or not enh['levels']) and base_levels:
+                            enh['levels'] = list(base_levels)
+                            total_levels_inherited += 1
+                    base['controls'] = enhancements
+                    total_nested += len(enhancements)
+            controls_by_family[family] = base_controls
+
+        print(f"  Generated {sum(len(c) for c in controls_by_family.values())} base controls across {len(controls_by_family)} families")
+        print(f"  Nested {total_nested} enhancements, {total_levels_inherited} levels inherited from parent")
 
         return controls_by_family
 

--- a/utils/nist_sync/templates/control-detail.html
+++ b/utils/nist_sync/templates/control-detail.html
@@ -482,6 +482,44 @@
                 `;
             }
 
+            // Enhancements (for base controls)
+            if (control.enhancements && control.enhancements.length > 0) {
+                const enhControls = control.enhancements
+                    .map(eid => controls.find(c => c.id === eid))
+                    .filter(Boolean);
+                const automatedCount = enhControls.filter(e => e.is_automated).length;
+                const totalCount = enhControls.length;
+                const pct = totalCount > 0 ? Math.round(automatedCount / totalCount * 100) : 0;
+
+                html += `
+                    <div class="card detail-section">
+                        <h3>Control Enhancements (${automatedCount}/${totalCount} automated)</h3>
+                        <div style="background: #e1e4e8; border-radius: 4px; height: 8px; margin-bottom: 15px;">
+                            <div style="background: #28a745; height: 8px; border-radius: 4px; width: ${pct}%;"></div>
+                        </div>
+                        <div style="display: flex; flex-direction: column; gap: 8px;">
+                `;
+                enhControls.forEach(enh => {
+                    const enhStatus = enh.is_automated ? 'automated' :
+                                    enh.is_manual ? 'manual' : 'pending';
+                    const enhGap = enh.has_rules ? '' :
+                        '<span class="gap-indicator gap-full"></span>';
+                    html += `
+                        <a href="control-detail.html?id=${enh.id}" style="text-decoration: none; display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; background: #f6f8fa; border-left: 3px solid #0366d6; border-radius: 4px;">
+                            <div>
+                                <span style="font-weight: 600; color: #0366d6;">${enhGap}${enh.id.toUpperCase()}</span>
+                                <span style="color: #24292e; margin-left: 8px;">${enh.title}</span>
+                            </div>
+                            <span class="badge badge-${enhStatus}">${enhStatus.toUpperCase()}</span>
+                        </a>
+                    `;
+                });
+                html += `
+                        </div>
+                    </div>
+                `;
+            }
+
             // Components
             if (control.components && Object.keys(control.components).length > 0) {
                 const sortedComps = Object.entries(control.components)
@@ -512,6 +550,22 @@
                         `).join('')}
                     </div>
                 `;
+            }
+
+            // Parent control link (for enhancements)
+            if (control.parent_id) {
+                const parentCtrl = controls.find(c => c.id === control.parent_id);
+                if (parentCtrl) {
+                    html += `
+                        <div class="card detail-section">
+                            <h3>Parent Control</h3>
+                            <a href="control-detail.html?id=${parentCtrl.id}" style="text-decoration: none; display: flex; align-items: center; gap: 8px; padding: 10px 12px; background: #f6f8fa; border-left: 3px solid #0366d6; border-radius: 4px;">
+                                <span style="font-weight: 600; color: #0366d6;">${parentCtrl.id.toUpperCase()}</span>
+                                <span style="color: #24292e;">${parentCtrl.title}</span>
+                            </a>
+                        </div>
+                    `;
+                }
             }
 
             // Related Controls

--- a/utils/nist_sync/templates/controls.html
+++ b/utils/nist_sync/templates/controls.html
@@ -66,12 +66,15 @@
             min-height: 400px;
         }
 
+        .control-group {
+            margin-bottom: 15px;
+        }
+
         .control-item {
             background: #fff;
             border: 1px solid #e1e4e8;
             border-radius: 6px;
             padding: 15px;
-            margin-bottom: 15px;
             cursor: pointer;
             transition: all 0.2s;
         }
@@ -79,6 +82,66 @@
         .control-item:hover {
             border-color: #0366d6;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .control-item.base-control {
+            border-left: 4px solid #0366d6;
+        }
+
+        .enhancements-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 12px;
+            color: #0366d6;
+            cursor: pointer;
+            background: #f1f8ff;
+            border: 1px solid #c8e1ff;
+            border-radius: 12px;
+            padding: 2px 10px;
+            margin-left: 8px;
+            user-select: none;
+        }
+
+        .enhancements-toggle:hover {
+            background: #dbedff;
+        }
+
+        .enhancements-toggle .arrow {
+            transition: transform 0.2s;
+            font-size: 10px;
+        }
+
+        .enhancements-toggle .arrow.expanded {
+            transform: rotate(90deg);
+        }
+
+        .enhancements-summary {
+            font-size: 11px;
+            color: #586069;
+            margin-left: 4px;
+        }
+
+        .enhancements-container {
+            margin-left: 20px;
+            margin-top: 8px;
+            border-left: 2px solid #e1e4e8;
+            padding-left: 12px;
+        }
+
+        .enhancements-container .control-item {
+            margin-bottom: 8px;
+            padding: 10px 12px;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+
+        .enhancements-container .control-id {
+            font-size: 14px;
+        }
+
+        .enhancements-container .control-title {
+            font-size: 13px;
         }
 
         .control-header {
@@ -325,6 +388,37 @@
             renderControls();
         }
 
+        function renderControlCard(control, isEnhancement) {
+            const statusClass = control.is_automated ? 'automated' :
+                              control.is_manual ? 'manual' :
+                              control.is_inherently_met ? 'inherently_met' :
+                              control.is_does_not_meet ? 'does_not_meet' :
+                              control.is_not_applicable ? 'not_applicable' : 'pending';
+            const gapIndicator = control.has_rules ? '' :
+                '<span class="gap-indicator gap-full"></span>';
+
+            const levels = (control.levels || []).join(', ').toUpperCase();
+            const ruleCount = (control.rules || []).length;
+
+            return `
+                <div class="control-item ${isEnhancement ? '' : 'base-control'}" onclick="window.location.href='control-detail.html?id=${control.id}'">
+                    <div class="control-header">
+                        <div>
+                            <div class="control-id">
+                                ${gapIndicator}${control.id.toUpperCase()}
+                            </div>
+                            <div class="control-title">${control.title}</div>
+                        </div>
+                        <span class="badge badge-${statusClass}">${statusClass.toUpperCase()}</span>
+                    </div>
+                    <div class="control-meta">
+                        ${levels ? `<span>Baselines: ${levels}</span>` : ''}
+                        <span>Rules: ${ruleCount}</span>
+                    </div>
+                </div>
+            `;
+        }
+
         function renderControls() {
             const container = document.getElementById('controls-container');
             const resultsCount = document.getElementById('results-count');
@@ -336,37 +430,77 @@
                 return;
             }
 
-            container.innerHTML = filteredControls.map(control => {
-                const statusClass = control.is_automated ? 'automated' :
-                                  control.is_manual ? 'manual' :
-                              control.is_inherently_met ? 'inherently_met' :
-                              control.is_does_not_meet ? 'does_not_meet' :
-                              control.is_not_applicable ? 'not_applicable' : 'pending';
-                const gapIndicator = control.has_rules ? '' :
-                    '<span class="gap-indicator gap-full"></span>';
+            // Group: base controls with their enhancements
+            const filteredIds = new Set(filteredControls.map(c => c.id));
+            const baseControls = filteredControls.filter(c => !c.parent_id);
+            const enhancementsByParent = {};
+            filteredControls.forEach(c => {
+                if (c.parent_id) {
+                    if (!enhancementsByParent[c.parent_id]) enhancementsByParent[c.parent_id] = [];
+                    enhancementsByParent[c.parent_id].push(c);
+                }
+            });
 
-                const levels = (control.levels || []).join(', ').toUpperCase();
-                const ruleCount = (control.rules || []).length;
+            // Also find orphan enhancements (parent didn't match filter)
+            const orphanEnhancements = filteredControls.filter(c => c.parent_id && !filteredIds.has(c.parent_id));
 
-                return `
-                    <div class="control-item" onclick="window.location.href='control-detail.html?id=${control.id}'">
-                        <div class="control-header">
-                            <div>
-                                <div class="control-id">
-                                    ${gapIndicator}${control.id.toUpperCase()}
-                                </div>
-                                <div class="control-title">${control.title}</div>
-                            </div>
-                            <span class="badge badge-${statusClass}">${statusClass.toUpperCase()}</span>
+            let html = '';
+
+            baseControls.forEach(base => {
+                const enhancements = enhancementsByParent[base.id] || [];
+                const allEnhancements = (base.enhancements || []);
+                const totalEnhCount = allEnhancements.length;
+
+                html += '<div class="control-group">';
+                html += renderControlCard(base, false);
+
+                if (totalEnhCount > 0) {
+                    const automatedCount = enhancements.filter(e => e.is_automated).length;
+                    // Use all enhancements from data to get the full picture
+                    const allEnhControls = allControls.filter(c => allEnhancements.includes(c.id));
+                    const totalAutomated = allEnhControls.filter(e => e.is_automated).length;
+
+                    const toggleId = `enh-${base.id}`;
+                    html += `
+                        <div style="margin-left: 20px; margin-top: 4px;">
+                            <span class="enhancements-toggle" onclick="toggleEnhancements('${toggleId}', event)">
+                                <span class="arrow" id="arrow-${toggleId}">&#9654;</span>
+                                ${enhancements.length} of ${totalEnhCount} enhancements shown
+                                <span class="enhancements-summary">(${totalAutomated}/${totalEnhCount} automated)</span>
+                            </span>
                         </div>
-                        <div class="control-meta">
-                            ${levels ? `<span>📊 Baselines: ${levels}</span>` : ''}
-                            <span>📋 Rules: ${ruleCount}</span>
-                            ${control.component_count > 0 ? `<span>📦 Components: ${control.component_count}</span>` : ''}
-                        </div>
-                    </div>
-                `;
-            }).join('');
+                    `;
+
+                    if (enhancements.length > 0) {
+                        html += `<div class="enhancements-container" id="${toggleId}" style="display: none;">`;
+                        enhancements.forEach(enh => {
+                            html += renderControlCard(enh, true);
+                        });
+                        html += '</div>';
+                    }
+                }
+
+                html += '</div>';
+            });
+
+            // Render orphan enhancements (their parent wasn't in the filtered set)
+            orphanEnhancements.forEach(enh => {
+                html += '<div class="control-group">';
+                html += renderControlCard(enh, true);
+                html += '</div>';
+            });
+
+            container.innerHTML = html;
+        }
+
+        function toggleEnhancements(toggleId, event) {
+            event.stopPropagation();
+            const container = document.getElementById(toggleId);
+            const arrow = document.getElementById('arrow-' + toggleId);
+            if (!container) return;
+            const isVisible = container.style.display !== 'none';
+            container.style.display = isVisible ? 'none' : 'block';
+            arrow.classList.toggle('expanded', !isVisible);
         }
 
         function resetFilters() {

--- a/utils/nist_sync/templates/family.html
+++ b/utils/nist_sync/templates/family.html
@@ -343,31 +343,66 @@
             progressBar.style.width = coverage + '%';
             progressBar.textContent = coverage + '%';
 
-            // Render controls
+            // Render controls grouped by base control
             const controlsContainer = document.getElementById('controls-in-family');
             controlsContainer.innerHTML = '';
 
-            familyControls.sort((a, b) => a.id.localeCompare(b.id)).forEach(control => {
+            const baseControls = familyControls.filter(c => !c.parent_id).sort((a, b) => a.id.localeCompare(b.id));
+            const enhByParent = {};
+            familyControls.filter(c => c.parent_id).forEach(c => {
+                if (!enhByParent[c.parent_id]) enhByParent[c.parent_id] = [];
+                enhByParent[c.parent_id].push(c);
+            });
+
+            baseControls.forEach(control => {
                 const statusClass = control.is_automated ? 'automated' :
                                   control.is_manual ? 'manual' :
                               control.is_inherently_met ? 'inherently_met' :
                               control.is_does_not_meet ? 'does_not_meet' :
                               control.is_not_applicable ? 'not_applicable' : 'pending';
                 const gapClass = control.has_rules ? '' : 'gap';
+                const enhancements = (enhByParent[control.id] || []).sort((a, b) => a.id.localeCompare(b.id));
+                const enhAutoCount = enhancements.filter(e => e.is_automated).length;
 
                 const item = document.createElement('div');
                 item.className = `control-item-mini ${gapClass}`;
+                item.style.borderLeft = '4px solid #0366d6';
                 item.onclick = () => window.location.href = `control-detail.html?id=${control.id}`;
                 item.innerHTML = `
                     <div style="display: flex; justify-content: space-between; align-items: center;">
                         <div>
                             <strong style="color: #0366d6;">${control.id.toUpperCase()}</strong>
+                            ${enhancements.length > 0 ? `<span style="font-size: 11px; color: #586069; margin-left: 6px;">${enhAutoCount}/${enhancements.length} enh. automated</span>` : ''}
                             <div style="font-size: 13px; color: #586069; margin-top: 3px;">${control.title}</div>
                         </div>
                         <span class="badge badge-${statusClass}">${statusClass.toUpperCase()}</span>
                     </div>
                 `;
                 controlsContainer.appendChild(item);
+
+                if (enhancements.length > 0) {
+                    const enhContainer = document.createElement('div');
+                    enhContainer.style.cssText = 'margin-left: 20px; border-left: 2px solid #e1e4e8; padding-left: 8px; margin-bottom: 8px;';
+                    enhancements.forEach(enh => {
+                        const enhStatusClass = enh.is_automated ? 'automated' :
+                                             enh.is_manual ? 'manual' : 'pending';
+                        const enhItem = document.createElement('div');
+                        enhItem.className = `control-item-mini ${enh.has_rules ? '' : 'gap'}`;
+                        enhItem.style.cssText = 'padding: 6px 10px; margin-bottom: 4px;';
+                        enhItem.onclick = (e) => { e.stopPropagation(); window.location.href = `control-detail.html?id=${enh.id}`; };
+                        enhItem.innerHTML = `
+                            <div style="display: flex; justify-content: space-between; align-items: center;">
+                                <div>
+                                    <strong style="color: #0366d6; font-size: 13px;">${enh.id.toUpperCase()}</strong>
+                                    <span style="font-size: 12px; color: #586069; margin-left: 6px;">${enh.title}</span>
+                                </div>
+                                <span class="badge badge-${enhStatusClass}" style="font-size: 10px;">${enhStatusClass.toUpperCase()}</span>
+                            </div>
+                        `;
+                        enhContainer.appendChild(enhItem);
+                    });
+                    controlsContainer.appendChild(enhContainer);
+                }
             });
 
             document.getElementById('family-list-view').style.display = 'none';

--- a/utils/nist_sync/templates/gaps.html
+++ b/utils/nist_sync/templates/gaps.html
@@ -232,11 +232,24 @@
                 return;
             }
 
-            container.innerHTML = gaps.map(control => {
+            // Group gaps: base controls with their enhancement gaps
+            const baseGaps = gaps.filter(c => !c.parent_id);
+            const enhGapsByParent = {};
+            gaps.forEach(c => {
+                if (c.parent_id) {
+                    if (!enhGapsByParent[c.parent_id]) enhGapsByParent[c.parent_id] = [];
+                    enhGapsByParent[c.parent_id].push(c);
+                }
+            });
+
+            let html = '';
+
+            baseGaps.forEach(control => {
                 const levels = (control.levels || []).join(', ').toUpperCase();
                 const familyName = getFamilyName(control.id);
+                const childGaps = enhGapsByParent[control.id] || [];
 
-                return `
+                html += `
                     <div class="gap-item" onclick="window.location.href='control-detail.html?id=${control.id}'">
                         <div class="gap-item-header">
                             <div>
@@ -245,11 +258,48 @@
                             </div>
                         </div>
                         <div style="font-size: 12px; color: #586069; margin-top: 8px;">
-                            📁 ${familyName} • 📊 Baselines: ${levels}
+                            ${familyName} | Baselines: ${levels}
+                            ${childGaps.length > 0 ? ` | ${childGaps.length} enhancement gap${childGaps.length > 1 ? 's' : ''}` : ''}
                         </div>
                     </div>
                 `;
-            }).join('');
+
+                if (childGaps.length > 0) {
+                    html += '<div style="margin-left: 20px; border-left: 2px solid #e1e4e8; padding-left: 12px;">';
+                    childGaps.forEach(enh => {
+                        html += `
+                            <div class="gap-item" style="padding: 8px 12px; margin-bottom: 4px;" onclick="window.location.href='control-detail.html?id=${enh.id}'">
+                                <div style="display: flex; align-items: center; gap: 8px;">
+                                    <span class="gap-id" style="font-size: 13px;">${enh.id.toUpperCase()}</span>
+                                    <span style="font-size: 13px; color: #24292e;">${enh.title}</span>
+                                </div>
+                            </div>
+                        `;
+                    });
+                    html += '</div>';
+                }
+            });
+
+            // Orphan enhancement gaps (parent not in this gap list)
+            const orphanEnhGaps = gaps.filter(c => c.parent_id && !baseGaps.find(b => b.id === c.parent_id));
+            orphanEnhGaps.forEach(control => {
+                const levels = (control.levels || []).join(', ').toUpperCase();
+                html += `
+                    <div class="gap-item" onclick="window.location.href='control-detail.html?id=${control.id}'">
+                        <div class="gap-item-header">
+                            <div>
+                                <div class="gap-id">${control.id.toUpperCase()}</div>
+                                <div class="gap-title">${control.title}</div>
+                            </div>
+                        </div>
+                        <div style="font-size: 12px; color: #586069; margin-top: 8px;">
+                            Baselines: ${levels} | Enhancement of ${control.parent_id.toUpperCase()}
+                        </div>
+                    </div>
+                `;
+            });
+
+            container.innerHTML = html;
         }
 
         function renderFamilyBreakdown(gaps) {

--- a/utils/nist_sync/templates/index.html
+++ b/utils/nist_sync/templates/index.html
@@ -47,6 +47,41 @@
             </div>
         </div>
 
+        <!-- Control Type Breakdown -->
+        <div class="card">
+            <h3>Controls by Type</h3>
+            <div class="grid grid-2" id="control-type-breakdown">
+                <div style="border: 1px solid #e1e4e8; border-radius: 6px; padding: 16px; border-left: 4px solid #0366d6;">
+                    <div style="font-size: 13px; font-weight: 600; color: #586069; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 10px;">Base Controls</div>
+                    <div style="font-size: 32px; font-weight: 700; color: #24292e;" id="stat-base">0</div>
+                    <div style="margin-top: 12px; display: flex; gap: 16px; flex-wrap: wrap;">
+                        <span style="font-size: 13px;"><span style="color: #28a745; font-weight: 600;" id="stat-base-automated">0</span> automated</span>
+                        <span style="font-size: 13px;"><span style="color: #ffc107; font-weight: 600;" id="stat-base-pending">0</span> pending</span>
+                    </div>
+                    <div style="margin-top: 10px;">
+                        <div style="background: #e1e4e8; border-radius: 4px; height: 6px;">
+                            <div id="base-progress" style="background: #28a745; height: 6px; border-radius: 4px; width: 0%;"></div>
+                        </div>
+                        <div style="font-size: 11px; color: #586069; margin-top: 4px;" id="base-pct">0% automated</div>
+                    </div>
+                </div>
+                <div style="border: 1px solid #e1e4e8; border-radius: 6px; padding: 16px; border-left: 4px solid #6f42c1;">
+                    <div style="font-size: 13px; font-weight: 600; color: #586069; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 10px;">Control Enhancements</div>
+                    <div style="font-size: 32px; font-weight: 700; color: #24292e;" id="stat-enh">0</div>
+                    <div style="margin-top: 12px; display: flex; gap: 16px; flex-wrap: wrap;">
+                        <span style="font-size: 13px;"><span style="color: #28a745; font-weight: 600;" id="stat-enh-automated">0</span> automated</span>
+                        <span style="font-size: 13px;"><span style="color: #ffc107; font-weight: 600;" id="stat-enh-pending">0</span> pending</span>
+                    </div>
+                    <div style="margin-top: 10px;">
+                        <div style="background: #e1e4e8; border-radius: 4px; height: 6px;">
+                            <div id="enh-progress" style="background: #28a745; height: 6px; border-radius: 4px; width: 0%;"></div>
+                        </div>
+                        <div style="font-size: 11px; color: #586069; margin-top: 4px;" id="enh-pct">0% automated</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Coverage Progress -->
         <div class="card">
             <h3>Overall Coverage</h3>
@@ -66,8 +101,9 @@
                     <tr>
                         <th>Product</th>
                         <th>Total</th>
+                        <th>Base</th>
+                        <th>Enhancements</th>
                         <th>Automated</th>
-                        <th>Manual</th>
                         <th>Pending</th>
                         <th>Coverage</th>
                     </tr>
@@ -133,6 +169,28 @@
             document.getElementById('stat-does-not-meet').textContent = stats.does_not_meet || 0;
             document.getElementById('stat-pending').textContent = stats.pending;
 
+            // Control type breakdown
+            const baseCount = stats.base_controls || 0;
+            const enhCount = stats.enhancement_controls || 0;
+            const baseAuto = stats.base_automated || 0;
+            const enhAuto = stats.enh_automated || 0;
+            const basePending = stats.base_pending || 0;
+            const enhPending = stats.enh_pending || 0;
+            const basePct = baseCount > 0 ? Math.round(baseAuto / baseCount * 100) : 0;
+            const enhPct = enhCount > 0 ? Math.round(enhAuto / enhCount * 100) : 0;
+
+            document.getElementById('stat-base').textContent = baseCount;
+            document.getElementById('stat-base-automated').textContent = baseAuto;
+            document.getElementById('stat-base-pending').textContent = basePending;
+            document.getElementById('base-progress').style.width = basePct + '%';
+            document.getElementById('base-pct').textContent = basePct + '% automated';
+
+            document.getElementById('stat-enh').textContent = enhCount;
+            document.getElementById('stat-enh-automated').textContent = enhAuto;
+            document.getElementById('stat-enh-pending').textContent = enhPending;
+            document.getElementById('enh-progress').style.width = enhPct + '%';
+            document.getElementById('enh-pct').textContent = enhPct + '% automated';
+
             // Update coverage progress
             const coveragePercent = stats.total > 0 ? Math.round((stats.with_rules / stats.total) * 100) : 0;
             const progressBar = document.getElementById('coverage-progress');
@@ -166,8 +224,9 @@
                 row.innerHTML = `
                     <td><strong>${product.toUpperCase()}</strong></td>
                     <td>${stats.total}</td>
+                    <td style="color: #0366d6;">${stats.base_controls || 0}</td>
+                    <td style="color: #6f42c1;">${stats.enhancement_controls || 0}</td>
                     <td><span class="badge badge-automated">${stats.automated}</span></td>
-                    <td><span class="badge badge-manual">${stats.manual}</span></td>
                     <td><span class="badge badge-pending">${stats.pending}</span></td>
                     <td>${coverage}%</td>
                 `;

--- a/utils/nist_sync/templates/statistics.html
+++ b/utils/nist_sync/templates/statistics.html
@@ -142,6 +142,32 @@
                     <!-- Populated by JavaScript -->
                 </div>
             </div>
+
+            <h4 style="margin: 20px 0 12px;">Control Types</h4>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;" id="type-breakdown">
+                <div style="border: 1px solid #e1e4e8; border-radius: 6px; padding: 14px; border-left: 4px solid #0366d6;">
+                    <div style="font-size: 12px; font-weight: 600; text-transform: uppercase; color: #586069; margin-bottom: 8px;">Base Controls</div>
+                    <div style="font-size: 28px; font-weight: 700;" id="stat-base">0</div>
+                    <div style="font-size: 12px; color: #586069; margin-top: 8px;">
+                        <span style="color: #28a745; font-weight: 600;" id="stat-base-auto">0</span> automated ·
+                        <span style="color: #ffc107; font-weight: 600;" id="stat-base-pend">0</span> pending
+                    </div>
+                    <div style="background: #e1e4e8; border-radius: 4px; height: 5px; margin-top: 8px;">
+                        <div id="base-bar" style="background: #28a745; height: 5px; border-radius: 4px; width: 0%;"></div>
+                    </div>
+                </div>
+                <div style="border: 1px solid #e1e4e8; border-radius: 6px; padding: 14px; border-left: 4px solid #6f42c1;">
+                    <div style="font-size: 12px; font-weight: 600; text-transform: uppercase; color: #586069; margin-bottom: 8px;">Control Enhancements</div>
+                    <div style="font-size: 28px; font-weight: 700;" id="stat-enh">0</div>
+                    <div style="font-size: 12px; color: #586069; margin-top: 8px;">
+                        <span style="color: #28a745; font-weight: 600;" id="stat-enh-auto">0</span> automated ·
+                        <span style="color: #ffc107; font-weight: 600;" id="stat-enh-pend">0</span> pending
+                    </div>
+                    <div style="background: #e1e4e8; border-radius: 4px; height: 5px; margin-top: 8px;">
+                        <div id="enh-bar" style="background: #28a745; height: 5px; border-radius: 4px; width: 0%;"></div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Baseline Level Breakdown -->
@@ -160,10 +186,11 @@
                     <tr>
                         <th>Product</th>
                         <th>Total</th>
+                        <th>Base</th>
+                        <th>Enhancements</th>
                         <th>With Rules</th>
                         <th>Without Rules</th>
                         <th>Automated</th>
-                        <th>Manual</th>
                         <th>Pending</th>
                         <th>Coverage %</th>
                     </tr>
@@ -249,6 +276,22 @@
                 `${total > 0 ? Math.round((stats.manual / total) * 100) : 0}% of total`;
             document.getElementById('pending-percent').textContent =
                 `${total > 0 ? Math.round((stats.pending / total) * 100) : 0}% of total`;
+
+            // Control type breakdown
+            const baseCount = stats.base_controls || 0;
+            const enhCount = stats.enhancement_controls || 0;
+            const baseAuto = stats.base_automated || 0;
+            const enhAuto = stats.enh_automated || 0;
+            const basePct = baseCount > 0 ? Math.round(baseAuto / baseCount * 100) : 0;
+            const enhPct = enhCount > 0 ? Math.round(enhAuto / enhCount * 100) : 0;
+            document.getElementById('stat-base').textContent = baseCount;
+            document.getElementById('stat-base-auto').textContent = baseAuto;
+            document.getElementById('stat-base-pend').textContent = stats.base_pending || 0;
+            document.getElementById('base-bar').style.width = basePct + '%';
+            document.getElementById('stat-enh').textContent = enhCount;
+            document.getElementById('stat-enh-auto').textContent = enhAuto;
+            document.getElementById('stat-enh-pend').textContent = stats.enh_pending || 0;
+            document.getElementById('enh-bar').style.width = enhPct + '%';
 
             // Render status distribution bar
             const automatedPct = total > 0 ? (stats.automated / total) * 100 : 0;
@@ -337,10 +380,11 @@
                 row.innerHTML = `
                     <td><strong>${product.toUpperCase()}</strong></td>
                     <td>${stats.total}</td>
+                    <td style="color: #0366d6;">${stats.base_controls || 0}</td>
+                    <td style="color: #6f42c1;">${stats.enhancement_controls || 0}</td>
                     <td style="color: #28a745;">${stats.with_rules}</td>
                     <td style="color: #d73a49;">${stats.without_rules}</td>
                     <td><span class="badge badge-automated">${stats.automated}</span></td>
-                    <td><span class="badge badge-manual">${stats.manual}</span></td>
                     <td><span class="badge badge-pending">${stats.pending}</span></td>
                     <td><strong>${coverage}%</strong></td>
                 `;


### PR DESCRIPTION
#### Description:

- Restructure NIST 800-53 control files for rhel8, rhel9, and rhel10 from a flat list to a nested hierarchy where enhancements (e.g., `ac-7.1`) are children of their base control (`ac-7`). No build changes needed — `ssg/controls.py` already handles nesting natively. 690 of 872 enhancements inherit their parent's baseline level where they had none.
- Update `sync_nist_split.py` to emit nested output so future re-syncs preserve the hierarchy.
- Update the `nist_sync` HTML viewer: enhancements grouped under their parent on all pages, collapsible enhancement lists with automated/total counts, parent↔child back-links, and a new "Controls by Type" dashboard card with separate base vs. enhancement stats.

#### Rationale:

- The flat layout obscured the parent–enhancement relationship. Nesting makes the control files match the NIST catalog structure and lets the viewer surface per-base-control coverage (e.g., "3/5 enhancements automated for AC-7").

#### Review Hints:

- Diffs are large but mechanical — only indentation depth and the addition of a `controls:` key change. Reviewing one family file (e.g., `ac.yml`) is representative.
- Rule selection is unchanged: flat and nested produce the identical 403-rule set for rhel9.
- To preview the viewer: `python3 utils/nist_sync/generate_nist_viewer.py --products rhel8 rhel9 rhel10 --output-dir /tmp/nist_viewer`, then open `/tmp/nist_viewer/index.html`.
