### PR TITLE
ocp-test-profiles: skip rules with no CI-tested profile instead of failing with division by 0

### DIFF
--- a/.github/workflows/ocp-test-profiles.yaml
+++ b/.github/workflows/ocp-test-profiles.yaml
@@ -1,7 +1,7 @@
 name: Trigger OCP Tests When Relevant
 on:
   pull_request:
-    branches: [ master, 'stabilization*' ]
+    branches: [master, 'stabilization*']
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true
@@ -62,7 +62,7 @@ jobs:
 
       - name: Process list of rules into a list of product-profiles to test
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' && (contains(steps.product.outputs.prop, 'ocp4') || contains(steps.product.outputs.prop, 'rhcos4')) }}
-        id: profiles_to_test 
+        id: profiles_to_test
         run: |
           # Let's grab the profiles for which we have a CI job configured
           PROW_CONFIG=https://raw.githubusercontent.com/openshift/release/refs/heads/master/ci-operator/config/ComplianceAsCode/content/ComplianceAsCode-content-master.yaml
@@ -90,8 +90,13 @@ jobs:
               done
             done
 
-            ALL_PROFILES+=(${ELIGIBLE_PROFILES[@]})
-            PROFILES+=(${ELIGIBLE_PROFILES[$(($RANDOM%(${#ELIGIBLE_PROFILES[@]})))]})
+            # Rules that are not part of any CI-tested profile (e.g. rules only
+            # in profiles without a prow lane, such as CEL-based profiles) have
+            # no eligible profiles; skip them instead of dividing by zero.
+            if [[ ${#ELIGIBLE_PROFILES[@]} -gt 0 ]]; then
+              ALL_PROFILES+=(${ELIGIBLE_PROFILES[@]})
+              PROFILES+=(${ELIGIBLE_PROFILES[$(($RANDOM%(${#ELIGIBLE_PROFILES[@]})))]})
+            fi
           done
 
           # Sort and ensure that the profiles are unique


### PR DESCRIPTION
The 'Identify rules changed in PR and test them in OCP Prow' job aborts with `division by 0 (error token is "(0)")` whenever a changed rule is not selected by any profile that has a prow lane — `ELIGIBLE_PROFILES` is empty and the random selection does `RANDOM % 0`.

This currently fails on every PR that only touches rules in the CEL-based `cis-vm-extension` profile (no prow lane yet): #14917, #14918, #14919.

Fix: skip such rules; the job then reports only profiles it can actually test. Also fixes the two yamllint complaints on the touched file (brackets on the branches line, one trailing space) so the changed-file lint gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)