### PR TITLE
Updating tmout stig from RHEL-08-020353 to RHEL-08-020360 in the rhel8 disa product

### DIFF
--- a/products/rhel8/controls/stig_rhel8.yml
+++ b/products/rhel8/controls/stig_rhel8.yml
@@ -1405,7 +1405,7 @@ controls:
           - accounts_umask_etc_profile
       status: automated
 
-    - id: RHEL-08-020353
+    - id: RHEL-08-020360
       levels:
           - medium
       title: RHEL 8 must automatically exit interactive command shell user sessions after 10 minutes of inactivity.


### PR DESCRIPTION
Two rules in the RHEL 8 DISA profile were both mapped to STIG ID RHEL-08-020353. The second occurrence was covering the 10-minute interactive shell timeout (accounts_tmout / var_accounts_tmout=10_min) which should be RHEL-08-020360 per the DISA STIG.

Change: updated the second entry from RHEL-08-020353 to RHEL-08-020360.

Impact: corrects STIG ID reporting in scan results. The underlying rules and remediations are unchanged; only the ID mapping is fixed.