### PR TITLE
CMP-4429: Add per-VirtualMachine CEL rules for CIS OCP-Virt 2.1/3.2/3.3

### DIFF
--- a/applications/openshift-virtualization/kubevirt-disk-error-policy-not-ignore/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-disk-error-policy-not-ignore/cel/shared.yml
@@ -1,0 +1,21 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more 'VirtualMachine' resources have a disk with
+    '.errorPolicy' set to "ignore", suppressing I/O errors and risking
+    silent data corruption.
+
+inputs:
+  - name: vms
+    kubernetes_input_spec:
+      api_version: kubevirt.io/v1
+      resource: virtualmachines
+
+expression: |
+  vms.items.all(v,
+      !has(v.spec.template.spec.domain.devices) ||
+      !has(v.spec.template.spec.domain.devices.disks) ||
+      v.spec.template.spec.domain.devices.disks.all(d,
+        !has(d.errorPolicy) || d.errorPolicy != "ignore"
+      )
+  )

--- a/applications/openshift-virtualization/kubevirt-disk-error-policy-not-ignore/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-disk-error-policy-not-ignore/cel/tests/cases.yaml
@@ -1,0 +1,77 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real VirtualMachine API objects (celctl cac scaffold format)
+  date: '2026-07-23'
+  openshift_version: 4.22.0
+  kubernetes_version: v1.35.5
+  source_api_versions:
+    vms: kubevirt.io/v1
+cases:
+  - name: no VMs -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: disk without errorPolicy -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-default
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: rootdisk
+  - name: disk with errorPolicy stop -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-stop
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: rootdisk
+                          errorPolicy: stop
+  - name: disk with errorPolicy ignore -> non-compliant
+    expect: false
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-ignore
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: rootdisk
+                          errorPolicy: ignore

--- a/applications/openshift-virtualization/kubevirt-disk-error-policy-not-ignore/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-disk-error-policy-not-ignore/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Virtual Machine Disks Must Not Ignore I/O Errors'
+
+description: |-
+    A disk with 'errorPolicy: ignore' tells the hypervisor to suppress I/O
+    errors instead of reporting or stopping on them. Ignored storage errors
+    lead to silent data corruption inside the guest, masking hardware
+    failures and tampering. The default (report) or 'stop' should be used.
+
+rationale: |-
+    Suppressed I/O errors deny the guest and the platform the signal needed
+    to fail over, alert or stop on storage corruption - undermining data
+    integrity guarantees for the workload.
+
+severity: medium
+
+ocil_clause: 'a VirtualMachine disk sets errorPolicy to ignore'
+
+ocil: |-
+    Run the following command to list disks that ignore I/O errors:
+    <pre>$ oc get vm -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.spec.template.spec.domain.devices.disks[?(@.errorPolicy=="ignore")].name}{"\n"}{end}'</pre>
+    No virtual machine disk should set errorPolicy to ignore.

--- a/applications/openshift-virtualization/kubevirt-no-shareable-disks/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-no-shareable-disks/cel/shared.yml
@@ -1,0 +1,21 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more 'VirtualMachine' resources have a disk with
+    '.shareable' set to "true", allowing the disk to be attached to multiple
+    virtual machines concurrently.
+
+inputs:
+  - name: vms
+    kubernetes_input_spec:
+      api_version: kubevirt.io/v1
+      resource: virtualmachines
+
+expression: |
+  vms.items.all(v,
+      !has(v.spec.template.spec.domain.devices) ||
+      !has(v.spec.template.spec.domain.devices.disks) ||
+      v.spec.template.spec.domain.devices.disks.all(d,
+        !has(d.shareable) || d.shareable == false
+      )
+  )

