### PR TITLE
DRAFT: CS9 - test contest-ansible fix for ansible-galaxy SSL fail

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,8 +26,8 @@ jobs:
 - &contest-oscap
   job: tests
   trigger: pull_request
-  fmf_url: https://github.com/RHSecurityCompliance/contest.git
-  fmf_ref: main
+  fmf_url: https://github.com/macko1/contest.git
+  fmf_ref: fix/ansible-galaxy-openssl-ssl-error
   tmt_plan: /plans/upstream-parallel/oscap
   identifier: contest-oscap
   targets:


### PR DESCRIPTION
#### Description
Temporary PR to validate the Contest workaround for the `ansible-galaxy` SSL failure on CentOS Stream 9 (OPENSCAP-7032). Sets `.packit.yaml` `fmf_url` to `https://github.com/macko1/contest.git` and `fmf_ref` to `fix/ansible-galaxy-openssl-ssl-error` instead of `main` on the upstream repo.

Do not merge — close after `testing-farm:centos-stream-9-x86_64:contest-ansible` passes.