### PR TITLE
CMP-4435: Add manual rule kubevirt-restrict-migration-tools-access for CIS OCP-Virt 1.10

### DIFF
--- a/applications/openshift-virtualization/kubevirt-restrict-migration-tools-access/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-restrict-migration-tools-access/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: 'Restrict Namespace Administrator Access to Migration Tools'
+
+description: |-
+    Only authorized subjects should be allowed to create
+    <tt>VirtualMachineInstanceMigration</tt> (vmim) and
+    <tt>MigrationPolicy</tt> resources. Unrestricted access to these
+    resources allows namespace administrators to trigger live migrations
+    and define migration policies, which can affect workload placement,
+    resource consumption, and the overall stability of the cluster.
+
+rationale: |-
+    Virtual machine live migration moves a running VM between nodes.
+    Granting the ability to create <tt>VirtualMachineInstanceMigration</tt>
+    or <tt>MigrationPolicy</tt> objects to untrusted or unnecessary
+    subjects increases the risk of unplanned resource contention,
+    denial of service through excessive migrations, and potential
+    exposure of workload data during the migration process. Restricting
+    access to these resources ensures that only approved administrators
+    can initiate or influence VM migration behavior.
+
+severity: medium
+
+ocil_clause: 'unauthorized subjects can create vmim or migrationpolicy resources'
+
+ocil: |-
+    Run the following commands to check which subjects can create
+    migration-related resources:
+    <pre>$ oc adm policy who-can create vmim</pre>
+    <pre>$ oc adm policy who-can create migrationpolicy</pre>
+    Verify that only authorized subjects are listed in the output.

--- a/applications/openshift-virtualization/kubevirt-restrict-migration-tools-access/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-restrict-migration-tools-access/rule.yml
@@ -3,12 +3,13 @@ documentation_complete: true
 title: 'Restrict Namespace Administrator Access to Migration Tools'
 
 description: |-
-    Only authorized subjects should be allowed to create
-    <tt>VirtualMachineInstanceMigration</tt> (vmim) and
-    <tt>MigrationPolicy</tt> resources. Unrestricted access to these
-    resources allows namespace administrators to trigger live migrations
-    and define migration policies, which can affect workload placement,
-    resource consumption, and the overall stability of the cluster.
+    Because the set of authorized subjects is specific to each environment,
+    this rule requires manual verification. Organizations can create a
+    CustomRule using CEL to automate this check by evaluating
+    ClusterRoleBindings and ClusterRoles for create and update access to
+    <tt>VirtualMachineInstanceMigration</tt> and
+    <tt>MigrationPolicy</tt> resources, verifying that only approved
+    subjects are bound to those permissions.
 
 rationale: |-
     Virtual machine live migration moves a running VM between nodes.

--- a/build-scripts/build_cel_content.py
+++ b/build-scripts/build_cel_content.py
@@ -339,8 +339,10 @@ def generate_cel_content(cel_rules, profiles):
         for rule_id in profile.selected:
             if rule_id not in cel_rule_ids:
                 rule_name = rule_id_to_name(rule_id)
