### PR TITLE
CMP-4432: Add secondary-network CEL rules for CIS OCP-Virt 4.1/4.2 (SR-IOV + NAD split)

### DIFF
--- a/applications/openshift-virtualization/kubevirt-bridge-mac-spoof-filtering/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-bridge-mac-spoof-filtering/cel/shared.yml
@@ -1,0 +1,20 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more bridge NetworkAttachmentDefinitions do not set
+    'macspoofchk: true' in their CNI configuration, allowing guests to
+    spoof layer-2 identities.
+
+inputs:
+  - name: nads
+    kubernetes_input_spec:
+      api_version: k8s.cni.cncf.io/v1
+      resource: network-attachment-definitions
+
+expression: |
+  nads.items.all(n,
+      !has(n.spec.config) ||
+      !("type" in parseJSON(n.spec.config)) ||
+      parseJSON(n.spec.config).type != "bridge" ||
+      ("macspoofchk" in parseJSON(n.spec.config) && parseJSON(n.spec.config).macspoofchk == true)
+  )

--- a/applications/openshift-virtualization/kubevirt-bridge-mac-spoof-filtering/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-bridge-mac-spoof-filtering/cel/tests/cases.yaml
@@ -1,0 +1,92 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real API objects (celctl cac scaffold format)
+  date: '2026-07-24'
+  openshift_version: 4.21.0
+  kubernetes_version: v1.34
+  source_api_versions:
+    nads: k8s.cni.cncf.io/v1
+cases:
+  - name: no NetworkAttachmentDefinitions present is compliant
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: bridge NAD with macspoofchk enabled is compliant
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: bridge-ok
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "bridge", "bridge": "br1",
+                "macspoofchk": true}'
+  - name: non-bridge NAD is ignored
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: ovn-a
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "ovn-k8s-cni-overlay", "topology":
+                "layer2", "netAttachDefName": "default/ovn-a"}'
+  - name: NAD config without a type key is ignored
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: plugins-nad
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "name": "br-net", "plugins": [{"type":
+                "cnv-bridge", "bridge": "br1"}]}'
+  - name: bridge NAD without macspoofchk is non-compliant
+    expect: false
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: bridge-nofilter
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "bridge", "bridge": "br2"}'
+  - name: bridge NAD with macspoofchk disabled is non-compliant
+    expect: false
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: bridge-off
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "bridge", "bridge": "br3",
+                "macspoofchk": false}'

--- a/applications/openshift-virtualization/kubevirt-bridge-mac-spoof-filtering/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-bridge-mac-spoof-filtering/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Bridge Network Attachments Must Enable MAC Spoof Filtering'
+
+description: |-
+    Bridge-type NetworkAttachmentDefinitions must set 'macspoofchk: true'
+    in their CNI configuration so the bridge drops frames whose source MAC
+    differs from the address assigned to the interface. Without it, a
+    compromised guest can impersonate other workloads or infrastructure at
+    layer 2 (ARP spoofing, man-in-the-middle).
+
+rationale: |-
+    Layer-2 identity is the basis for switching decisions on secondary
+    networks. A guest that can spoof MAC addresses can intercept or
+    redirect other workloads' traffic on the same segment.
+
+severity: medium
+
+ocil_clause: 'a bridge NetworkAttachmentDefinition does not enable macspoofchk'
+
+ocil: |-
+    Run the following command:
+    <pre>$ oc get network-attachment-definitions -A -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.config}{"\n"}{end}'</pre>
+    Every config with '"type":"bridge"' should set '"macspoofchk": true'.

--- a/applications/openshift-virtualization/kubevirt-localnet-vlan-required/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-localnet-vlan-required/cel/shared.yml
@@ -1,0 +1,20 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more localnet NetworkAttachmentDefinitions do not declare a
+    'vlanID' in their CNI configuration, leaving virtual machine traffic on
+    the untagged provider segment.
+
+inputs:
+  - name: nads
+    kubernetes_input_spec:
+      api_version: k8s.cni.cncf.io/v1
+      resource: network-attachment-definitions
+
+expression: |
+  nads.items.all(n,
+      !has(n.spec.config) ||
+      !("topology" in parseJSON(n.spec.config)) ||
+      parseJSON(n.spec.config).topology != "localnet" ||
+      ("vlanID" in parseJSON(n.spec.config) && parseJSON(n.spec.config).vlanID > 0)
+  )

