### PR TITLE
firewalld_loopback_traffic_restricted: fix OVAL check and OCIL typo

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/oval/shared.xml
@@ -9,92 +9,72 @@
                     comment="Ensure default trusted zone file was not overridden"
                     test_ref="test_firewalld_trusted_zone_not_overridden"/>
                 <criterion
-                    comment="Ensure default trusted restrict loopback source"
-                    test_ref="test_firewalld_loopback_restricted_source_usr"/>
-                <criterion
-                    comment="Ensure default trusted zone restrict loopback destination"
-                    test_ref="test_firewalld_loopback_restricted_destination_usr"/>
-                <criterion
-                    comment="Ensure default trusted zone restrict loopback traffic"
-                    test_ref="test_firewalld_loopback_restricted_policy_usr"/>
+                    comment="Ensure default trusted zone has IPv4 loopback restriction rule"
+                    test_ref="test_firewalld_loopback_restricted_ipv4_usr"/>
+                <criteria operator="OR">
+                    <extend_definition comment="IPv6 disabled or..."
+                        definition_ref="sysctl_kernel_ipv6_disable"/>
+                    <criterion
+                        comment="Ensure default trusted zone has IPv6 loopback restriction rule"
+                        test_ref="test_firewalld_loopback_restricted_ipv6_usr"/>
+                </criteria>
             </criteria>
             <criteria operator="AND">
                 <criterion
-                    comment="Ensure custom trusted zone restrict loopback source"
-                    test_ref="test_firewalld_loopback_restricted_source_etc"/>
-                <criterion
-                    comment="Ensure custom trusted zone zone restrict loopback destination"
-                    test_ref="test_firewalld_loopback_restricted_destination_etc"/>
-                <criterion
-                    comment="Ensure custom trusted zone zone restrict loopback traffic"
-                    test_ref="test_firewalld_loopback_restricted_policy_etc"/>
+                    comment="Ensure custom trusted zone has IPv4 loopback restriction rule"
+                    test_ref="test_firewalld_loopback_restricted_ipv4_etc"/>
+                <criteria operator="OR">
+                    <extend_definition comment="IPv6 disabled or..."
+                        definition_ref="sysctl_kernel_ipv6_disable"/>
+                    <criterion
+                        comment="Ensure custom trusted zone has IPv6 loopback restriction rule"
+                        test_ref="test_firewalld_loopback_restricted_ipv6_etc"/>
+                </criteria>
             </criteria>
         </criteria>
     </definition>
 
-    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_source_usr" version="1"
+    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_ipv4_usr" version="1"
         check="all" check_existence="all_exist"
-        comment="default trusted zone has rich-rule to restrict loopback source">
-        <ind:object object_ref="object_firewalld_loopback_restricted_source_usr"/>
+        comment="default trusted zone has IPv4 loopback restriction rich-rule">
+        <ind:object object_ref="object_firewalld_loopback_restricted_ipv4_usr"/>
     </ind:xmlfilecontent_test>
 
-    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_source_usr" version="1">
+    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_ipv4_usr" version="1">
         <ind:filepath>/usr/lib/firewalld/zones/trusted.xml</ind:filepath>
-        <ind:xpath>/zone/rule/source[@address='127.0.0.1' or @address='::1']</ind:xpath>
+        <ind:xpath>/zone/rule[@family='ipv4'][source[@address='127.0.0.1']][destination[@address='127.0.0.1' and @invert='True']][drop]</ind:xpath>
     </ind:xmlfilecontent_object>
 
-    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_destination_usr" version="1"
+    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_ipv6_usr" version="1"
         check="all" check_existence="all_exist"
-        comment="default trusted zone has rich-rule to restrict loopback destination">
-        <ind:object object_ref="object_firewalld_loopback_restricted_destination_usr"/>
+        comment="default trusted zone has IPv6 loopback restriction rich-rule">
+        <ind:object object_ref="object_firewalld_loopback_restricted_ipv6_usr"/>
     </ind:xmlfilecontent_test>
 
