### PR TITLE
Allow Automatus to connect to remote qemu

### DIFF
--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -449,7 +449,8 @@ def normalize_passed_arguments(options):
     else:
         hypervisor, domain_name = options.libvirt
         # Possible hypervisor spec we have to catch: qemu+unix:///session
-        if not re.match(r"[\w\+]+:///", hypervisor):
+        # Also accept remote URIs like qemu+tcp://host/system (two slashes)
+        if not re.match(r"[\w\+]+://", hypervisor):
             hypervisor = "qemu:///" + hypervisor
         options.test_env = ssg_test_suite.test_env.VMTestEnv(
             options.scanning_mode, hypervisor, domain_name, options.keep_snapshots)


### PR DESCRIPTION
#### Description:

- broaden the regex to check for allowed qemu hypervisor

#### Rationale:

- the goal is to connect to TCP based qemu hypervisors, such as qemu://tcp:ip_address
- this can be used in case the hypervisor is reachable through TCP. One such case is reaching the hypervisor from a sandbox.


#### Review Hints:

Test if using regular qemu:///system or qemu:///session does not break.
