### PR TITLE
Simplify build_product commands in Claude Skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -423,7 +423,7 @@ Common selection patterns:
 ./build_product --cel-content=ocp4,rhel9
 
 # Build with only specific rules (fastest, for testing individual rules)
-./build_product ocp4 --datastream --rule-id api_server_tls_security_profile
+./build_product ocp4 --rule-id api_server_tls_security_profile
 ```
 
 Build output goes to `build/`. The data stream file is at:

--- a/.claude/skills/build-product/SKILL.md
+++ b/.claude/skills/build-product/SKILL.md
@@ -44,7 +44,7 @@ Examples:
 ```bash
 ./build_product rhel9                                          # Full build
 ./build_product --datastream-only rhel9                        # Data stream only
-./build_product --datastream-only --rule-id sshd_set_idle_timeout rhel9  # Single rule
+./build_product --rule-id sshd_set_idle_timeout rhel9          # Single rule
 ```
 
 ### Build Output

--- a/.claude/skills/create-template/SKILL.md
+++ b/.claude/skills/create-template/SKILL.md
@@ -396,9 +396,9 @@ If the rule has static content (files in `oval/`, `bash/`, `ansible/` subdirecto
 
 ### 5.4 Build and Test
 
-1. Build the product to verify the template generates correctly:
+1. Build the single-rule data stream to verify the template generates correctly:
    ```bash
-   ./build_product <product> --datastream --rule-id <rule_id>
+   ./build_product <product> --rule-id <rule_id>
    ```
 
 2. Verify correct template expansion in the rendered output:


### PR DESCRIPTION
If the `build_product` command is run with the `--rule-id` option, the `--datastream` option doesn't need to be provided, because if the `--rule-id` option is used, the script always builds only the data stream, therefore adding `--datastream` option is superfluous.