--- a/applications/openshift-virtualization/kubevirt-localnet-vlan-required/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-localnet-vlan-required/cel/tests/cases.yaml
@@ -1,0 +1,77 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real API objects (celctl cac scaffold format)
+  date: '2026-07-24'
+  openshift_version: 4.21.0
+  kubernetes_version: v1.34
+  source_api_versions:
+    nads: k8s.cni.cncf.io/v1
+cases:
+  - name: no NetworkAttachmentDefinitions present is compliant
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: localnet NAD with a vlanID is compliant
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: localnet-a
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "ovn-k8s-cni-overlay", "topology":
+                "localnet", "vlanID": 200, "netAttachDefName": "default/localnet-a"}'
+  - name: non-localnet NAD without a VLAN is ignored
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: bridge-a
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "bridge", "bridge": "br1"}'
+  - name: NAD config without a topology key is ignored
+    expect: true
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: plugins-nad
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "name": "br-net", "plugins": [{"type":
+                "cnv-bridge", "bridge": "br1"}]}'
+  - name: localnet NAD without a vlanID is non-compliant
+    expect: false
+    inputs:
+      nads:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: k8s.cni.cncf.io/v1
+            kind: NetworkAttachmentDefinition
+            metadata:
+              name: localnet-untagged
+              namespace: default
+            spec:
+              config: '{"cniVersion": "0.3.1", "type": "ovn-k8s-cni-overlay", "topology":
+                "localnet", "netAttachDefName": "default/localnet-untagged"}'

--- a/applications/openshift-virtualization/kubevirt-localnet-vlan-required/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-localnet-vlan-required/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Localnet Network Attachments Must Declare a Dedicated VLAN'
+
+description: |-
+    NetworkAttachmentDefinitions with the OVN 'localnet' topology bridge
+    virtual machine traffic onto the physical provider network. Such
+    attachments must declare a 'vlanID' in their CNI configuration so the
+    traffic is segmented on a dedicated VLAN rather than the untagged
+    provider segment. Environments that intentionally use untagged provider
+    networks should tailor the profile to exclude this rule for those objects.
+
+rationale: |-
+    Without VLAN segmentation, workloads attached to localnet networks
+    share a broadcast domain with other traffic, enabling lateral movement,
+    sniffing and spoofing between tenants and toward the infrastructure.
+
+severity: medium
+
+ocil_clause: 'a localnet NetworkAttachmentDefinition does not declare a vlanID'
+
+ocil: |-
+    Run the following command:
+    <pre>$ oc get network-attachment-definitions -A -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.config}{"\n"}{end}'</pre>
+    Every config with '"topology":"localnet"' should declare a non-zero vlanID.

--- a/applications/openshift-virtualization/kubevirt-sriov-spoofchk-on/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-sriov-spoofchk-on/cel/shared.yml
@@ -1,0 +1,16 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more SriovNetwork resources do not set '.spec.spoofChk' to "on",
+    allowing guests to spoof layer-2 identities.
+
+inputs:
+  - name: sriovnets
+    kubernetes_input_spec:
+      api_version: sriovnetwork.openshift.io/v1
+      resource: sriovnetworks
+
+expression: |
+  sriovnets.items.all(n,
+      has(n.spec.spoofChk) && n.spec.spoofChk == "on"
+  )

--- a/applications/openshift-virtualization/kubevirt-sriov-spoofchk-on/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-sriov-spoofchk-on/cel/tests/cases.yaml
@@ -1,0 +1,62 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real API objects (celctl cac scaffold format)
+  date: '2026-07-24'
+  openshift_version: 4.21.0
+  kubernetes_version: v1.34
+  source_api_versions:
+    sriovnets: sriovnetwork.openshift.io/v1
+cases:
+  - name: no SriovNetworks present is compliant
+    expect: true
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: SriovNetwork with spoofChk on is compliant
+    expect: true
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: sriovnetwork.openshift.io/v1
+            kind: SriovNetwork
+            metadata:
+              name: net-a
+              namespace: openshift-sriov-network-operator
+            spec:
+              spoofChk: 'on'
+              resourceName: sriov_a
+  - name: SriovNetwork with spoofChk off is non-compliant
+    expect: false
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: sriovnetwork.openshift.io/v1
+            kind: SriovNetwork
+            metadata:
+              name: net-off
+              namespace: openshift-sriov-network-operator
+            spec:
+              spoofChk: 'off'
+              resourceName: sriov_b
+  - name: SriovNetwork without explicit spoofChk is non-compliant
+    expect: false
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: sriovnetwork.openshift.io/v1
+            kind: SriovNetwork
+            metadata:
+              name: net-unset
+              namespace: openshift-sriov-network-operator
+            spec:
+              resourceName: sriov_c