-    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_destination_usr" version="1">
+    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_ipv6_usr" version="1">
         <ind:filepath>/usr/lib/firewalld/zones/trusted.xml</ind:filepath>
-        <ind:xpath>/zone/rule/destination[@address='127.0.0.1' or @address='::1' and @invert='True']</ind:xpath>
+        <ind:xpath>/zone/rule[@family='ipv6'][source[@address='::1']][destination[@address='::1' and @invert='True']][drop]</ind:xpath>
     </ind:xmlfilecontent_object>
 
-    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_policy_usr" version="1"
+    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_ipv4_etc" version="1"
         check="all" check_existence="all_exist"
-        comment="default trusted zone has rich-rule to restrict loopback traffic">
-        <ind:object object_ref="object_firewalld_loopback_restricted_policy_usr"/>
+        comment="custom trusted zone has IPv4 loopback restriction rich-rule">
+        <ind:object object_ref="object_firewalld_loopback_restricted_ipv4_etc"/>
     </ind:xmlfilecontent_test>
 
-    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_policy_usr" version="1">
-        <ind:filepath>/usr/lib/firewalld/zones/trusted.xml</ind:filepath>
-        <ind:xpath>/zone/rule/drop</ind:xpath>
-    </ind:xmlfilecontent_object>
-
-    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_source_etc" version="1"
-        check="all" check_existence="all_exist"
-        comment="custom trusted zone has rich-rule to restrict loopback source">
-        <ind:object object_ref="object_firewalld_loopback_restricted_source_etc"/>
-    </ind:xmlfilecontent_test>
-
-    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_source_etc" version="1">
+    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_ipv4_etc" version="1">
         <ind:filepath>/etc/firewalld/zones/trusted.xml</ind:filepath>
-        <ind:xpath>/zone/rule/source[@address='127.0.0.1' or @address='::1']</ind:xpath>
+        <ind:xpath>/zone/rule[@family='ipv4'][source[@address='127.0.0.1']][destination[@address='127.0.0.1' and @invert='True']][drop]</ind:xpath>
     </ind:xmlfilecontent_object>
 
-    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_destination_etc" version="1"
+    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_ipv6_etc" version="1"
         check="all" check_existence="all_exist"
-        comment="custom trusted zone has rich-rule to restrict loopback destination">
-        <ind:object object_ref="object_firewalld_loopback_restricted_destination_etc"/>
+        comment="custom trusted zone has IPv6 loopback restriction rich-rule">
+        <ind:object object_ref="object_firewalld_loopback_restricted_ipv6_etc"/>
     </ind:xmlfilecontent_test>
 
-    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_destination_etc" version="1">
+    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_ipv6_etc" version="1">
         <ind:filepath>/etc/firewalld/zones/trusted.xml</ind:filepath>
-        <ind:xpath>/zone/rule/destination[@address='127.0.0.1' or @address='::1' and @invert='True']</ind:xpath>
-    </ind:xmlfilecontent_object>
-
-    <ind:xmlfilecontent_test id="test_firewalld_loopback_restricted_policy_etc" version="1"
-        check="all" check_existence="all_exist"
-        comment="custom trusted zone has rich-rule to restrict loopback traffic">
-        <ind:object object_ref="object_firewalld_loopback_restricted_policy_etc"/>
-    </ind:xmlfilecontent_test>
-
-    <ind:xmlfilecontent_object id="object_firewalld_loopback_restricted_policy_etc" version="1">
-        <ind:filepath>/etc/firewalld/zones/trusted.xml</ind:filepath>
-        <ind:xpath>/zone/rule/drop</ind:xpath>
+        <ind:xpath>/zone/rule[@family='ipv6'][source[@address='::1']][destination[@address='::1' and @invert='True']][drop]</ind:xpath>
     </ind:xmlfilecontent_object>
 </def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/rule.yml