-                raise ValueError(
-                    f"profile '{profile_name}' references unknown rule '{rule_name}'"
+                logging.warning(
+                    "profile '%s' references rule '%s' without CEL checks "
+                    "(manual rule) - skipping from CEL content",
+                    profile_name, rule_name,
                 )
 
         cel_profile = profile_to_cel_dict(profile, cel_rule_ids)

--- a/build-scripts/build_cel_content.py
+++ b/build-scripts/build_cel_content.py
@@ -386,13 +386,13 @@ def main():
     # Load all rules in a single pass
     cel_rules, all_rules = load_rules(args.resolved_rules_dir)
 
-    if not cel_rules:
+    # Load profiles
+    cel_rule_ids = set(cel_rules.keys())
+    profiles = load_profiles(args.profiles_dir, cel_rule_ids)
+
+    if not cel_rules and not profiles:
         content = {'profiles': [], 'rules': []}
     else:
-        # Load profiles
-        cel_rule_ids = set(cel_rules.keys())
-        profiles = load_profiles(args.profiles_dir, cel_rule_ids)
-
         # Generate CEL content
         content = generate_cel_content(cel_rules, profiles, all_rules)
 

--- a/build-scripts/build_cel_content.py
+++ b/build-scripts/build_cel_content.py
@@ -61,6 +61,34 @@ def setup_logging(log_level_str):
     logging.basicConfig(format=MESSAGE_FORMAT, level=numeric_level)
 
 
+def load_all_rule_ids(rules_dir):
+    """
+    Load IDs of all compiled rules regardless of check type.
+
+    Args:
+        rules_dir: Directory containing resolved rule JSON files
+
+    Returns:
+        set: Set of all rule IDs found in the directory
+    """
+    all_ids = set()
+
+    if not os.path.isdir(rules_dir):
+        return all_ids
+
+    for rule_file in os.listdir(rules_dir):
+        rule_path = os.path.join(rules_dir, rule_file)
+        try:
+            rule = ssg.build_yaml.Rule.from_compiled_json(rule_path)
+            all_ids.add(rule.id_)
+        except ssg.build_yaml.DocumentationNotComplete:
+            continue
+        except Exception:
+            continue
+
+    return all_ids
+
+
 def load_cel_rules(rules_dir):
     """
     Load all rules that use the CEL checking engine.
@@ -300,21 +328,26 @@ def profile_to_cel_dict(profile, cel_rule_ids):
     return cel_profile
 
 
-def generate_cel_content(cel_rules, profiles):
+def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
     """
     Generate the complete CEL content structure.
 
     Args:
         cel_rules: Dictionary of rules with CEL checks
         profiles: List of profiles targeting the CEL checking engine
+        all_rule_ids: Set of all compiled rule IDs (used to distinguish
+                      manual rules from nonexistent rules)
 
     Returns:
         dict: Complete CEL content structure
 
     Raises:
-        ValueError: If duplicate rule names found or profile references unknown rules
+        ValueError: If duplicate rule names found or profile references
+                    a rule that does not exist
     """
     cel_rule_ids = set(cel_rules.keys())
+    if all_rule_ids is None:
+        all_rule_ids = cel_rule_ids
 
     # Generate rules section and check for duplicates
     cel_rules_list = []
@@ -334,16 +367,21 @@ def generate_cel_content(cel_rules, profiles):
     # Generate profiles section and validate rule references
     cel_profiles = []
     for profile in profiles:
-        # Validate that all selected rules have CEL checks
         profile_name = rule_id_to_name(profile.id_)
         for rule_id in profile.selected:
             if rule_id not in cel_rule_ids:
                 rule_name = rule_id_to_name(rule_id)
-                logging.warning(
-                    "profile '%s' references rule '%s' without CEL checks "
-                    "(manual rule) - skipping from CEL content",
-                    profile_name, rule_name,
-                )
+                if rule_id in all_rule_ids:
+                    logging.warning(
+                        "profile '%s' references rule '%s' without CEL checks "
+                        "(manual rule) - skipping from CEL content",
+                        profile_name, rule_name,
+                    )
+                else:
+                    raise ValueError(
+                        f"profile '{profile_name}' references unknown rule "
+                        f"'{rule_name}'"
+                    )
 
         cel_profile = profile_to_cel_dict(profile, cel_rule_ids)
         if cel_profile:
@@ -362,7 +400,8 @@ def main():
     args = parse_args()
     setup_logging(args.log)
 
-    # Load rules with CEL checks
+    # Load all rule IDs and rules with CEL checks
+    all_rule_ids = load_all_rule_ids(args.resolved_rules_dir)
     cel_rules = load_cel_rules(args.resolved_rules_dir)
 
     if not cel_rules:
@@ -372,7 +411,7 @@ def main():
         profiles = load_profiles(args.profiles_dir, set(cel_rules.keys()))
 
         # Generate CEL content
-        content = generate_cel_content(cel_rules, profiles)
+        content = generate_cel_content(cel_rules, profiles, all_rule_ids)
 
     # Write output YAML
     os.makedirs(os.path.dirname(args.output), exist_ok=True)

--- a/build-scripts/build_cel_content.py
+++ b/build-scripts/build_cel_content.py
@@ -328,7 +328,8 @@ def profile_to_cel_dict(profile, cel_rule_ids):
     return cel_profile
 
 
-def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
+def generate_cel_content(cel_rules, profiles, all_rule_ids=None,
+                         manual_rules=None):
     """
     Generate the complete CEL content structure.
 
@@ -337,6 +338,8 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
         profiles: List of profiles targeting the CEL checking engine
         all_rule_ids: Set of all compiled rule IDs (used to distinguish
                       manual rules from nonexistent rules)
+        manual_rules: Dictionary of manual rules (rules without CEL checks
+                      that are selected by CEL profiles)
 
     Returns:
         dict: Complete CEL content structure
@@ -348,12 +351,19 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
     cel_rule_ids = set(cel_rules.keys())
     if all_rule_ids is None:
         all_rule_ids = cel_rule_ids
+    if manual_rules is None:
+        manual_rules = {}
+
+    # Combine CEL and manual rules for output
+    all_output_rules = dict(cel_rules)
+    all_output_rules.update(manual_rules)
+    all_output_rule_ids = set(all_output_rules.keys())
 
     # Generate rules section and check for duplicates
     cel_rules_list = []
     rule_names_seen = set()
-    for rule_id in sorted(cel_rules.keys()):
-        rule = cel_rules[rule_id]
+    for rule_id in sorted(all_output_rules.keys()):
+        rule = all_output_rules[rule_id]
         cel_rule = rule_to_cel_dict(rule)
 
         # Check for duplicate rule names
@@ -369,7 +379,7 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
     for profile in profiles:
         profile_name = rule_id_to_name(profile.id_)
         for rule_id in profile.selected:
-            if rule_id not in cel_rule_ids:
+            if rule_id not in all_output_rule_ids:
                 rule_name = rule_id_to_name(rule_id)
                 if rule_id in all_rule_ids:
                     logging.warning(
@@ -383,7 +393,7 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
                         f"'{rule_name}'"
                     )
 
-        cel_profile = profile_to_cel_dict(profile, cel_rule_ids)
+        cel_profile = profile_to_cel_dict(profile, all_output_rule_ids)
         if cel_profile:
             cel_profiles.append(cel_profile)
 
@@ -394,6 +404,40 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None):
     }
 
     return content