--- a/applications/openshift-virtualization/kubevirt-sriov-spoofchk-on/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-sriov-spoofchk-on/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'SR-IOV Networks Must Enable MAC Spoof Checking'
+
+description: |-
+    SR-IOV networks must set '.spec.spoofChk' to "on" so the NIC rejects
+    frames whose source MAC differs from the address assigned to the
+    virtual function. Without it, a compromised guest can impersonate other
+    workloads or infrastructure at layer 2.
+
+    NOTE: this rule reads SriovNetwork resources and therefore requires the
+    SR-IOV Network Operator. On clusters without the operator the resource
+    type does not exist and the check reports an error; CPE applicability
+    for CEL rules (CMP-4483) will mark it Not Applicable instead.
+
+rationale: |-
+    Layer-2 identity is the basis for switching decisions on secondary
+    networks. A guest that can spoof MAC addresses can intercept or
+    redirect other workloads' traffic on the same segment.
+
+severity: medium
+
+ocil_clause: 'an SriovNetwork does not set spoofChk to on'
+
+ocil: |-
+    Run the following command:
+    <pre>$ oc get sriovnetwork -A -o jsonpath='{range .items[*]}{.metadata.name}: spoofChk={.spec.spoofChk}{"\n"}{end}'</pre>
+    Every SR-IOV network should set spoofChk to "on".

--- a/applications/openshift-virtualization/kubevirt-sriov-vlan-required/cel/shared.yml
+++ b/applications/openshift-virtualization/kubevirt-sriov-vlan-required/cel/shared.yml
@@ -1,0 +1,16 @@
+check_type: Platform
+
+failure_reason: |-
+    One or more SriovNetwork resources do not declare a dedicated VLAN in
+    '.spec.vlan', leaving virtual machine traffic unsegmented.
+
+inputs:
+  - name: sriovnets
+    kubernetes_input_spec:
+      api_version: sriovnetwork.openshift.io/v1
+      resource: sriovnetworks
+
+expression: |
+  sriovnets.items.all(n,
+      has(n.spec.vlan) && n.spec.vlan > 0
+  )

--- a/applications/openshift-virtualization/kubevirt-sriov-vlan-required/cel/tests/cases.yaml
+++ b/applications/openshift-virtualization/kubevirt-sriov-vlan-required/cel/tests/cases.yaml
@@ -1,0 +1,62 @@
+# CEL rule unit-test fixtures. Evaluated by tests/unit/kubernetes/test_cel_rules.py
+# via celctl (cel-go, the Compliance Operator scanner engine).
+# Seeded from real API objects; see provenance. Versions only, nothing cluster-identifiable.
+provenance:
+  fetched_with: modeled on real API objects (celctl cac scaffold format)
+  date: '2026-07-24'
+  openshift_version: 4.21.0
+  kubernetes_version: v1.34
+  source_api_versions:
+    sriovnets: sriovnetwork.openshift.io/v1
+cases:
+  - name: no SriovNetworks present is compliant
+    expect: true
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items: []
+  - name: SriovNetwork with a VLAN is compliant
+    expect: true
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: sriovnetwork.openshift.io/v1
+            kind: SriovNetwork
+            metadata:
+              name: net-a
+              namespace: openshift-sriov-network-operator
+            spec:
+              vlan: 100
+              resourceName: sriov_a
+  - name: SriovNetwork without a VLAN is non-compliant
+    expect: false
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: sriovnetwork.openshift.io/v1
+            kind: SriovNetwork
+            metadata:
+              name: net-novlan
+              namespace: openshift-sriov-network-operator
+            spec:
+              resourceName: sriov_b
+  - name: SriovNetwork with VLAN 0 (untagged) is non-compliant
+    expect: false
+    inputs:
+      sriovnets:
+        apiVersion: v1
+        kind: List
+        items:
+          - apiVersion: sriovnetwork.openshift.io/v1
+            kind: SriovNetwork
+            metadata:
+              name: net-zero
+              namespace: openshift-sriov-network-operator
+            spec:
+              vlan: 0
+              resourceName: sriov_c