@@ -44,7 +44,7 @@ ocil: |-
     The following rich-rules should be listed:
     <pre>
     rule family="ipv4" source address="127.0.0.1" destination not address="127.0.0.1" drop
-    rule family="ipv6" source address="::1" destination not address="127.0.0.1" drop
+    rule family="ipv6" source address="::1" destination not address="::1" drop
     </pre>
 
 fixtext: |-

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/ipv6_disabled_only_ipv4_rule.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/ipv6_disabled_only_ipv4_rule.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# packages = firewalld
+
+# Ensure the required service is started
+systemctl start firewalld
+
+# Disable IPv6 both statically and at runtime
+echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/99-disable-ipv6.conf
+sysctl -w net.ipv6.conf.all.disable_ipv6=1
+
+# Ensure the trusted zone is overridden by an equivalent file in /etc/firewalld/zones
+firewall-cmd --permanent --zone=trusted --add-service=http
+
+# Add only the IPv4 rich-rule. With IPv6 disabled, the IPv6 rule is not required.
+firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/missing_destination_invert.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/missing_destination_invert.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# packages = firewalld
+# remediation = none
+
+# Ensure the required service is started
+systemctl start firewalld
+
+# Ensure the trusted zone is overridden by an equivalent file in /etc/firewalld/zones
+firewall-cmd --permanent --zone=trusted --add-service=http
+
+# Add rich-rules WITHOUT the "not" keyword on the destination.
+# This drops traffic FROM loopback TO loopback rather than
+# FROM loopback to non-loopback, which fails to restrict spoofed traffic.
+firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv4 source address="127.0.0.1" destination address="127.0.0.1" drop'
+firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv6 source address="::1" destination address="::1" drop'

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/only_ipv4_rule.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/only_ipv4_rule.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = firewalld
+# remediation = none
+
+# Ensure the required service is started
+systemctl start firewalld
+
+# Ensure the trusted zone is overridden by an equivalent file in /etc/firewalld/zones
+firewall-cmd --permanent --zone=trusted --add-service=http
+
+# Add only the IPv4 rich-rule, omitting the IPv6 rule.
+# The policy requires both families to be restricted.
+firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'


### PR DESCRIPTION
#### Description:

- Fix three bugs in the OVAL check for `firewalld_loopback_traffic_restricted`:
  1. **XPath operator precedence**: `and` binds tighter than `or`, so the predicate `@address='127.0.0.1' or @address='::1' and @invert='True'` allowed a non-inverted IPv4 destination to pass.
  2. **IPv4/IPv6 conflation**: using `or` meant only one address family needed to be present, but both are required.
  3. **Cross-element matching**: source, destination, and drop were checked as independent elements across the entire zone, allowing components from different rich-rules to satisfy different tests.
- Make the IPv6 check conditional on IPv6 being enabled, matching CIS audit script behavior and the existing pattern used by `set_nftables_loopback_traffic` and `network_ipv6_default_gateway`.
- Fix IPv6 address typo in OCIL (`127.0.0.1` → `::1`).
- Add three new test scenarios covering previously untested OVAL paths.

#### Rationale:

- The OVAL check could produce false-positive (pass) results due to XPath logic errors, letting non-compliant firewalld configurations through. The typo in the OCIL made the manual verification instructions incorrect for IPv6.

#### Review Hints:

- **Affected products**: rhel8, rhel9, rhel10 (based on CCE identifiers)
  ```
  ./build_product rhel9 --datastream --rule-id firewalld_loopback_traffic_restricted
  ```
- **Automatus testing** (adjust VM name and libvirt URI to your setup):
  ```
  ./tests/automatus.py rule --libvirt qemu:///system rhel9 --datastream build/ssg-rhel9-ds.xml firewalld_loopback_traffic_restricted
  ```
- **Key file to review**: `oval/shared.xml` — the XPath rewrite is the core change; review the per-family expressions and the conditional IPv6 `extend_definition`.
- All three commits are closely related; reviewing them together is recommended.
