### PR TITLE
Fix glob expansion order in sshd_lineinfile test scripts for RHEL8

### DIFF
--- a/shared/templates/sshd_lineinfile/tests/duplicated_param.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param.pass.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
-
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 if grep -q "^\s*{{{ PARAMETER }}}" "${SSHD_PATHS[@]}" ; then
     sed -i "/^\s*{{{ PARAMETER }}}.*/Id" "${SSHD_PATHS[@]}"

--- a/shared/templates/sshd_lineinfile/tests/line_not_there.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/line_not_there.fail.sh
@@ -2,9 +2,9 @@
 
 SSHD_PARAM={{{ PARAMETER }}}
 
-declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 mkdir -p "{{{ sshd_config_dir }}}"
 touch "{{{ sshd_config_dir }}}/nothing"
+declare -a SSHD_PATHS=({{{ sshd_main_config_file }}} {{{ sshd_config_dir }}}/*)
 
 {{% if product in ['sle16', 'slmicro6'] %}}
 touch "{{{ sshd_main_config_file }}}"


### PR DESCRIPTION
#### Description:

- Continuation of https://github.com/ComplianceAsCode/content/pull/14875
- PR removed quotes around the glob in `SSHD_PATHS` array declarations to enable proper glob expansion. However, in two test scripts the declare statement appeared before `mkdir -p` / `touch`, meaning the glob expanded before the directory existed.

#### Rationale:

- On systems where `/etc/ssh/sshd_config.d/` is not pre-created (RHEL 8), bash keeps the unexpanded literal `/etc/ssh/sshd_config.d/*` in the array
- When grep later tries to open that literal path, it fails with exit code 2
- 2 test scenarios for `sshd_lineinfile` template were updated