+
+
+def load_manual_rules(rules_dir, manual_rule_ids):
+    """
+    Load rules that are selected by CEL profiles but have no CEL checks.
+
+    These are emitted into CEL content with checkType: Manual so the
+    compliance-operator can produce MANUAL/notchecked results for them.
+
+    Args:
+        rules_dir: Directory containing resolved rule JSON files
+        manual_rule_ids: Set of rule IDs to load as manual rules
+
+    Returns:
+        dict: Dictionary of rule_id -> rule object for manual rules
+    """
+    manual_rules = {}
+
+    if not manual_rule_ids or not os.path.isdir(rules_dir):
+        return manual_rules
+
+    for rule_file in os.listdir(rules_dir):
+        rule_path = os.path.join(rules_dir, rule_file)
+        try:
+            rule = ssg.build_yaml.Rule.from_compiled_json(rule_path)
+            if rule.id_ in manual_rule_ids:
+                rule.check_type = 'Manual'
+                manual_rules[rule.id_] = rule
+        except ssg.build_yaml.DocumentationNotComplete:
+            continue
+        except Exception:
+            continue
+
+    return manual_rules
 
 
 def main():
@@ -408,10 +452,22 @@ def main():
         content = {'profiles': [], 'rules': []}
     else:
         # Load profiles
-        profiles = load_profiles(args.profiles_dir, set(cel_rules.keys()))
+        cel_rule_ids = set(cel_rules.keys())
+        profiles = load_profiles(args.profiles_dir, cel_rule_ids)
+
+        # Collect rule IDs selected by CEL profiles that have no CEL checks
+        manual_rule_ids = set()
+        for profile in profiles:
+            for rule_id in profile.selected:
+                if rule_id not in cel_rule_ids and rule_id in all_rule_ids:
+                    manual_rule_ids.add(rule_id)
+
+        manual_rules = load_manual_rules(args.resolved_rules_dir, manual_rule_ids)
 
         # Generate CEL content
-        content = generate_cel_content(cel_rules, profiles, all_rule_ids)
+        content = generate_cel_content(
+            cel_rules, profiles, all_rule_ids, manual_rules
+        )
 
     # Write output YAML
     os.makedirs(os.path.dirname(args.output), exist_ok=True)

--- a/build-scripts/build_cel_content.py
+++ b/build-scripts/build_cel_content.py
@@ -61,65 +61,40 @@ def setup_logging(log_level_str):
     logging.basicConfig(format=MESSAGE_FORMAT, level=numeric_level)
 
 
-def load_all_rule_ids(rules_dir):
+def load_rules(rules_dir):
     """
-    Load IDs of all compiled rules regardless of check type.
+    Load all compiled rules, separating CEL rules from the rest.
+
+    Scans the directory once, returning CEL rules (with expression and
+    inputs) and all remaining rules keyed by ID.
 
     Args:
         rules_dir: Directory containing resolved rule JSON files
 
     Returns:
-        set: Set of all rule IDs found in the directory
-    """
-    all_ids = set()
-
-    if not os.path.isdir(rules_dir):
-        return all_ids
-
-    for rule_file in os.listdir(rules_dir):
-        rule_path = os.path.join(rules_dir, rule_file)
-        try:
-            rule = ssg.build_yaml.Rule.from_compiled_json(rule_path)
-            all_ids.add(rule.id_)
-        except ssg.build_yaml.DocumentationNotComplete:
-            continue
-        except Exception:
-            continue
-
-    return all_ids
-
-
-def load_cel_rules(rules_dir):
-    """
-    Load all rules that use the CEL checking engine.
-
-    Args:
-        rules_dir: Directory containing resolved rule JSON files
-
-    Returns:
-        dict: Dictionary of rule_id -> rule object for rules with CEL checks
+        tuple: (cel_rules, all_rules) where cel_rules is a dict of
+               rule_id -> rule object for rules with CEL checks, and
+               all_rules is a dict of rule_id -> rule object for all rules
 
     Raises:
         ValueError: If a rule with CEL checks is missing required fields
     """
     cel_rules = {}
+    all_rules = {}
 
     if not os.path.isdir(rules_dir):
-        return cel_rules
+        return cel_rules, all_rules
 
     for rule_file in os.listdir(rules_dir):
         rule_path = os.path.join(rules_dir, rule_file)
         try:
             rule = ssg.build_yaml.Rule.from_compiled_json(rule_path)
+            all_rules[rule.id_] = rule
 
-            # Check if this rule has CEL checks by looking for CEL-specific fields
-            # A rule uses CEL if it has both expression and inputs
-            # (loaded from cel/shared.yml during rule compilation)
             has_expression = hasattr(rule, 'expression') and rule.expression
             has_inputs = hasattr(rule, 'inputs') and rule.inputs
 
             if has_expression and has_inputs:
-                # Validate required CEL fields
                 rule_name = rule_id_to_name(rule.id_)
 
                 if not hasattr(rule, 'check_type') or not rule.check_type:
@@ -130,16 +105,14 @@ def load_cel_rules(rules_dir):
 
                 cel_rules[rule.id_] = rule
         except ssg.build_yaml.DocumentationNotComplete:
-            # Skip documentation-incomplete rules in non-debug builds
             continue
         except ValueError:
-            # Re-raise validation errors
             raise
         except Exception as e:
             logging.warning("Failed to load rule from %s: %s", rule_file, e)
             continue
 
-    return cel_rules
+    return cel_rules, all_rules
 
 
 def load_profiles(profiles_dir, cel_rule_ids):
@@ -406,47 +379,13 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None,
     return content
 
 
