### PR TITLE
Allow leading whitespace before $FileCreateMode in rsyslog_filecreatemode OVAL

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
@@ -17,7 +17,7 @@
 
   <ind:textfilecontent54_object id="obj_filecreatemode" version="1">
     <ind:filepath operation="pattern match">^\/etc\/rsyslog(\.conf|\.d\/.*\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^\$FileCreateMode\s+(\d+)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\$FileCreateMode\s+(\d+)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_indented.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_indented.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
+echo '  $FileCreateMode 0640' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf


### PR DESCRIPTION
#### Description:

Fix the OVAL regex pattern in `rsyslog_filecreatemode` to allow leading
whitespace before `$FileCreateMode`. Add a test scenario covering this case.

- `rsyslog_filecreatemode/oval/shared.xml`: pattern changed from
  `^\$FileCreateMode\s+(\d+)` to `^\s*\$FileCreateMode\s+(\d+)`
- `rsyslog_filecreatemode/tests/filecreatemode_indented.pass.sh`: new test
  scenario with an indented directive

#### Rationale:

rsyslog accepts leading whitespace on legacy `$` directives. Ansible logging
roles (such as `linux-system-roles/logging`) write `$FileCreateMode` with
leading indentation when generating rsyslog config snippets. The previous
pattern was anchored strictly at column 0, causing the OVAL check to return
a false failure on systems where the directive was written this way.

#### Review Hints:

One character change in the OVAL pattern (`^\$` → `^\s*\$`). The new test
`filecreatemode_indented.pass.sh` writes `  $FileCreateMode 0640` (two
leading spaces) and expects a pass result, directly exercising the fix.