### PR TITLE
CMP-4445: Add rule ensure all cpu vulnerabilities are mitigated cis ocp virt 6.3

### DIFF
--- a/applications/openshift-virtualization/kubevirt-cpu-vulnerabilities-mitigated/oval/shared.xml
+++ b/applications/openshift-virtualization/kubevirt-cpu-vulnerabilities-mitigated/oval/shared.xml
@@ -1,0 +1,23 @@
+<def-group>
+  <definition class="compliance" id="kubevirt-cpu-vulnerabilities-mitigated" version="1">
+    {{{ oval_metadata("No CPU vulnerability sysfs file should report a status beginning with 'Vulnerable'.", rule_title=rule_title) }}}
+
+    <criteria operator="AND">
+      <criterion comment="No CPU vulnerability file reports Vulnerable"
+        test_ref="test_kubevirt_cpu_vuln_none_vulnerable" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="No file under /sys/devices/system/cpu/vulnerabilities/ starts with Vulnerable"
+    id="test_kubevirt_cpu_vuln_none_vulnerable" version="1">
+    <ind:object object_ref="object_kubevirt_cpu_vuln_vulnerable" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_kubevirt_cpu_vuln_vulnerable" version="1">
+    <ind:path>/sys/devices/system/cpu/vulnerabilities</ind:path>
+    <ind:filename operation="pattern match">^.*$</ind:filename>
+    <ind:pattern operation="pattern match">^Vulnerable</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/applications/openshift-virtualization/kubevirt-cpu-vulnerabilities-mitigated/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-cpu-vulnerabilities-mitigated/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+platform: {{{ product }}}-node
+
+title: 'Ensure All CPU Vulnerabilities Are Mitigated'
+
+description: |-
+    The Linux kernel exposes the mitigation status of known CPU hardware
+    vulnerabilities via sysfs files under
+    <tt>/sys/devices/system/cpu/vulnerabilities/</tt>. Each file reports
+    whether the running kernel has applied mitigations for a specific
+    vulnerability (e.g., Spectre, Meltdown, MDS, Retbleed). None of
+    these files should report a status beginning with
+    <tt>Vulnerable</tt>.
+
+rationale: |-
+    Unmitigated CPU vulnerabilities expose the host to speculative
+    execution attacks that can leak sensitive data across security
+    boundaries. In a virtualization environment, this risk is amplified
+    because a compromised guest may exploit hardware vulnerabilities to
+    read memory from other guests or the hypervisor. Ensuring that all
+    known CPU vulnerabilities are mitigated reduces the attack surface
+    of the virtualization host.
+
+severity: medium
+
+ocil_clause: 'any CPU vulnerability is not mitigated'
+
+ocil: |-
+    Run the following command on each node to check for unmitigated CPU
+    vulnerabilities:
+    <pre>$ grep -r "Vulnerable" /sys/devices/system/cpu/vulnerabilities/</pre>
+    If any output is returned, the corresponding vulnerability is not
+    mitigated.

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -30,3 +30,4 @@ description: |-
 selections:
     - kubevirt-nested-virtualization-disabled
     - kubevirt-seccomp-profile-permissions
+    - kubevirt-cpu-vulnerabilities-mitigated

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -29,3 +29,4 @@ description: |-
 
 selections:
     - kubevirt-nested-virtualization-disabled
+    - kubevirt-cpu-vulnerabilities-mitigated


### PR DESCRIPTION
Add an OpenSCAP node rule for CIS OCP-Virt control 6.3 "Ensure all CPU vulnerabilities are mitigated". The OVAL check scans all files under /sys/devices/system/cpu/vulnerabilities/ and fails if any report a status beginning with "Vulnerable". Added to the cis-vm-extension-node profile.

Co-Authored-By: Claude

Extends [PR](https://github.com/ComplianceAsCode/content/pull/14930) cause it adds the profile that was needed for this rule. 