-def load_manual_rules(rules_dir, manual_rule_ids):
-    """
-    Load rules that are selected by CEL profiles but have no CEL checks.
-
-    These are emitted into CEL content with checkType: Manual so the
-    compliance-operator can produce MANUAL/notchecked results for them.
-
-    Args:
-        rules_dir: Directory containing resolved rule JSON files
-        manual_rule_ids: Set of rule IDs to load as manual rules
-
-    Returns:
-        dict: Dictionary of rule_id -> rule object for manual rules
-    """
-    manual_rules = {}
-
-    if not manual_rule_ids or not os.path.isdir(rules_dir):
-        return manual_rules
-
-    for rule_file in os.listdir(rules_dir):
-        rule_path = os.path.join(rules_dir, rule_file)
-        try:
-            rule = ssg.build_yaml.Rule.from_compiled_json(rule_path)
-            if rule.id_ in manual_rule_ids:
-                rule.check_type = 'Manual'
-                manual_rules[rule.id_] = rule
-        except ssg.build_yaml.DocumentationNotComplete:
-            continue
-        except Exception:
-            continue
-
-    return manual_rules
-
-
 def main():
     args = parse_args()
     setup_logging(args.log)
 
-    # Load all rule IDs and rules with CEL checks
-    all_rule_ids = load_all_rule_ids(args.resolved_rules_dir)
-    cel_rules = load_cel_rules(args.resolved_rules_dir)
+    # Load all rules in a single pass
+    cel_rules, all_rules = load_rules(args.resolved_rules_dir)
+    all_rule_ids = set(all_rules.keys())
 
     if not cel_rules:
         content = {'profiles': [], 'rules': []}
@@ -455,14 +394,14 @@ def main():
         cel_rule_ids = set(cel_rules.keys())
         profiles = load_profiles(args.profiles_dir, cel_rule_ids)
 
-        # Collect rule IDs selected by CEL profiles that have no CEL checks
-        manual_rule_ids = set()
+        # Collect manual rules: selected by CEL profiles but no CEL checks
+        manual_rules = {}
         for profile in profiles:
             for rule_id in profile.selected:
                 if rule_id not in cel_rule_ids and rule_id in all_rule_ids:
