### PR TITLE
Use 'rhel' in families instead of 'rhel' in product in three rules

### DIFF
--- a/linux_os/guide/services/cron_and_at/package_cron_installed/rule.yml
+++ b/linux_os/guide/services/cron_and_at/package_cron_installed/rule.yml
@@ -1,4 +1,4 @@
-{{% if 'rhel' in product or product in ["ol9", "ol10", "sle12", "sle15", "sle16"] %}}
+{{% if 'rhel' in families or product in ["ol9", "ol10", "sle12", "sle15", "sle16"] %}}
   {{%- set package = "cronie" %}}
 {{% else %}}
   {{%- set package = "cron" %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if "rhel" in product %}}
+{{% if "rhel" in families %}}
 {{%- set pam_files = ['/etc/pam.d/password-auth', '/etc/pam.d/system-auth'] -%}}
 {{% else %}}
 {{%- set pam_files = ['/etc/pam.d/common-password'] -%}}

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -76,7 +76,7 @@ template:
         {{% if product == 'rhel8' %}}
         sysctlval: '1'
         wrong_sysctlval_for_testing: "0"
-        {{% elif 'ol' in families or 'rhel' in product %}}
+        {{% elif 'ol' in families or 'rhel' in families %}}
         sysctlval:
         - '1'
         - '2'


### PR DESCRIPTION
#### Description:

Replace `'rhel' in product` Jinja2 string checks with `'rhel' in families`
in three rules:

- `package_cron_installed/rule.yml` — selects `cronie` vs `cron` package name
- `accounts_password_pam_unix_authtok/oval/shared.xml` — selects RHEL PAM file paths
- `sysctl_kernel_kptr_restrict/rule.yml` — selects accepted sysctl values (1 or 2)

#### Rationale:

Products in the RHEL family declare `families: [rhel, rhel-like]` in their
`product.yml`. Checking `'rhel' in product` is a fragile string match that
only works when the product ID happens to contain the word "rhel". Using
`'rhel' in families` is the correct and intended mechanism, and it naturally
covers RHEL-family products whose product ID does not contain "rhel".

No functional change for existing RHEL products (rhel8, rhel9, rhel10) since
all of them have both "rhel" in their product ID and `rhel` in their families
list.

#### Review Hints:

Three one-line changes, each replacing a single Jinja2 condition. The diff
is minimal. Existing test scenarios for `pam_unix_authtok` (rhel_correct.pass.sh,
rhel_wrong.fail.sh) and `sysctl_kernel_kptr_restrict` (value_1.pass.sh,
value_2.pass.sh, value_2_rhel8.fail.sh) cover the affected conditions.