--- a/applications/openshift-virtualization/kubevirt-no-shareable-disks/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-no-shareable-disks/cel/tests/cases.yaml
@@ -1,0 +1,91 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real VirtualMachine API objects (celctl cac scaffold format)
+  date: '2026-07-23'
+  openshift_version: 4.22.0
+  kubernetes_version: v1.35.5
+  source_api_versions:
+    vms: kubevirt.io/v1
+cases:
+  - name: no VMs -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: VM with a normal disk -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-normal
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: rootdisk
+                          disk:
+                            bus: virtio
+  - name: VM disk with shareable false -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-explicit
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: rootdisk
+                          shareable: false
+  - name: VM disk with shareable true -> non-compliant
+    expect: false
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-ok
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: rootdisk
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-shared
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      disks:
+                        - name: data
+                          shareable: true

--- a/applications/openshift-virtualization/kubevirt-no-shareable-disks/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-no-shareable-disks/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Virtual Machine Disks Must Not Be Shareable'
+
+description: |-
+    A disk marked 'shareable: true' may be attached to multiple virtual
+    machines concurrently. Shared writable disks bypass the isolation
+    between workloads: one guest can tamper with data another guest reads,
+    and concurrent writers without cluster-aware filesystems corrupt data.
+    Disks should not be shareable unless a reviewed clustered workload
+    requires it.
+
+rationale: |-
+    Every disk with '.shareable == true' creates a data path between
+    virtual machines that circumvents network controls and namespace
+    isolation, enabling tampering and data corruption across workloads.
+
+severity: medium
+
+ocil_clause: 'a VirtualMachine disk is marked shareable'
+
+ocil: |-
+    Run the following command to list shareable disks:
+    <pre>$ oc get vm -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.spec.template.spec.domain.devices.disks[?(@.shareable==true)].name}{"\n"}{end}'</pre>
+    No virtual machine should list a shareable disk.

--- a/applications/openshift-virtualization/kubevirt-no-vm-device-passthrough/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-no-vm-device-passthrough/cel/shared.yml
@@ -1,0 +1,21 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more 'VirtualMachine' resources request GPU or host-device
+    passthrough ('.spec.template.spec.domain.devices.gpus' or
+    '.spec.template.spec.domain.devices.hostDevices'), giving guests direct
+    access to host hardware.
+
+inputs:
+  - name: vms
+    kubernetes_input_spec:
+      api_version: kubevirt.io/v1
+      resource: virtualmachines
+
+expression: |
+  vms.items.all(v,
+      (!has(v.spec.template.spec.domain.devices) || (
+        (!has(v.spec.template.spec.domain.devices.gpus) || size(v.spec.template.spec.domain.devices.gpus) == 0) &&
+        (!has(v.spec.template.spec.domain.devices.hostDevices) || size(v.spec.template.spec.domain.devices.hostDevices) == 0)
+      ))
+  )

--- a/applications/openshift-virtualization/kubevirt-no-vm-device-passthrough/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-no-vm-device-passthrough/cel/tests/cases.yaml
@@ -1,0 +1,94 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real VirtualMachine API objects (celctl cac scaffold format)
+  date: '2026-07-23'
+  openshift_version: 4.22.0
+  kubernetes_version: v1.35.5
+  source_api_versions:
+    vms: kubevirt.io/v1
+cases:
+  - name: no VMs -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: VM without devices -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-plain
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices: {}
+  - name: VM with empty gpus/hostDevices lists -> compliant
+    expect: true
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-empty-lists
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      gpus: []
+                      hostDevices: []
+  - name: VM with a GPU passthrough -> non-compliant
+    expect: false
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-gpu
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      gpus:
+                        - deviceName: nvidia.com/T4
+                          name: gpu1
+  - name: VM with a host device -> non-compliant
+    expect: false
+    inputs:
+      vms:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: kubevirt.io/v1
+            kind: VirtualMachine
+            metadata:
+              name: vm-hostdev
+              namespace: default
+            spec:
+              template:
+                spec:
+                  domain:
+                    devices:
+                      hostDevices:
+                        - deviceName: kubevirt.io/usb-storage
+                          name: usb1

