### PR TITLE
service_pcscd_enabled: add rule-specific fail test for socket activation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/tests/service_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/tests/service_disabled.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# packages = pcsc-lite
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+# pcscd uses socket activation; pcscd.socket must also be stopped and disabled
+# otherwise the SCE check sees an enabled/active socket and returns pass
+"$SYSTEMCTL_EXEC" stop 'pcscd.socket'
+"$SYSTEMCTL_EXEC" disable 'pcscd.socket'
+"$SYSTEMCTL_EXEC" stop 'pcscd.service'
+"$SYSTEMCTL_EXEC" disable 'pcscd.service'


### PR DESCRIPTION


#### Description:
- service_pcscd_enabled: add rule-specific fail test for socket activation
  - The generic service_enabled template test only stops and disables pcscd.service. Because pcscd uses socket activation, systemctl disable pcscd.service removes the pcscd.socket symlink via Also= but leaves the socket unit still active. The SCE check sees pcscd.socket as enabled (systemctl is-enabled falls back to the preset state) and active, so it incorrectly returns pass.

Add a rule-specific service_disabled.fail.sh that explicitly stops and disables pcscd.socket before the service, ensuring both is-enabled and is-active return the expected values for the SCE check to fail.
