### PR TITLE
Remove RHEVH checks from RHEL 9 and 10 OS detection

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhel10.xml
+++ b/shared/checks/oval/installed_OS_is_rhel10.xml
@@ -14,13 +14,7 @@
     <criteria>
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_rhel10_unix_family" />
-      <criteria operator="OR">
-        <criterion comment="RHEL 10 is installed" test_ref="test_rhel10" />
-        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
-          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
-          <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 10" test_ref="test_rhevh_rhel10_version" />
-        </criteria>
-      </criteria>
+      <criterion comment="RHEL 10 is installed" test_ref="test_rhel10" />
     </criteria>
   </definition>
 
@@ -44,16 +38,4 @@
     <linux:name>redhat-release</linux:name>
   </linux:rpminfo_object>
 
-  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 10" id="test_rhevh_rhel10_version" version="1">
-    <ind:object object_ref="obj_rhevh_rhel10_version" />
-    <ind:state state_ref="state_rhevh_rhel10_version" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_rhevh_rhel10_version" version="1">
-    <ind:filepath>/etc/redhat-release</ind:filepath>
-    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_rhevh_rhel10_version" version="1">
-    <ind:subexpression operation="pattern match">10</ind:subexpression>
-  </ind:textfilecontent54_state>
 </def-group>

--- a/shared/checks/oval/installed_OS_is_rhel9.xml
+++ b/shared/checks/oval/installed_OS_is_rhel9.xml
@@ -14,16 +14,10 @@
     <criteria>
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_rhel9_unix_family" />
-      <criteria operator="OR">
-        <criteria operator="AND" comment="RHEL 9 is installed">
-          <criterion comment="RHEL 9 is installed" test_ref="test_rhel9" />
-          <!-- This prevent false positive RHEL9 in OL9 because OL9 has redhat-release package present -->
-          <extend_definition comment="Installed OS is not OL9" definition_ref="installed_OS_is_ol9" negate="true"/>
-        </criteria>
-        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
-          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
-          <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 9" test_ref="test_rhevh_rhel9_version" />
-        </criteria>
+      <criteria operator="AND" comment="RHEL 9 is installed">
+        <criterion comment="RHEL 9 is installed" test_ref="test_rhel9" />
+        <!-- This prevent false positive RHEL9 in OL9 because OL9 has redhat-release package present -->
+        <extend_definition comment="Installed OS is not OL9" definition_ref="installed_OS_is_ol9" negate="true"/>
       </criteria>
     </criteria>
   </definition>
@@ -48,16 +42,4 @@
     <linux:name>redhat-release</linux:name>
   </linux:rpminfo_object>
 
-  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 9" id="test_rhevh_rhel9_version" version="1">
-    <ind:object object_ref="obj_rhevh_rhel9_version" />
-    <ind:state state_ref="state_rhevh_rhel9_version" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_rhevh_rhel9_version" version="1">
-    <ind:filepath>/etc/redhat-release</ind:filepath>
-    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_rhevh_rhel9_version" version="1">
-    <ind:subexpression operation="pattern match">9</ind:subexpression>
-  </ind:textfilecontent54_state>
 </def-group>


### PR DESCRIPTION
#### Description:

- Remove RHEVH (Red Hat Enterprise Virtualization Host) specific checks from `installed_OS_is_rhel9.xml` and `installed_OS_is_rhel10.xml` shared OVAL checks.
- The RHEVH criteria and associated `textfilecontent54` tests/objects/states are removed entirely from both files.
- In `installed_OS_is_rhel9.xml`, the criteria structure is also simplified — the unnecessary outer `OR` operator wrapping RHEL 9 and RHEVH alternatives is collapsed since only the RHEL 9 check remains.

#### Rationale:

- RHEVH 4.4 (the latest version) is based on RHEL 8.6. There is no RHEVH based on RHEL 9 or RHEL 10, so these checks are dead code that was likely copied from the RHEL 8 version without adjusting for the actual product scope.
- References: [RHV 4.4 Release Notes](https://docs.redhat.com/en/documentation/red_hat_virtualization/4.4/html-single/release_notes/index), [BZ#2132386](https://bugzilla.redhat.com/show_bug.cgi?id=2132386)

#### Review Hints:

- Two files changed, both shared OVAL checks under `shared/checks/oval/`.
- Review both files together — the changes are analogous (remove RHEVH criteria and associated OVAL objects).
- Note the extra simplification in `installed_OS_is_rhel9.xml`: the `OR` criteria wrapper is removed since only one alternative (RHEL 9) remains.
- Build affected products to verify no OVAL breakage:
  ```
  ./build_product rhel9 --datastream
  ./build_product rhel10 --datastream
  ```