--- a/applications/openshift-virtualization/kubevirt-no-vm-device-passthrough/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-no-vm-device-passthrough/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Virtual Machines Must Not Pass Through GPUs or Host Devices'
+
+description: |-
+    Passing host devices (GPUs, PCI or USB devices) through to a virtual
+    machine gives the guest direct access to host hardware, bypassing the
+    hypervisor's isolation. A compromised guest with device passthrough can
+    attack the host through the device (DMA, firmware) far more easily than
+    through the virtualized surface. Only explicitly approved workloads
+    should use passthrough; any use must be reviewed.
+
+rationale: |-
+    Every '.spec.template.spec.domain.devices.gpus' or
+    '.spec.template.spec.domain.devices.hostDevices' entry on a
+    VirtualMachine widens the guest's reach into host hardware and weakens
+    the isolation boundary that virtualization provides.
+
+severity: medium
+
+ocil_clause: 'a VirtualMachine requests GPU or host-device passthrough'
+
+ocil: |-
+    Run the following command to list virtual machines requesting device
+    passthrough:
+    <pre>$ oc get vm -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: gpus={.spec.template.spec.domain.devices.gpus} hostDevices={.spec.template.spec.domain.devices.hostDevices}{"\n"}{end}'</pre>
+    No virtual machine should list gpus or hostDevices entries.

--- a/products/ocp4/profiles/cis-vm-extension.profile
+++ b/products/ocp4/profiles/cis-vm-extension.profile
@@ -30,3 +30,4 @@ selections:
     - kubevirt-enforce-trusted-tls-registries
     - kubevirt-no-vm-device-passthrough
     - kubevirt-no-shareable-disks
+    - kubevirt-disk-error-policy-not-ignore

--- a/products/ocp4/profiles/cis-vm-extension.profile
+++ b/products/ocp4/profiles/cis-vm-extension.profile
@@ -28,3 +28,4 @@ selections:
     - kubevirt-persistent-reservation-disabled
     - kubevirt-no-vms-overcommitting-guest-memory
     - kubevirt-enforce-trusted-tls-registries
+    - kubevirt-no-vm-device-passthrough

--- a/products/ocp4/profiles/cis-vm-extension.profile
+++ b/products/ocp4/profiles/cis-vm-extension.profile
@@ -29,3 +29,4 @@ selections:
     - kubevirt-no-vms-overcommitting-guest-memory
     - kubevirt-enforce-trusted-tls-registries
     - kubevirt-no-vm-device-passthrough
+    - kubevirt-no-shareable-disks


### PR DESCRIPTION
## Summary

Adds three CEL rules that evaluate every VirtualMachine individually, one commit per Jira:

| Commit | CIS | Rule |
|---|---|---|
| CMP-4429 | 2.1 | `kubevirt-no-vm-device-passthrough` — no GPU/host-device passthrough |
| CMP-4430 | 3.2 | `kubevirt-no-shareable-disks` — no disk with `shareable: true` |
| CMP-4431 | 3.3 | `kubevirt-disk-error-policy-not-ignore` — no disk with `errorPolicy: ignore` |

All three consume the `virtualmachines` List (`vms.items.all(...)`, the scanner's List-binding semantics). Scanner RBAC merged in ComplianceAsCode/compliance-operator#1293. Rules added to the `cis-vm-extension` profile selections.

## Testing

Each rule ships `cel/tests/cases.yaml` fixtures with compliant and non-compliant cases, evaluated through `celctl` (the compliance-operator scanner engine):

- `celctl cac lint` + `cac test`: 13/13 cases pass
- Live cluster (OCP 4.22 + CNV, running VMs): `cac live` AND a full operator scan (ProfileBundle with celContentFile → ScanSettingBinding, collector granted the #1293 RBAC) — all three rules PASS against real VirtualMachine objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
