### PR TITLE
grub2_bootloader_argument_absent template: fix OVAL regex

### DIFF
--- a/shared/templates/grub2_bootloader_argument_absent/oval.template
+++ b/shared/templates/grub2_bootloader_argument_absent/oval.template
@@ -142,14 +142,14 @@
 {{%- if system_with_expanded_kernel_options_in_loader_entries %}}
     <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
                                 comment="check absence of kernel command line parameters {{{ ARG_NAME}}} on all boot entries."
-                                check="all" check_existence="all_exist" version="1">
+                                check="at least one" check_existence="none_exist" version="1">
       <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" />
     </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" version="1">
     <ind:path>/boot/loader/entries/</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^options .*\b{{{ ARG_NAME }}}\b</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     <filter action="exclude">state_grub2_rescue_entry_for_{{{ _RULE_ID }}}</filter>
   </ind:textfilecontent54_object>

--- a/shared/templates/grub2_bootloader_argument_absent/oval.template
+++ b/shared/templates/grub2_bootloader_argument_absent/oval.template
@@ -163,7 +163,7 @@
 {{%- macro test_and_object_for_kernel_options_grub_cfg(base_name, path) %}}
   <ind:textfilecontent54_test id="test_{{{ base_name }}}"
   comment="check absence of kernel command line parameter {{{ ARG_NAME}}} in {{{ path }}} for all kernels"
-  check="all" check_existence="all_exist" version="1">
+  check="at least one" check_existence="none_exist" version="1">
     <ind:object object_ref="object_{{{ base_name }}}" />
   </ind:textfilecontent54_test>
 
@@ -171,9 +171,9 @@
   version="1">
     <ind:filepath>{{{ path }}}</ind:filepath>
     {{% if 'ubuntu' in product %}}
-      <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
+      <ind:pattern operation="pattern match">^.*/vmlinuz.*\b{{{ ARG_NAME }}}\b</ind:pattern>
     {{% else %}}
-      <ind:pattern operation="pattern match">^set default_kernelopts=(.*)$</ind:pattern>
+      <ind:pattern operation="pattern match">^set default_kernelopts=.*\b{{{ ARG_NAME }}}\b</ind:pattern>
     {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/grub2_bootloader_argument_absent/tests/arg_there_grub_cfg.fail.sh
+++ b/shared/templates/grub2_bootloader_argument_absent/tests/arg_there_grub_cfg.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = grub2
+
+# Remove any existing arg from /etc/default/grub
+sed -i 's/\s*{{{ ARG_NAME }}}//g' /etc/default/grub
+
+# Create grub.cfg with the argument in a vmlinuz line
+mkdir -p /boot/grub
+{
+    echo 'menuentry "Ubuntu" {'
+    echo '    linux /vmlinuz-5.4.0-mock root=/dev/sda1 ro quiet {{{ ARG_NAME }}}'
+    echo '    initrd /initrd.img-5.4.0-mock'
+    echo '}'
+} > /boot/grub/grub.cfg

--- a/shared/templates/grub2_bootloader_argument_absent/tests/arg_there_loader_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument_absent/tests/arg_there_loader_entries.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 9,Red Hat Enterprise Linux 10
+# packages = grub2,grubby
+
+# Remove any existing arg from /etc/default/grub
+sed -i 's/\s*{{{ ARG_NAME }}}//g' /etc/default/grub
+
+# Create a loader entry with the argument on the options line
+mkdir -p /boot/loader/entries
+rm -f /boot/loader/entries/*.conf
+{
+    echo 'title OS 1'
+    echo 'version 5.0'
+    echo 'linux /vmlinuz'
+    echo 'initrd /initramfs'
+    echo 'options root=UUID=abc-def rhgb ro quiet {{{ ARG_NAME }}}'
+} > /boot/loader/entries/mock.conf


### PR DESCRIPTION
#### Description:

- Fix the `grub2_bootloader_argument_absent` OVAL template so it correctly detects when a kernel argument is still present in `/boot/loader/entries/*.conf` files and in `grub.cfg`.
- The old regex (`^options (.*)$` / `^set default_kernelopts=(.*)$` / `^.*/vmlinuz.*(root=.*)$`) captured the entire options line and relied on state-level matching, but with `check="all" check_existence="all_exist"` this always passed — even when the argument was present.
- The fix changes the pattern to directly match the argument with word boundaries (`\b{ARG_NAME}\b`) and flips the test to `check="at least one" check_existence="none_exist"`, so the check passes only when no occurrence of the argument is found.
- Add two new fail test scenarios covering the `/boot/loader/entries/` path (RHEL 9/10) and the `grub.cfg` path (Ubuntu).

#### Rationale:

- The template was producing OVAL checks that would never report a failure when a kernel argument was present in loader entries or grub.cfg, making the "argument absent" check ineffective for those file paths.

#### Review Hints:

- This is a template-level fix affecting all rules that use `grub2_bootloader_argument_absent`. Review both commits together — the first fixes the loader entries and non-Ubuntu grub.cfg paths, the second applies the same fix to the Ubuntu grub.cfg path.
- Build any product that has rules using this template to verify the generated OVAL, e.g.:
  ```
  ./build_product rhel9 --datastream
  ./build_product ubuntu2204 --datastream
  ```
- Test scenarios can be run with Automatus against any rule using this template, e.g.:
  ```
  ./tests/automatus.py rule --libvirt qemu:///system rhel9 --datastream build/ssg-rhel9-ds.xml <rule_using_this_template>
  ```
- Key file to review: `shared/templates/grub2_bootloader_argument_absent/oval.template` — the logic change from `all_exist` → `none_exist` with the tighter regex is the core fix.