--- a/applications/openshift-virtualization/kubevirt-sriov-vlan-required/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-sriov-vlan-required/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+title: 'SR-IOV Networks Must Declare a Dedicated VLAN'
+
+description: |-
+    SR-IOV networks used by virtual machines must segment traffic with a
+    dedicated VLAN declared in '.spec.vlan'. An SR-IOV network without a
+    VLAN places virtual machine traffic on the untagged provider segment,
+    mixing tenant traffic with infrastructure traffic. Environments that
+    intentionally use untagged provider networks should tailor the profile
+    to exclude this rule for those objects.
+
+    NOTE: this rule reads SriovNetwork resources and therefore requires the
+    SR-IOV Network Operator. On clusters without the operator the resource
+    type does not exist and the check reports an error; CPE applicability
+    for CEL rules (CMP-4483) will mark it Not Applicable instead.
+
+rationale: |-
+    Without VLAN segmentation, workloads attached to SR-IOV networks share
+    a broadcast domain with other traffic, enabling lateral movement,
+    sniffing and spoofing between tenants and toward the infrastructure.
+
+severity: medium
+
+ocil_clause: 'an SriovNetwork does not declare a VLAN'
+
+ocil: |-
+    Run the following command:
+    <pre>$ oc get sriovnetwork -A -o jsonpath='{range .items[*]}{.metadata.name}: vlan={.spec.vlan}{"\n"}{end}'</pre>
+    Every SR-IOV network should declare a non-zero vlan.

--- a/products/ocp4/profiles/cis-vm-extension.profile
+++ b/products/ocp4/profiles/cis-vm-extension.profile
@@ -33,3 +33,5 @@ selections:
     - kubevirt-disk-error-policy-not-ignore
     - kubevirt-sriov-vlan-required
     - kubevirt-localnet-vlan-required
+    - kubevirt-sriov-spoofchk-on
+    - kubevirt-bridge-mac-spoof-filtering

--- a/products/ocp4/profiles/cis-vm-extension.profile
+++ b/products/ocp4/profiles/cis-vm-extension.profile
@@ -31,3 +31,5 @@ selections:
     - kubevirt-no-vm-device-passthrough
     - kubevirt-no-shareable-disks
     - kubevirt-disk-error-policy-not-ignore
+    - kubevirt-sriov-vlan-required
+    - kubevirt-localnet-vlan-required


### PR DESCRIPTION
## Summary

Adds four CEL rules for the CIS OCP-Virt secondary-network controls — each control split into an SR-IOV rule and a NAD rule so applicability is clean:

| Commit | CIS | Rules |
|---|---|---|
| CMP-4432 | 4.1 | `kubevirt-sriov-vlan-required` (SriovNetwork `.spec.vlan > 0`), `kubevirt-localnet-vlan-required` (localnet NAD `vlanID`) |
| CMP-4433 | 4.2 | `kubevirt-sriov-spoofchk-on` (SriovNetwork `spoofChk: "on"`), `kubevirt-bridge-mac-spoof-filtering` (bridge NAD `macspoofchk: true`) |

**Why split:** a combined rule ERRORs wholesale on clusters without the SR-IOV Network Operator — one failed input fetch (`sriovnetworks` type not registered) prevents binding for the whole expression. Verified via an operator scan on a stock AWS cluster. With the split, the NAD rules work on every cluster (the NAD CRD ships with multus); only the two SR-IOV rules depend on the operator and will be marked Not Applicable by the CEL CPE work (CMP-4483) — documented in each rule.

All parsed-JSON key access is guarded with `in` (configs without `topology`/`type` keys are ignored, never a no-such-key FAIL). Scanner RBAC merged in ComplianceAsCode/compliance-operator#1293. Rules added to the `cis-vm-extension` profile selections.

CIS 4.3 (multi-network policies, CMP-4434) ships as a Manual rule in the Manual-rules PR (MultiNetworkPolicy CRD disabled by default cluster-wide).

## Testing

- `celctl cac lint` + `cac test`: 19/19 fixture cases across the 4 rules
- Operator scan on OCP 4.21 + CNV (fresh install): `kubevirt-localnet-vlan-required` PASS; `kubevirt-bridge-mac-spoof-filtering` correctly FAILs when a bridge NAD without `macspoofchk` is present and PASSes when only compliant NADs exist; the two SR-IOV rules report the documented not-applicable ERROR on a cluster without the SR-IOV operator
- Strict-semantics check on a separate OCP 4.22 + CNV cluster with a real SriovNetwork lacking `vlan`/`spoofChk`: SR-IOV rules correctly report non-compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
