### PR TITLE
firewall_single_service_active: add firewalld support and fix tests

### DIFF
--- a/linux_os/guide/system/network/firewall_single_service_active/oval/shared.xml
+++ b/linux_os/guide/system/network/firewall_single_service_active/oval/shared.xml
@@ -11,7 +11,7 @@
   <!-- Objects and states to identify active firewall services -->
   <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_firewall_services" version="1"
       comment="All active firewall services">
-    <linux:unit operation="pattern match">^(ufw|iptables|nftables).service$</linux:unit>
+    <linux:unit operation="pattern match">^(firewalld|ufw|iptables|nftables).service$</linux:unit>
     <linux:property>ActiveState</linux:property>
     <filter action="include">ste_{{{ rule_id }}}_firewall_services</filter>
   </linux:systemdunitproperty_object>

--- a/linux_os/guide/system/network/firewall_single_service_active/rule.yml
+++ b/linux_os/guide/system/network/firewall_single_service_active/rule.yml
@@ -8,6 +8,7 @@ description: |-
     and ensure consistent packet filtering. Only one of the following services should
     be enabled and active at any time:
     <ul>
+        <li>firewalld - Dynamic Firewall Manager (RHEL/Fedora/SUSE default)</li>
         <li>ufw - Uncomplicated Firewall (Ubuntu/Debian default)</li>
         <li>iptables - Classic Linux firewall</li>
         <li>nftables - Next Generation Firewall replacement for iptables</li>

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/firewalld_multiple.fail.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/firewalld_multiple.fail.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+# packages = firewalld,nftables
 # remediation = none
 
 systemctl stop firewalld 2>/dev/null || true
 systemctl stop iptables 2>/dev/null || true
 systemctl stop nftables 2>/dev/null || true
-systemctl stop ufw 2>/dev/null || true
+systemctl start firewalld
+systemctl start nftables

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/firewalld_single.pass.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/firewalld_single.pass.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# remediation = none
+# platform = multi_platform_rhel,multi_platform_fedora
+# packages = firewalld
 
 systemctl stop firewalld 2>/dev/null || true
 systemctl stop iptables 2>/dev/null || true
 systemctl stop nftables 2>/dev/null || true
-systemctl stop ufw 2>/dev/null || true
+systemctl start firewalld

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/multiple.fail.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/multiple.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-#
+# platform = multi_platform_debian,multi_platform_fedora,multi_platform_ubuntu
+# packages = ufw,nftables
 # remediation = none
 
-apt install -y iptables nftables ufw
-systemctl stop iptables
-systemctl stop nftables
-systemctl stop ufw
+systemctl stop iptables 2>/dev/null || true
+systemctl stop nftables 2>/dev/null || true
+systemctl stop ufw 2>/dev/null || true
 systemctl start nftables
 systemctl start ufw

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/single.pass.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/single.pass.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+# platform = multi_platform_debian,multi_platform_fedora,multi_platform_ubuntu
+# packages = ufw
 
-apt install -y iptables nftables ufw
-systemctl stop iptables
-systemctl stop nftables
-systemctl stop ufw
+systemctl stop iptables 2>/dev/null || true
+systemctl stop nftables 2>/dev/null || true
+systemctl stop ufw 2>/dev/null || true
 systemctl start ufw


### PR DESCRIPTION
#### Description:

- Add `firewalld` to the list of recognized firewall services in the `firewall_single_service_active` rule. Previously, the OVAL check and rule description only covered `ufw`, `iptables`, and `nftables`, missing the default firewall on RHEL/Fedora/SUSE systems.
- Add new test scenarios (`firewalld_single.pass.sh`, `firewalld_multiple.fail.sh`) targeting RHEL and Fedora platforms.
- Update existing test scenarios to use proper `platform` and `packages` metadata, replace hardcoded `apt install` calls with `packages` directives, and add `2>/dev/null || true` guards for `systemctl stop` calls to handle services that may not exist.

#### Rationale:

- The rule was incomplete — it did not detect `firewalld`, the default firewall manager on RHEL and Fedora. This meant RHEL/Fedora systems with `firewalld` active were not being evaluated, and conflicts between `firewalld` and another firewall service were missed.
- The existing test scenarios were fragile: they assumed Debian/Ubuntu (`apt install`) without declaring platform constraints, and `systemctl stop` calls would fail on systems where a given service was not installed.

#### Review Hints:

- The OVAL change is a one-line addition of `firewalld` to the service name regex in `oval/shared.xml`.
- The `rule.yml` change adds `firewalld` to the description list.
- New test scenarios follow the same pattern as existing ones but target RHEL/Fedora.
- Existing test scenarios were cleaned up for portability (platform metadata, package declarations, error-tolerant stop commands).
- Build and test with:
  ```
  ./build_product rhel10 --datastream --rule-id firewall_single_service_active
  ./tests/automatus.py rule --libvirt qemu:///system rhel10 --datastream build/ssg-rhel10-ds.xml firewall_single_service_active
  ```
- The rule is not currently selected by any RHEL profile, so no profile-level side effects.
- Review both commits together — they are tightly related.
