### PR TITLE
CMP-4513: Add cis-vm-extension-node profile with nested-virtualization rule (CIS OCP-Virt 6.1)

### DIFF
--- a/applications/openshift-virtualization/kubevirt-nested-virtualization-disabled/oval/shared.xml
+++ b/applications/openshift-virtualization/kubevirt-nested-virtualization-disabled/oval/shared.xml
@@ -1,0 +1,50 @@
+<def-group>
+  <definition class="compliance" id="kubevirt-nested-virtualization-disabled" version="2">
+    {{{ oval_metadata("Nested virtualization must be disabled via the kvm_intel/kvm_amd module 'nested' parameter.", rule_title=rule_title) }}}
+
+    <criteria operator="AND">
+      <criteria operator="OR">
+        <criterion comment="kvm_intel nested parameter is absent" test_ref="test_kubevirt_nested_kvm_intel_absent" />
+        <criterion comment="kvm_intel nested parameter is N or 0" test_ref="test_kubevirt_nested_kvm_intel_disabled" />
+      </criteria>
+      <criteria operator="OR">
+        <criterion comment="kvm_amd nested parameter is absent" test_ref="test_kubevirt_nested_kvm_amd_absent" />
+        <criterion comment="kvm_amd nested parameter is N or 0" test_ref="test_kubevirt_nested_kvm_amd_disabled" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="kvm_intel nested parameter file does not exist" id="test_kubevirt_nested_kvm_intel_absent" version="2">
+    <ind:object object_ref="object_kubevirt_nested_kvm_intel_content" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+    comment="kvm_intel nested parameter is N or 0" id="test_kubevirt_nested_kvm_intel_disabled" version="2">
+    <ind:object object_ref="object_kubevirt_nested_kvm_intel_content" />
+    <ind:state state_ref="state_kubevirt_nested_disabled" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kubevirt_nested_kvm_intel_content" version="2">
+    <ind:filepath>/sys/module/kvm_intel/parameters/nested</ind:filepath>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="kvm_amd nested parameter file does not exist" id="test_kubevirt_nested_kvm_amd_absent" version="2">
+    <ind:object object_ref="object_kubevirt_nested_kvm_amd_content" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+    comment="kvm_amd nested parameter is N or 0" id="test_kubevirt_nested_kvm_amd_disabled" version="2">
+    <ind:object object_ref="object_kubevirt_nested_kvm_amd_content" />
+    <ind:state state_ref="state_kubevirt_nested_disabled" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kubevirt_nested_kvm_amd_content" version="2">
+    <ind:filepath>/sys/module/kvm_amd/parameters/nested</ind:filepath>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_kubevirt_nested_disabled" version="2">
+    <ind:subexpression operation="pattern match">^(N|0)$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/applications/openshift-virtualization/kubevirt-nested-virtualization-disabled/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-nested-virtualization-disabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+platform: {{{ product }}}-node
+
+title: 'Nested Virtualization Must Be Disabled on Virtualization Hosts'
+
+description: |-
+    Nested virtualization allows a virtual machine to itself act as a
+    hypervisor. It is controlled by the <tt>nested</tt> parameter of the
+    <tt>kvm_intel</tt> or <tt>kvm_amd</tt> kernel module, visible at
+    <tt>/sys/module/kvm_intel/parameters/nested</tt> (or
+    <tt>kvm_amd</tt> respectively). The value must be <tt>N</tt> or
+    <tt>0</tt>. Nodes where the KVM modules are not loaded do not expose
+    the parameter, which is compliant.
+
+rationale: |-
+    Nested virtualization exposes additional virtualization interfaces to
+    guest workloads, widening the attack surface of the hypervisor stack
+    and enabling a compromised guest to host further, harder-to-observe
+    virtual machines.
+
+severity: medium
+
+ocil_clause: 'nested virtualization is enabled on a node'
+
+ocil: |-
+    Run the following on each node running virtualization workloads:
+    <pre>$ cat /sys/module/kvm_intel/parameters/nested 2>/dev/null; cat /sys/module/kvm_amd/parameters/nested 2>/dev/null</pre>
+    Any output present should be <tt>N</tt> or <tt>0</tt>.

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -1,0 +1,31 @@
+---
+documentation_complete: true
+
+title: 'CIS Red Hat Openshift Virtual Machine Extension Benchmark (Node)'
+
+platform: ocp4-node
+
+metadata:
+    version: 1.0.0
+    SMEs:
+        - rhmdnd
+        - Vincent056
+        - yuumasato
+        - abushkin-redhat
+        - taimurhafeez
+
+description: |-
+    This profile defines a baseline that aligns to the Center for Internet Security®
+    Red Hat OpenShift Virtual Machine Extension Benchmark™, V1.0.0.
+
+    This profile includes Center for Internet Security®
+    Red Hat OpenShift Virtual Machine Extension Benchmarks™ content.
+
+    Note that this part of the profile is meant to run on the Operating System
+    that Red Hat OpenShift Container Platform 4 runs on top of, covering the
+    benchmark's node-level controls (host file permissions, kernel and CPU
+    configuration). The platform-level controls are covered by the companion
+    cis-vm-extension profile.
+
+selections:
+    - kubevirt-nested-virtualization-disabled


### PR DESCRIPTION
## Summary

Adds the **node companion profile** for the CIS OpenShift Virtualization benchmark, plus its first rule:

- `cis-vm-extension-node.profile` (CMP-4513): `platform: ocp4-node` → the Compliance Operator parses it as a Node-type profile and runs per-role (master/worker) node scans, exactly like `cis-node`. Covers the benchmark's node-level controls; the platform-level controls live in the CEL-based `cis-vm-extension` profile.
- `kubevirt-nested-virtualization-disabled` (CMP-4443, CIS 6.1): the `nested` parameter of `kvm_intel`/`kvm_amd` (`/sys/module/kvm_*/parameters/nested`) must be `N` or `0`. **Absent parameter (modules not loaded) is compliant**, so the rule is inert on non-virtualization nodes with no CPE gymnastics needed.

The build rejects profiles with zero selections, which is why the scaffold ships with its first rule rather than empty. The remaining node rules add their selections under their own tickets: CMP-4441 (1.8 seccomp profile permissions), CMP-4442 (1.9 cache directory permissions), CMP-4444 (6.2 vCPU metrics), CMP-4445 (6.3 CPU vulnerability mitigations). e2e/CI coverage for the profile is tracked in CMP-4510.

## Testing

- `ocp4` datastream builds; the profile appears as `xccdf_org.ssgproject.content_profile_cis-vm-extension-node` with the `openshift_container_platform_node` CPE platform and the rule selected.
- OVAL validated two ways against the built `ssg-ocp4-oval.xml`:
  - **Real hardware** (`oscap oval eval`): a host with `kvm_amd nested=1` evaluates **false** (non-compliant), with the absent `kvm_intel` branch passing via `none_exist`.
  - **Full state matrix** (`oscap-chroot` against fabricated sysfs roots) — 6/6 as expected:

    | scenario | result |
    |---|---|
    | no kvm modules (non-virt node) | true (compliant) |
    | `kvm_intel=N` | true |
    | `kvm_intel=0`, `kvm_amd=0` | true |
    | `kvm_amd=1` | false |
    | `kvm_intel=Y` | false |
    | `kvm_intel=N`, `kvm_amd=1` | false |
- yamllint clean on all added/changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