-                    manual_rule_ids.add(rule_id)
-
-        manual_rules = load_manual_rules(args.resolved_rules_dir, manual_rule_ids)
+                    rule = all_rules[rule_id]
+                    rule.check_type = 'Manual'
+                    manual_rules[rule_id] = rule
 
         # Generate CEL content
         content = generate_cel_content(

--- a/build-scripts/build_cel_content.py
+++ b/build-scripts/build_cel_content.py
@@ -63,7 +63,7 @@ def setup_logging(log_level_str):
 
 def load_rules(rules_dir):
     """
-    Load all compiled rules, separating CEL rules from the rest.
+    Load all compiled rules, separating rules with CEL check from the rest.
 
     Scans the directory once, returning CEL rules (with expression and
     inputs) and all remaining rules keyed by ID.
@@ -91,6 +91,9 @@ def load_rules(rules_dir):
             rule = ssg.build_yaml.Rule.from_compiled_json(rule_path)
             all_rules[rule.id_] = rule
 
+            # Check if this rule has CEL checks by looking for CEL-specific fields
+            # A rule uses CEL if it has both expression and inputs
+            # (loaded from cel/shared.yml during rule compilation)
             has_expression = hasattr(rule, 'expression') and rule.expression
             has_inputs = hasattr(rule, 'inputs') and rule.inputs
 
@@ -301,18 +304,15 @@ def profile_to_cel_dict(profile, cel_rule_ids):
     return cel_profile
 
 
-def generate_cel_content(cel_rules, profiles, all_rule_ids=None,
-                         manual_rules=None):
+def generate_cel_content(cel_rules, profiles, all_rules=None):
     """
     Generate the complete CEL content structure.
 
     Args:
         cel_rules: Dictionary of rules with CEL checks
         profiles: List of profiles targeting the CEL checking engine
-        all_rule_ids: Set of all compiled rule IDs (used to distinguish
-                      manual rules from nonexistent rules)
-        manual_rules: Dictionary of manual rules (rules without CEL checks
-                      that are selected by CEL profiles)
+        all_rules: Dictionary of all compiled rule objects keyed by ID
+                   (used to distinguish manual rules from nonexistent rules)
 
     Returns:
         dict: Complete CEL content structure
@@ -322,21 +322,37 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None,
                     a rule that does not exist
     """
     cel_rule_ids = set(cel_rules.keys())
-    if all_rule_ids is None:
-        all_rule_ids = cel_rule_ids
-    if manual_rules is None:
-        manual_rules = {}
+    if all_rules is None:
+        all_rules = {}
+    all_rule_ids = set(all_rules.keys())
 
-    # Combine CEL and manual rules for output
-    all_output_rules = dict(cel_rules)
-    all_output_rules.update(manual_rules)
-    all_output_rule_ids = set(all_output_rules.keys())
+    # Process profiles first to identify manual rules
+    output_rules = dict(cel_rules)
+    for profile in profiles:
+        profile_name = rule_id_to_name(profile.id_)
+        for rule_id in profile.selected:
+            if rule_id not in cel_rule_ids:
+                rule_name = rule_id_to_name(rule_id)
+                if rule_id in all_rule_ids:
+                    logging.warning(
+                        "profile '%s' references rule '%s' without CEL checks "
+                        "- adding as manual rule",
+                        profile_name, rule_name,
+                    )
+                    output_rules[rule_id] = all_rules[rule_id]
+                else:
+                    raise ValueError(
+                        f"profile '{profile_name}' references unknown rule "
+                        f"'{rule_name}'"
+                    )
+
+    output_rule_ids = set(output_rules.keys())
 
     # Generate rules section and check for duplicates
     cel_rules_list = []
     rule_names_seen = set()
-    for rule_id in sorted(all_output_rules.keys()):
-        rule = all_output_rules[rule_id]
+    for rule_id in sorted(output_rules.keys()):
+        rule = output_rules[rule_id]
         cel_rule = rule_to_cel_dict(rule)
 
         # Check for duplicate rule names
@@ -347,26 +363,10 @@ def generate_cel_content(cel_rules, profiles, all_rule_ids=None,
 
         cel_rules_list.append(cel_rule)
 
-    # Generate profiles section and validate rule references
+    # Generate profiles section
     cel_profiles = []
     for profile in profiles:
-        profile_name = rule_id_to_name(profile.id_)
-        for rule_id in profile.selected:
-            if rule_id not in all_output_rule_ids:
-                rule_name = rule_id_to_name(rule_id)
-                if rule_id in all_rule_ids:
-                    logging.warning(
-                        "profile '%s' references rule '%s' without CEL checks "
-                        "(manual rule) - skipping from CEL content",
-                        profile_name, rule_name,
-                    )
-                else:
-                    raise ValueError(
-                        f"profile '{profile_name}' references unknown rule "
-                        f"'{rule_name}'"
-                    )
-
-        cel_profile = profile_to_cel_dict(profile, all_output_rule_ids)
+        cel_profile = profile_to_cel_dict(profile, output_rule_ids)
         if cel_profile:
             cel_profiles.append(cel_profile)
 
@@ -385,7 +385,6 @@ def main():
 
     # Load all rules in a single pass
     cel_rules, all_rules = load_rules(args.resolved_rules_dir)
-    all_rule_ids = set(all_rules.keys())
 
     if not cel_rules:
         content = {'profiles': [], 'rules': []}
@@ -394,19 +393,8 @@ def main():
         cel_rule_ids = set(cel_rules.keys())
         profiles = load_profiles(args.profiles_dir, cel_rule_ids)
 
-        # Collect manual rules: selected by CEL profiles but no CEL checks
-        manual_rules = {}
-        for profile in profiles:
-            for rule_id in profile.selected:
-                if rule_id not in cel_rule_ids and rule_id in all_rule_ids:
-                    rule = all_rules[rule_id]
-                    rule.check_type = 'Manual'
-                    manual_rules[rule_id] = rule
-
         # Generate CEL content
-        content = generate_cel_content(
-            cel_rules, profiles, all_rule_ids, manual_rules
-        )
+        content = generate_cel_content(cel_rules, profiles, all_rules)
 
     # Write output YAML
     os.makedirs(os.path.dirname(args.output), exist_ok=True)

--- a/docs/manual/developer/13_cel_content.md
+++ b/docs/manual/developer/13_cel_content.md
@@ -141,7 +141,7 @@ selections:
     - kubevirt-persistent-reservation-disabled
 ```
 
-**Important:** CEL profiles can only select CEL rules. If a profile includes both CEL and OVAL rules, only the CEL rules will be included in the generated CEL content file.
+**Important:** CEL profiles can select both CEL rules and manual rules (rules without `cel/shared.yml`). Only CEL rules are included in the generated CEL content file; manual rules are skipped with a build warning.
 
 ## Creating a CEL Rule
 
@@ -347,8 +347,8 @@ The build system validates CEL content automatically:
 
 **Profile Validation:**
 - `selected` field must contain at least one rule
-- All selected rules must exist in CEL rules
-- Profile cannot reference OVAL rules
+- Rules without CEL checks (manual rules) are skipped with a warning
+- Only CEL rules are included in the generated content
 
 **Content Validation:**
 - No duplicate rule names (after underscore-to-hyphen conversion)
@@ -434,9 +434,10 @@ cel-spec '{"resource": {"spec": {"enabled": true}}}' 'resource.spec.enabled == t
 **Error: `CEL profile 'profile-name' has no rules`**
 - Add rules to the `selections` field in the profile
 
-**Error: `profile 'profile-name' references unknown rule 'rule-name'`**
-- Verify the rule exists and has CEL checks (has `cel/shared.yml` with `expression` and `inputs`)
-- Check the rule ID matches the profile selection
+**Warning: `profile 'profile-name' references rule 'rule-name' without CEL checks (manual rule)`**
+- This is expected for manual rules that have no automated CEL check
+- The rule will be skipped from CEL content output but remains in the profile selections
+- If this is unintentional, verify the rule has `cel/shared.yml` with `expression` and `inputs`
 
 ### CEL Content Not Generated
 

--- a/docs/manual/developer/13_cel_content.md
+++ b/docs/manual/developer/13_cel_content.md
@@ -141,7 +141,7 @@ selections:
     - kubevirt-persistent-reservation-disabled
 ```
 
-**Important:** CEL profiles can select both CEL rules and manual rules (rules without `cel/shared.yml`). Only CEL rules are included in the generated CEL content file; manual rules are skipped with a build warning.
+**Important:** CEL profiles can select both CEL and SCAP rules. If a CEL rules doesn't have manual rules (rules without `cel/shared.yml`), or a SCAP rule is selected it will be included as  manual rule with a build warning.
 
 ## Creating a CEL Rule
 
@@ -347,8 +347,8 @@ The build system validates CEL content automatically:
 
 **Profile Validation:**
 - `selected` field must contain at least one rule
-- Rules without CEL checks (manual rules) are skipped with a warning
-- Only CEL rules are included in the generated content
+- Rules without CEL checks are included as manual rules with a warning
+- Both CEL rules and manual rules are included in the generated content
 
 **Content Validation:**
 - No duplicate rule names (after underscore-to-hyphen conversion)
@@ -434,9 +434,9 @@ cel-spec '{"resource": {"spec": {"enabled": true}}}' 'resource.spec.enabled == t
 **Error: `CEL profile 'profile-name' has no rules`**
 - Add rules to the `selections` field in the profile
 
-**Warning: `profile 'profile-name' references rule 'rule-name' without CEL checks (manual rule)`**
-- This is expected for manual rules that have no automated CEL check
-- The rule will be skipped from CEL content output but remains in the profile selections
+**Warning: `profile 'profile-name' references rule 'rule-name' without CEL checks - adding as manual rule`**
+- This is expected for rules that have no automated CEL check
+- The rule will be included in CEL content output without expression and inputs
 - If this is unintentional, verify the rule has `cel/shared.yml` with `expression` and `inputs`
 
 ### CEL Content Not Generated

--- a/docs/manual/developer/13_cel_content.md
+++ b/docs/manual/developer/13_cel_content.md
@@ -141,7 +141,7 @@ selections:
     - kubevirt-persistent-reservation-disabled
 ```
 
-**Important:** CEL profiles can select both CEL and SCAP rules. If a CEL rules doesn't have manual rules (rules without `cel/shared.yml`), or a SCAP rule is selected it will be included as  manual rule with a build warning.
+**Important:** CEL profiles can select both CEL and SCAP rules. Rules selected by a CEL profile that don't have a CEL check (no cel/shared.yml) will be included as manual rules with a build warning.
 
 ## Creating a CEL Rule
 

--- a/products/ocp4/profiles/cis-vm-extension.profile
+++ b/products/ocp4/profiles/cis-vm-extension.profile
@@ -35,3 +35,4 @@ selections:
     - kubevirt-localnet-vlan-required
     - kubevirt-sriov-spoofchk-on
     - kubevirt-bridge-mac-spoof-filtering
+    - kubevirt-restrict-migration-tools-access

--- a/tests/unit/ssg-module/test_build_cel_content.py
+++ b/tests/unit/ssg-module/test_build_cel_content.py
@@ -239,25 +239,29 @@ def test_extract_controls_from_references():
     assert controls_empty == {}
 
 
-def test_load_cel_rules(temp_rules_dir):
+def test_load_rules(temp_rules_dir):
     """Test loading rules with CEL checks from directory."""
-    cel_rules = build_cel_content.load_cel_rules(temp_rules_dir)
+    cel_rules, all_rules = build_cel_content.load_rules(temp_rules_dir)
 
-    # Should load only the rule with CEL checks (identified by presence of expression + inputs)
+    # Should load only the rule with CEL checks
     assert len(cel_rules) == 1
     assert 'kubevirt_nonroot_feature_gate_is_enabled' in cel_rules
 
+    # all_rules should contain both CEL and non-CEL rules
+    assert len(all_rules) == 2
+    assert 'some_oval_rule' in all_rules
+
     rule = cel_rules['kubevirt_nonroot_feature_gate_is_enabled']
-    # Rules with CEL checks are identified by presence of expression and inputs
     assert hasattr(rule, 'expression') and rule.expression
     assert hasattr(rule, 'inputs') and rule.inputs
     assert rule.title == 'Ensure NonRoot Feature Gate is Enabled'
 
 
-def test_load_cel_rules_nonexistent_dir():
-    """Test loading rules with CEL checks from nonexistent directory."""
-    cel_rules = build_cel_content.load_cel_rules('/nonexistent/path')
+def test_load_rules_nonexistent_dir():
+    """Test loading rules from nonexistent directory."""
+    cel_rules, all_rules = build_cel_content.load_rules('/nonexistent/path')
     assert cel_rules == {}
+    assert all_rules == {}
 
 
 def test_load_profiles(temp_profiles_dir):
@@ -469,12 +473,13 @@ def test_load_cel_rules_missing_expression():
 
         # Should not raise error - rule is not identified as CEL without both expression and inputs
         # This rule will be skipped since it doesn't have both fields
-        cel_rules = build_cel_content.load_cel_rules(tmpdir)
-        assert len(cel_rules) == 0  # Rule should be skipped
+        cel_rules, all_rules = build_cel_content.load_rules(tmpdir)
+        assert len(cel_rules) == 0  # Not a CEL rule
+        assert len(all_rules) == 1  # But still loaded as a rule
 
 
 def test_load_cel_rules_missing_inputs():
-    """Test that rule without inputs is skipped."""
+    """Test that rule without inputs is skipped from CEL rules."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create rule without inputs (but with expression - incomplete for CEL checks)
         rule_dict = {
@@ -493,10 +498,9 @@ def test_load_cel_rules_missing_inputs():
         with open(rule_path, 'w') as f:
             json.dump(rule_dict, f)
 
-        # Should not raise error - rule is not identified as CEL without both expression and inputs
-        # This rule will be skipped since it doesn't have both fields
-        cel_rules = build_cel_content.load_cel_rules(tmpdir)
-        assert len(cel_rules) == 0  # Rule should be skipped
+        cel_rules, all_rules = build_cel_content.load_rules(tmpdir)
+        assert len(cel_rules) == 0  # Not a CEL rule
+        assert len(all_rules) == 1  # But still loaded as a rule
 
 
 def test_load_profiles_no_rules():
@@ -610,13 +614,13 @@ def test_validation_empty_expression():
         with open(rule_path, 'w') as f:
             json.dump(rule_dict, f)
 
-        # Empty expression means rule is not identified as CEL and is skipped
-        cel_rules = build_cel_content.load_cel_rules(tmpdir)
+        cel_rules, all_rules = build_cel_content.load_rules(tmpdir)
         assert len(cel_rules) == 0
+        assert len(all_rules) == 1
 
 
 def test_validation_empty_inputs():
-    """Test that rule with empty inputs list is skipped."""
+    """Test that rule with empty inputs list is skipped from CEL rules."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create rule with empty inputs
         rule_dict = {
@@ -636,9 +640,9 @@ def test_validation_empty_inputs():
         with open(rule_path, 'w') as f:
             json.dump(rule_dict, f)
 
-        # Empty inputs means rule is not identified as CEL and is skipped
-        cel_rules = build_cel_content.load_cel_rules(tmpdir)
+        cel_rules, all_rules = build_cel_content.load_rules(tmpdir)
         assert len(cel_rules) == 0
+        assert len(all_rules) == 1
 
 
 def test_validation_profile_with_empty_selections():
@@ -737,7 +741,7 @@ def test_validation_integration_full_flow():
             json.dump(profile_dict, f)
 
         # Load and validate
-        cel_rules = build_cel_content.load_cel_rules(rules_dir)
+        cel_rules, all_rules = build_cel_content.load_rules(rules_dir)
         assert len(cel_rules) == 1
         assert 'valid_cel_rule' in cel_rules
 

--- a/tests/unit/ssg-module/test_build_cel_content.py
+++ b/tests/unit/ssg-module/test_build_cel_content.py
@@ -574,6 +574,8 @@ def test_generate_cel_content_unknown_rule_reference():
         'existing_rule': rule1
     }
 
+    all_rule_ids = {'existing_rule'}
+
     # Create a profile that references a non-existent rule
     profile = ssg.build_yaml.Profile('test_profile')
     profile.id_ = 'test_profile'
@@ -584,7 +586,7 @@ def test_generate_cel_content_unknown_rule_reference():
     profiles = [profile]
 
     with pytest.raises(ValueError, match="references unknown rule 'nonexistent-rule'"):
-        build_cel_content.generate_cel_content(cel_rules, profiles)
+        build_cel_content.generate_cel_content(cel_rules, profiles, all_rule_ids)
 
 
 def test_validation_empty_expression():
@@ -663,7 +665,7 @@ def test_validation_profile_with_empty_selections():
 
 
 def test_validation_mixed_oval_and_cel_in_profile():
-    """Test that profile with both OVAL and CEL checks only includes rules with CEL checks."""
+    """Test that profile with both OVAL and CEL checks only includes CEL rules in output."""
     # Create rule with CEL checks
     cel_rule = ssg.build_yaml.Rule('cel_rule')
     cel_rule.id_ = 'cel_rule'
@@ -679,19 +681,22 @@ def test_validation_mixed_oval_and_cel_in_profile():
         'cel_rule': cel_rule
     }
 
+    # oval_rule exists as a compiled rule but has no CEL checks
+    all_rule_ids = {'cel_rule', 'oval_rule'}
+
     # Create a CEL profile that references both CEL and OVAL rules
-    # (OVAL rules won't be in cel_rule_ids)
     profile = ssg.build_yaml.Profile('mixed_profile')
     profile.id_ = 'mixed_profile'
     profile.title = 'Mixed Profile'
     profile.description = 'Test'
-    profile.selected = ['cel_rule', 'oval_rule']  # oval_rule doesn't have CEL checks
+    profile.selected = ['cel_rule', 'oval_rule']
 
     profiles = [profile]
 
-    # This should fail because oval_rule doesn't have CEL checks
-    with pytest.raises(ValueError, match="references unknown rule 'oval-rule'"):
-        build_cel_content.generate_cel_content(cel_rules, profiles)
+    # Should warn about oval_rule but not error since it exists
+    content = build_cel_content.generate_cel_content(cel_rules, profiles, all_rule_ids)
+    assert len(content['rules']) == 1
+    assert content['rules'][0]['id'] == 'cel_rule'
 
 
 def test_validation_integration_full_flow():

--- a/tests/unit/ssg-module/test_build_cel_content.py
+++ b/tests/unit/ssg-module/test_build_cel_content.py
@@ -727,6 +727,33 @@ def test_validation_mixed_oval_and_cel_in_profile():
     assert len(content['profiles'][0]['rules']) == 2
 
 
+def test_generate_cel_content_manual_only_profile():
+    """Test that a profile with only manual rules (no CEL rules) is output correctly."""
+    manual_rule = ssg.build_yaml.Rule('manual_only_rule')
+    manual_rule.id_ = 'manual_only_rule'
+    manual_rule.title = 'Manual Only Rule'
+    manual_rule.description = 'Description'
+    manual_rule.rationale = 'Rationale'
+    manual_rule.severity = 'medium'
+    manual_rule.references = {}
+
+    all_rules = {'manual_only_rule': manual_rule}
+
+    profile = ssg.build_yaml.Profile('manual_profile')
+    profile.id_ = 'manual_profile'
+    profile.title = 'Manual Profile'
+    profile.description = 'Profile with only manual rules'
+    profile.selected = ['manual_only_rule']
+
+    content = build_cel_content.generate_cel_content({}, [profile], all_rules)
+    assert len(content['rules']) == 1
+    assert content['rules'][0]['id'] == 'manual_only_rule'
+    assert 'expression' not in content['rules'][0]
+    assert 'inputs' not in content['rules'][0]
+    assert len(content['profiles']) == 1
+    assert len(content['profiles'][0]['rules']) == 1
+
+
 def test_validation_integration_full_flow():
     """Integration test: validate full flow from directories to content generation."""
     with tempfile.TemporaryDirectory() as rules_dir, tempfile.TemporaryDirectory() as profiles_dir:
@@ -774,7 +801,7 @@ def test_validation_integration_full_flow():
         assert len(profiles) == 1
 
         # Generate content
-        content = build_cel_content.generate_cel_content(cel_rules, profiles)
+        content = build_cel_content.generate_cel_content(cel_rules, profiles, all_rules)
         assert len(content['rules']) == 1
         assert len(content['profiles']) == 1
         assert content['rules'][0]['name'] == 'valid-cel-rule'

--- a/tests/unit/ssg-module/test_build_cel_content.py
+++ b/tests/unit/ssg-module/test_build_cel_content.py
@@ -578,7 +578,7 @@ def test_generate_cel_content_unknown_rule_reference():
         'existing_rule': rule1
     }
 
-    all_rule_ids = {'existing_rule'}
+    all_rules = {'existing_rule': rule1}
 
     # Create a profile that references a non-existent rule
     profile = ssg.build_yaml.Profile('test_profile')
@@ -590,7 +590,7 @@ def test_generate_cel_content_unknown_rule_reference():
     profiles = [profile]
 
     with pytest.raises(ValueError, match="references unknown rule 'nonexistent-rule'"):
-        build_cel_content.generate_cel_content(cel_rules, profiles, all_rule_ids)
+        build_cel_content.generate_cel_content(cel_rules, profiles, all_rules)
 
 
 def test_validation_empty_expression():
@@ -620,7 +620,7 @@ def test_validation_empty_expression():
 
 
 def test_validation_empty_inputs():
-    """Test that rule with empty inputs list is skipped from CEL rules."""
+    """Test that rule with empty inputs list is not identified as CEL but is included in all rules."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create rule with empty inputs
         rule_dict = {
@@ -669,7 +669,7 @@ def test_validation_profile_with_empty_selections():
 
 
 def test_validation_mixed_oval_and_cel_in_profile():
-    """Test that profile with both OVAL and CEL checks only includes CEL rules in output."""
+    """Test that profile with both OVAL and CEL checks are output as CEL and manual rules."""
     # Create rule with CEL checks
     cel_rule = ssg.build_yaml.Rule('cel_rule')
     cel_rule.id_ = 'cel_rule'
@@ -686,7 +686,15 @@ def test_validation_mixed_oval_and_cel_in_profile():
     }
 
     # oval_rule exists as a compiled rule but has no CEL checks
-    all_rule_ids = {'cel_rule', 'oval_rule'}
+    oval_rule = ssg.build_yaml.Rule('oval_rule')
+    oval_rule.id_ = 'oval_rule'
+    oval_rule.title = 'OVAL Rule'
+    oval_rule.description = 'Description'
+    oval_rule.rationale = 'Rationale'
+    oval_rule.severity = 'medium'
+    oval_rule.references = {}
+
+    all_rules = {'cel_rule': cel_rule, 'oval_rule': oval_rule}
 
     # Create a CEL profile that references both CEL and OVAL rules
     profile = ssg.build_yaml.Profile('mixed_profile')
@@ -697,10 +705,26 @@ def test_validation_mixed_oval_and_cel_in_profile():
 
     profiles = [profile]
 
-    # Should warn about oval_rule but not error since it exists
-    content = build_cel_content.generate_cel_content(cel_rules, profiles, all_rule_ids)
-    assert len(content['rules']) == 1
-    assert content['rules'][0]['id'] == 'cel_rule'
+    # Should warn about oval_rule and include it as a manual rule
+    content = build_cel_content.generate_cel_content(cel_rules, profiles, all_rules)
+    assert len(content['rules']) == 2
+    rule_ids = [r['id'] for r in content['rules']]
+    assert 'cel_rule' in rule_ids
+    assert 'oval_rule' in rule_ids
+
+    # Verify the CEL rule has expression and inputs
+    cel_output = next(r for r in content['rules'] if r['id'] == 'cel_rule')
+    assert 'expression' in cel_output
+    assert 'inputs' in cel_output
+
+    # Verify the manual rule does NOT have expression or inputs
+    oval_output = next(r for r in content['rules'] if r['id'] == 'oval_rule')
+    assert 'expression' not in oval_output
+    assert 'inputs' not in oval_output
+
+    # Verify the profile includes both rules
+    assert len(content['profiles']) == 1
+    assert len(content['profiles'][0]['rules']) == 2
 
 
 def test_validation_integration_full_flow():


### PR DESCRIPTION
Adds a manual rule to restrict namespace administrator access to migration tools (vmim and migrationpolicy resources) for the CIS VM Extension Benchmark. The rule documents the audit procedure without an automated CEL check, as the pass/fail is a human authorization decision.