### PR TITLE
Ansible/Bash remediations: add explicit file permissions to all file-creating tasks and commands

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
+    mode: 0600
     block: |
         ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
+    mode: 0600
     block: |
         ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
+    mode: 0600
     block: |
         ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
+    mode: 0600
     block: |
         ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
+    mode: 0600
     block: |
         ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
+    mode: 0600
     block: |
         ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -43,6 +43,7 @@
         line: '-a always,exit -F arch=b32 -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
         regexp: "^.* -F arch=b32 -F path={{ item | regex_escape() }} .*$"
         create: yes
+        mode: 0600
       with_items:
         - "{{ privileged_commands }}"
 
@@ -52,6 +53,7 @@
         line: '-a always,exit -F arch=b32 -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
         regexp: "^.* -F arch=b32 -F path={{ item | regex_escape() }} .*$"
         create: yes
+        mode: 0600
       with_items:
         - "{{ privileged_commands }}"
 
@@ -61,6 +63,7 @@
         line: '-a always,exit -F arch=b64 -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
         regexp: "^.* -F arch=b64 -F path={{ item | regex_escape() }} .*$"
         create: yes
+        mode: 0600
       with_items:
         - "{{ privileged_commands }}"
       when: audit_arch == "b64"
@@ -71,6 +74,7 @@
         line: '-a always,exit -F arch=b64 -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
         regexp: "^.* -F arch=b64 -F path={{ item | regex_escape() }} .*$"
         create: yes
+        mode: 0600
       with_items:
         - "{{ privileged_commands }}"
       when: audit_arch == "b64"
@@ -81,6 +85,7 @@
         line: '-a always,exit -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
         regexp: "^.*path={{ item | regex_escape() }} .*$"
         create: yes
+        mode: 0600
       with_items:
         - "{{ privileged_commands }}"
 
@@ -90,6 +95,7 @@
         line: '-a always,exit -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
         regexp: "^.*path={{ item | regex_escape() }} .*$"
         create: yes
+        mode: 0600
       with_items:
         - "{{ privileged_commands }}"
 {{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/bash/shared.sh
@@ -14,6 +14,7 @@ else
   done <    <(find /etc/audit/rules.d -maxdepth 1 -name '*.rules' -print0)
   if [ $immutable_found -eq 0 ]; then
     echo "--loginuid-immutable" >> /etc/audit/rules.d/immutable.rules
+    chmod 0600 /etc/audit/rules.d/immutable.rules
   fi
 fi
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
@@ -44,6 +44,7 @@
     line: "{{  item.rule  }}"
     regexp: "{{ item.regex }}"
     create: yes
+    mode: 0600
   when:
     - '"auditd.service" in ansible_facts.services'
     - '"augenrules" in check_rules_scripts_result.stdout'
@@ -56,6 +57,7 @@
     line: "{{  item.rule  }}"
     regexp: "{{ item.regex }}"
     create: yes
+    mode: 0600
   when:
     - '"auditd.service" in ansible_facts.services'
     - '"auditctl" in check_rules_scripts_result.stdout'

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -50,6 +50,7 @@
     line: "{{  item.rule  }}"
     regexp: "{{ item.regex }}"
     create: yes
+    mode: 0600
   when:
     - ('"auditd.service" in ansible_facts.services' or
         '"augenrules.service" in ansible_facts.services')

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/ansible/shared.yml
@@ -23,6 +23,7 @@
     create: true
     state: present
     backrefs: true
+    mode: 0640
 {{% endif %}}
 
 - name: "{{{ rule_title }}} - Make sure that a remote server is configured for Audispd"
@@ -32,3 +33,4 @@
     regexp: '^\s*remote_server\s*=.*$'
     create: true
     state: present
+    mode: 0640

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/ansible/shared.yml
@@ -13,3 +13,4 @@
     regexp: '^\s*disk_full_action\s*=.*$'
     create: true
     state: present
+    mode: 0640

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/ansible/shared.yml
@@ -13,3 +13,4 @@
     regexp: '^\s*network_failure_action\s*=.*$'
     create: true
     state: present
+    mode: 0640

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/ansible/shared.yml
@@ -10,3 +10,4 @@
     regexp: "^active"
     line: active = yes
     create: yes
+    mode: 0640

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action_stig/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action_stig/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -12,3 +12,4 @@
         line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
         state: present
         create: yes
+        mode: 0640

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*admin_space_left_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/ansible/shared.yml
@@ -12,3 +12,4 @@
     regexp: '^\s*admin_space_left\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
@@ -12,4 +12,5 @@
     line: "flush = {{ var_auditd_flush }}"
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -12,4 +12,5 @@
     line: "max_log_file = {{ var_auditd_max_log_file }}"
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*max_log_file_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*max_log_file_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*num_logs\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*space_left\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*space_left_action\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/ansible/shared.yml
@@ -12,4 +12,5 @@
     regexp: '^\s*space_left\s*=\s*.*$'
     state: present
     create: yes
+    mode: 0640
   #notify: reload auditd

--- a/linux_os/guide/auditing/policy_rules/audit_rules_for_ospp/bash/shared.sh
+++ b/linux_os/guide/auditing/policy_rules/audit_rules_for_ospp/bash/shared.sh
@@ -4,5 +4,9 @@ cp /usr/share/doc/audit*/rules/10-base-config.rules /etc/audit/rules.d
 cp /usr/share/doc/audit*/rules/11-loginuid.rules /etc/audit/rules.d
 cp /usr/share/doc/audit*/rules/30-ospp-v42.rules /etc/audit/rules.d
 cp /usr/share/doc/audit*/rules/43-module-load.rules /etc/audit/rules.d
+chmod 0600 /etc/audit/rules.d/10-base-config.rules
+chmod 0600 /etc/audit/rules.d/11-loginuid.rules
+chmod 0600 /etc/audit/rules.d/30-ospp-v42.rules
+chmod 0600 /etc/audit/rules.d/43-module-load.rules
 
 augenrules --load

--- a/linux_os/guide/services/apt/apt_disable_weak_dependencies/bash/shared.sh
+++ b/linux_os/guide/services/apt/apt_disable_weak_dependencies/bash/shared.sh
@@ -1,7 +1,9 @@
 # platform = multi_platform_debian
 
 mkdir -p /etc/apt/apt.conf.d
+chmod 0755 /etc/apt/apt.conf.d
 cat > /etc/apt/apt.conf.d/60-no-weak-dependencies <<'EOF'
 APT::Install-Recommends "0";
 APT::Install-Suggests "0";
 EOF
+chmod 0644 /etc/apt/apt.conf.d/60-no-weak-dependencies

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/ansible/shared.yml
@@ -12,6 +12,7 @@
     regexp: '^(?:[rR][oO][oO][tT]|"[rR][oO][oO][tT]")\s*:\s*(.+)$'
     create: true
     state: present
+    mode: 0644
   register: aliases_root_mail_alias_changed
 
 - name: {{{ rule_title }}} - Check if newaliases command is available

--- a/linux_os/guide/services/ntp/chronyd_configure_local_socket/ansible/rhel9.yml
+++ b/linux_os/guide/services/ntp/chronyd_configure_local_socket/ansible/rhel9.yml
@@ -14,6 +14,7 @@
 - name: "{{{ rule_title }}} - Replace chrony-wait.service to use Unix socket (KCS 7064388)"
   ansible.builtin.copy:
     dest: /etc/systemd/system/chrony-wait.service
+    mode: 0644
     content: |
       [Unit]
       Description=Wait for chrony to synchronize system clock(KCS 7064388)

--- a/linux_os/guide/services/ntp/chronyd_configure_local_socket/bash/rhel8.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_local_socket/bash/rhel8.sh
@@ -26,6 +26,7 @@ StandardOutput=null
 [Install]
 WantedBy=multi-user.target
 EOF
+    chmod 0644 /etc/systemd/system/chrony-wait.service
     systemctl daemon-reload
     systemctl enable chrony-wait.service
 fi

--- a/linux_os/guide/services/ntp/chronyd_configure_local_socket/bash/rhel9.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_local_socket/bash/rhel9.sh
@@ -56,6 +56,7 @@ UMask=0777
 [Install]
 WantedBy=multi-user.target
 EOF
+    chmod 0644 /etc/systemd/system/chrony-wait.service
     systemctl daemon-reload
     systemctl enable chrony-wait.service
 fi

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/ansible/shared.yml
@@ -13,6 +13,7 @@
     state: present
     line: 'server {{ item }}'
     create: true
+    mode: 0644
   with_items: 
     - '{{ var_multiple_time_servers.split(",") }}'
 
@@ -23,5 +24,6 @@
     state: present
     line: 'pool {{ item }}'
     create: true
+    mode: 0644
   with_items: 
     - '{{ var_multiple_time_pools.split(",") }}'

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/ansible/shared.yml
@@ -14,7 +14,7 @@
     line: 'server {{ item }}'
     create: true
     mode: 0644
-  with_items: 
+  with_items:
     - '{{ var_multiple_time_servers.split(",") }}'
 
 - name: {{{ rule_title }}} - Add missing / update wrong records for remote time pools
@@ -25,5 +25,5 @@
     line: 'pool {{ item }}'
     create: true
     mode: 0644
-  with_items: 
+  with_items:
     - '{{ var_multiple_time_pools.split(",") }}'

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/ansible/shared.yml
@@ -17,6 +17,7 @@
     line: 'server {{ item }}'
     state: present
     create: True
+    mode: 0644
   loop: '{{ var_multiple_time_servers.split(",") }}'
   when: chrony_server_config.matched == 1
 
@@ -33,5 +34,6 @@
     line: 'pool {{ item }}'
     state: present
     create: True
+    mode: 0644
   loop: '{{ var_multiple_time_servers.split(",") }}'
   when: ntp_server_config.matched == 1

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
@@ -39,5 +39,6 @@
     line: 'OPTIONS="-u chrony"'
     state: present
     create: True
+    mode: 0644
   when: chronyd_file is defined and chronyd_file.matched == 0
 {{%- endif %}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/ansible/shared.yml
@@ -117,6 +117,7 @@
     line: 'server {{ item }}'
     state: present
     create: true
+    mode: 0644
   loop: '{{ var_multiple_time_servers.split(",") }}'
   when:
     - chrony_conf_has_servers.rc != 0

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/ansible/shared.yml
@@ -19,6 +19,7 @@
     state: present
     create: True
     backrefs: True
+    mode: 0644
   when: ntpd_file.matched > 0
 
 - name: "Put line into file, assume file was empty"
@@ -27,4 +28,5 @@
     line: 'OPTIONS="-u ntp:ntp"'
     state: present
     create: True
+    mode: 0644
   when: ntpd_file.matched == 0

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
@@ -18,5 +18,6 @@
     line: 'server {{ item }}'
     state: present
     create: True
+    mode: 0644
   loop: '{{ var_multiple_time_servers.split(",") }}'
   when: ntp_servers.matched == 0

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
@@ -26,6 +26,7 @@ done
 if [ ! -d "/etc/systemd/timesyncd.conf.d" ]
 then 
     mkdir /etc/systemd/timesyncd.conf.d
+    chmod 0755 /etc/systemd/timesyncd.conf.d
 fi
 
 {{{ bash_ini_file_set("/etc/systemd/timesyncd.conf.d/oscap-remedy.conf", "Time", "NTP", "$preferred_ntp_servers", rule_id=rule_id) }}}

--- a/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/ansible/shared.yml
@@ -6,6 +6,7 @@
 
 - name: {{{ rule_title }}} - Add missing / update wrong records for root distance
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if "sle15" in product %}}
     path: /usr/lib/systemd/timesyncd.conf.d/oscap-remedy.conf
 {{% else %}}

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
@@ -59,26 +59,26 @@
 
 -   name: "{{{ rule_title }}} - Remediate only if necessary"
     block:
-    -   name: "Ensure drop-in directory exists"
-        ansible.builtin.file:
-            path: /etc/systemd/system/tftp.service.d
-            state: directory
-            mode: 0755
+        -   name: "Ensure drop-in directory exists"
+            ansible.builtin.file:
+                path: /etc/systemd/system/tftp.service.d
+                state: directory
+                mode: 0755
 
-    -   name: "Deploy 10-ssg-hardening.conf drop-in"
-        ansible.builtin.copy:
-            dest: /etc/systemd/system/tftp.service.d/10-ssg-hardening.conf
-            mode: 0644
-            content: |-
-                [Service]
-                # clear any existing ExecStart in the original unit
-                ExecStart=
-                ExecStart=/usr/sbin/in.tftpd -s {{ var_tftpd_secure_directory }}
+        -   name: "Deploy 10-ssg-hardening.conf drop-in"
+            ansible.builtin.copy:
+                dest: /etc/systemd/system/tftp.service.d/10-ssg-hardening.conf
+                mode: 0644
+                content: |-
+                    [Service]
+                    # clear any existing ExecStart in the original unit
+                    ExecStart=
+                    ExecStart=/usr/sbin/in.tftpd -s {{ var_tftpd_secure_directory }}
 
-    -   name: "Reload systemd and restart tftp service"
-        ansible.builtin.systemd:
-            daemon_reload: true
-            name: tftp
-            state: restarted
-            enabled: yes
+        -   name: "Reload systemd and restart tftp service"
+            ansible.builtin.systemd:
+                daemon_reload: true
+                name: tftp
+                state: restarted
+                enabled: yes
     when: not tftp_config_valid

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
@@ -59,26 +59,26 @@
 
 -   name: "{{{ rule_title }}} - Remediate only if necessary"
     block:
-        -   name: "Ensure drop-in directory exists"
-            ansible.builtin.file:
-                path: /etc/systemd/system/tftp.service.d
-                state: directory
-                mode: 0755
+    -   name: "Ensure drop-in directory exists"
+        ansible.builtin.file:
+            path: /etc/systemd/system/tftp.service.d
+            state: directory
+            mode: 0755
 
-        -   name: "Deploy 10-ssg-hardening.conf drop-in"
-            ansible.builtin.copy:
-                dest: /etc/systemd/system/tftp.service.d/10-ssg-hardening.conf
-                mode: 0644
-                content: |-
-                    [Service]
-                    # clear any existing ExecStart in the original unit
-                    ExecStart=
-                    ExecStart=/usr/sbin/in.tftpd -s {{ var_tftpd_secure_directory }}
+    -   name: "Deploy 10-ssg-hardening.conf drop-in"
+        ansible.builtin.copy:
+            dest: /etc/systemd/system/tftp.service.d/10-ssg-hardening.conf
+            mode: 0644
+            content: |-
+                [Service]
+                # clear any existing ExecStart in the original unit
+                ExecStart=
+                ExecStart=/usr/sbin/in.tftpd -s {{ var_tftpd_secure_directory }}
 
-        -   name: "Reload systemd and restart tftp service"
-            ansible.builtin.systemd:
-                daemon_reload: true
-                name: tftp
-                state: restarted
-                enabled: yes
+    -   name: "Reload systemd and restart tftp service"
+        ansible.builtin.systemd:
+            daemon_reload: true
+            name: tftp
+            state: restarted
+            enabled: yes
     when: not tftp_config_valid

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
@@ -63,10 +63,12 @@
         ansible.builtin.file:
             path: /etc/systemd/system/tftp.service.d
             state: directory
+            mode: 0755
 
     -   name: "Deploy 10-ssg-hardening.conf drop-in"
         ansible.builtin.copy:
             dest: /etc/systemd/system/tftp.service.d/10-ssg-hardening.conf
+            mode: 0644
             content: |-
                 [Service]
                 # clear any existing ExecStart in the original unit

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/bash/shared.sh
@@ -23,6 +23,7 @@ elif [ ! -d "$DROPIN_DIR" ] && grep -qE "$REGEX_TFTP_SERVICE_FILE" "$TFTP_SERVIC
     exit 0
 else
     mkdir -p "$DROPIN_DIR"
+    chmod 0755 "$DROPIN_DIR"
 
     cat > "$DROPIN_FILE" << EOF
 [Service]
@@ -30,6 +31,7 @@ else
 ExecStart=
 ExecStart=/usr/sbin/in.tftpd -s $var_tftpd_secure_directory
 EOF
+    chmod 0644 $DROPIN_FILE
     systemctl daemon-reload
     systemctl restart tftp.service
 fi

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/bash/shared.sh
@@ -31,7 +31,7 @@ else
 ExecStart=
 ExecStart=/usr/sbin/in.tftpd -s $var_tftpd_secure_directory
 EOF
-    chmod 0644 $DROPIN_FILE
+    chmod 0644 "$DROPIN_FILE"
     systemctl daemon-reload
     systemctl restart tftp.service
 fi

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/ansible/shared.yml
@@ -28,4 +28,5 @@
     line: "server_args = -s {{ var_tftpd_secure_directory }}"
     state: present
     create: true
+    mode: 0644
   when: tftpd_secure_config_line is defined and tftpd_secure_config_line.matched == 0

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_csh/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_csh/ansible/shared.yml
@@ -11,6 +11,7 @@
     line: 'setenv SSH_USE_STRONG_RNG 32'
     state: present
     create: yes
+    mode: 0644
 
 - name: "Ensure that the configuration is not overridden in /etc/profile"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_csh/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_csh/bash/shared.sh
@@ -2,6 +2,7 @@
 
 # put line into the file
 echo "setenv SSH_USE_STRONG_RNG 32" > /etc/profile.d/cc-ssh-strong-rng.csh
+chmod 0644 /etc/profile.d/cc-ssh-strong-rng.csh
 
 # remove eventual override in /etc/profile
 sed -i '/^[[:space:]]*setenv[[:space:]]\+SSH_USE_STRONG_RNG.*$/d' /etc/profile

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_sh/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_sh/ansible/shared.yml
@@ -11,6 +11,7 @@
     line: 'export SSH_USE_STRONG_RNG=32'
     state: present
     create: yes
+    mode: 0644
 
 - name: "Ensure that the configuration is not overridden in /etc/profile"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_sh/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_sh/bash/shared.sh
@@ -2,6 +2,7 @@
 
 # put line into the file
 echo "export SSH_USE_STRONG_RNG=32" > /etc/profile.d/cc-ssh-strong-rng.sh
+chmod 0644 /etc/profile.d/cc-ssh-strong-rng.sh
 
 # remove eventual override in /etc/profile
 sed -i '/^[[:space:]]*export[[:space:]]\+SSH_USE_STRONG_RNG=.*$/d' /etc/profile

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_directory_configuration/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_directory_configuration/bash/shared.sh
@@ -19,5 +19,5 @@ cat > {{{ base_config }}} << EOF
 
 {{{ include_directive }}}
 EOF
-chmod 0644 {{{ base_config }}}
+chmod 0600 {{{ base_config }}}
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_directory_configuration/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_directory_configuration/bash/shared.sh
@@ -11,6 +11,7 @@ elif grep -Eq '{{{ include_regex }}}' {{{ base_config }}} && ! grep -Eq '^\s*Mat
 	{{{ die("Remediation probably already happened, '" ~ base_config ~ "' already contains the include directive.", action="false") }}}
 else
 	mkdir -p {{{ config_dir }}}
+	chmod 0700 {{{ config_dir }}}
 	mv {{{ base_config }}} {{{ target_file }}}
 cat > {{{ base_config }}} << EOF
 # To modify the system-wide sshd configuration, create a  *.conf  file under
@@ -18,4 +19,5 @@ cat > {{{ base_config }}} << EOF
 
 {{{ include_directive }}}
 EOF
+chmod 0644 {{{ base_config }}}
 fi

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/bash/shared.sh
@@ -24,6 +24,7 @@ fi
 # if section not in file, append section with key = value
 if ! $found ; then
     mkdir -p "/etc/sssd"
+    chmod 0711 "/etc/sssd"
     echo -e "\n[domain/example.com]\nca_cert = /etc/ssl/certs/ca-certificates.crt" >> "/etc/sssd/sssd.conf"
 fi
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/ansible/shared.yml
@@ -9,6 +9,7 @@
 - name: "{{{ rule_title }}} - Ensure Correct Banner"
   ansible.builtin.copy:
     dest: /etc/issue
+    mode: 0644
     content: "{{ login_banner_contents | replace('\\n', '\n') }}\n"
 {{%- else -%}}
 - name: {{{ rule_title }}} Ensure issue-generator is Installed
@@ -19,6 +20,7 @@
 - name: "{{{ rule_title }}} - Ensure Correct Banner"
   ansible.builtin.copy:
     dest: /etc/issue.d/99-oscap-setting
+    mode: 0644
     content: "{{ login_banner_contents | replace('\\n', '\n') }}\n"
 
 - name: "{{{ rule_title }}} - Restart issue-generator Service on Issue Configuration Change"

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
@@ -4,8 +4,10 @@ login_banner_contents=$(echo "(bash-populate login_banner_contents)" | sed 's/\\
 
 {{%- if product not in ['sle15', 'slmicro5', 'slmicro6'] %}}
 echo "$login_banner_contents" > /etc/issue
+chmod 0644 /etc/issue
 {{%- else %}}
 {{{ bash_package_install("issue-generator") }}}
 echo "$login_banner_contents" > /etc/issue.d/99-oscap-setting
+chmod 0644 /etc/issue.d/99-oscap-setting
 {{{ bash_service_command("restart", "issue-generator") }}}
 {{%- endif -%}}

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/ansible/shared.yml
@@ -8,4 +8,5 @@
 - name: "{{{ rule_title }}} - ensure correct banner"
   ansible.builtin.copy:
     dest: /etc/issue.net
+    mode: 0644
     content: "{{ remote_login_banner_contents | replace('\\n', '\n') }}\n"

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/bash/shared.sh
@@ -2,3 +2,4 @@
 
 remote_login_banner_contents=$(echo "(bash-populate remote_login_banner_contents)" | sed 's/\\n/\n/g')
 echo "$remote_login_banner_contents" > /etc/issue.net
+chmod 0644 /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/ansible/shared.yml
@@ -8,4 +8,5 @@
 - name: "{{{ rule_title }}} - ensure correct banner"
   ansible.builtin.copy:
     dest: /etc/motd
+    mode: 0644
     content: "{{ motd_banner_contents | replace('\\n', '\n') }}\n"

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
@@ -2,3 +2,4 @@
 
 motd_banner_contents=$(echo "(bash-populate motd_banner_contents)" | sed 's/\\n/\n/g')
 echo "$motd_banner_contents" > /etc/motd
+chmod 0644 /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/bash/shared.sh
@@ -19,5 +19,6 @@ umask u=rw,go=r
 cat <<EOF >/etc/profile.d/ssh_confirm.sh
 $formatted
 EOF
+chmod 0644 /etc/profile.d/ssh_confirm.sh
 
 umask $OLD_UMASK

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/ansible/shared.yml
@@ -10,3 +10,4 @@
     dest: /etc/gdm/banner
     line: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME banner-message-enabled"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/login-screen/banner-message-enable$'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
@@ -35,6 +35,7 @@
     value: '''{{ dconf_login_banner_contents }}'''
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of the GNOME3 Login Warning Banner Text"
@@ -44,6 +45,7 @@
     line: '/org/gnome/login-screen/banner-message-text'
     create: yes
     state: present
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
@@ -25,6 +25,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    mode: 0755
   with_items: "{{ list_faillock_dir }}"
   when: item != ""
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -18,6 +18,7 @@ if [ -n "$faillock_dirs" ]; then
         fi
         if [ ! -e $dir ]; then
             mkdir -p $dir
+            chmod 0755 $dir
         fi
         /usr/sbin/restorecon -R -v $dir
     done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -18,7 +18,7 @@ if [ -n "$faillock_dirs" ]; then
         fi
         if [ ! -e $dir ]; then
             mkdir -p $dir
-            chmod 0755 $dir
+            chmod 0755 "$dir"
         fi
         /usr/sbin/restorecon -R -v $dir
     done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/ubuntu.sh
@@ -10,5 +10,6 @@ Auth-Type: Primary
 Auth:
     required                   pam_faildelay.so delay=$var_password_pam_delay
 EOF
+chmod 0644 /usr/share/pam-configs/cac_faildelay
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_faildelay

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
@@ -21,6 +21,7 @@
     path: "{{ var_accounts_passwords_pam_faillock_dir }}"
     state: directory
     setype: 'faillog_t'
+    mode: 0755
 
 - name: '{{{ rule_title }}} - Get SELinux context for faillock directory'
   ansible.builtin.command:

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
@@ -14,6 +14,7 @@
 {{{ bash_package_install("policycoreutils-python-utils") }}}
 
 mkdir -p "$var_accounts_passwords_pam_faillock_dir"
+chmod 0755 "$var_accounts_passwords_pam_faillock_dir"
 # Workaround for https://github.com/OpenSCAP/openscap/issues/2242: Use full
 # path to semanage and restorecon commands to avoid the issue with the command
 # not being found.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -24,6 +24,7 @@
     dest: "{{{ pwquality_path }}}"
     regexp: '^\s*retry'
     line: "retry = {{ var_password_pam_retry }}"
+    mode: 0644
 {{% for cfile in configuration_files %}}
 {{{ ansible_remove_pam_module_option_configuration(pam_file='/etc/pam.d/' ~ cfile,
                                                    group='password',

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/ansible/shared.yml
@@ -14,3 +14,4 @@
     line: crypt_style = {{ var_password_hashing_algorithm_pam }}
     state: present
     create: true
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
@@ -24,4 +24,5 @@
       line: ENCRYPT_METHOD {{ var_password_hashing_algorithm.split('|')[0] }}
       state: present
       create: yes
+      mode: 0644
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
@@ -11,3 +11,4 @@
     regexp: ^CtrlAltDelBurstAction
     line: "CtrlAltDelBurstAction=none"
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/bash/shared.sh
@@ -9,6 +9,7 @@
 # create drop-in in the /etc/systemd/logind.conf.d/ directory
 {{% set logind_conf_file = "/etc/systemd/logind.conf.d/oscap-idle-sessions.conf" %}}
 mkdir -p "/etc/systemd/logind.conf.d/"
+chmod 0755 "/etc/systemd/logind.conf.d/"
 # remove StopIdleSessionSec from drop-in files
 {{{ lineinfile_absent_in_directory("/etc/systemd/logind.conf.d", "^\s*StopIdleSessionSec\s*=", insensitive=true, filename_glob="*.conf") | indent(4) }}}
 {{% else %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -24,6 +24,6 @@
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
-      mode: 0644
       {{%- endif %}}
+      mode: 0644
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -9,7 +9,7 @@
   ansible.builtin.blockinfile:
       create: yes
       dest: /etc/systemd/system/emergency.service.d/10-oscap.conf
-      mode: 0644
+      mode: '0644'
       block: |
         [Service]
         ExecStart=
@@ -25,5 +25,5 @@
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
       {{%- endif %}}
-      mode: 0644
+      mode: '0644'
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -9,6 +9,7 @@
   ansible.builtin.blockinfile:
       create: yes
       dest: /etc/systemd/system/emergency.service.d/10-oscap.conf
+      mode: 0644
       block: |
         [Service]
         ExecStart=
@@ -23,5 +24,6 @@
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
+      mode: 0644
       {{%- endif %}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
@@ -15,6 +15,7 @@ sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default
 
 {{% if 'sle' in product or 'rhel' in product or product == 'fedora' or product == 'slmicro5' or 'ol' in families  %}}
 mkdir -p "${service_dropin_cfg_dir}"
+chmod 0755 "${service_dropin_cfg_dir}"
 echo "[Service]" >> "${service_dropin_file}"
 echo "ExecStart=" >> "${service_dropin_file}"
 echo "ExecStart=-$sulogin" >> "${service_dropin_file}"

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
@@ -19,6 +19,7 @@ chmod 0755 "${service_dropin_cfg_dir}"
 echo "[Service]" >> "${service_dropin_file}"
 echo "ExecStart=" >> "${service_dropin_file}"
 echo "ExecStart=-$sulogin" >> "${service_dropin_file}"
+chmod 0644 "${service_dropin_file}"
 {{% else %}}
 if grep "^ExecStart=.*" "$service_file" ; then
     sed -i "s%^ExecStart=.*%ExecStart=-$sulogin%" "$service_file"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -14,8 +14,8 @@
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
-      mode: 0644
       {{%- endif %}}
+      mode: 0644
 {{% else %}}
 - name: "{{{ rule_title }}} - find files which already override Execstart of rescue.service"
   ansible.builtin.find:

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -14,6 +14,7 @@
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
+      mode: 0644
       {{%- endif %}}
 {{% else %}}
 - name: "{{{ rule_title }}} - find files which already override Execstart of rescue.service"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/ansible/shared.yml
@@ -21,6 +21,7 @@
 - name: "{{{ rule_title }}}: Insert the Correct Script into /etc/profile.d/tmux.sh"
   ansible.builtin.blockinfile:
     path: '/etc/profile.d/tmux.sh'
+    mode: 0644
     block: |
       if [ "$PS1" ]; then
         parent=$(ps -o ppid= -p $$)

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/ansible/shared.yml
@@ -21,6 +21,7 @@
 - name: "{{{ rule_title }}}: Insert the correct script into /etc/profile.d/tmux.sh"
   ansible.builtin.blockinfile:
     path: '/etc/profile.d/tmux.sh'
+    mode: 0644
     block: |
       if [ "$PS1" ]; then
         parent=$(ps -o ppid= -p $$)

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/ubuntu.sh
@@ -4,6 +4,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--path-inc
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+    chmod 0644 /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
 sed -i -e 's/debug = true/debug = false/g' \

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -54,10 +54,10 @@ then
     if ! grep -q 'pam_faildelay.so' "$SYSTEM_AUTH_CONF"
     then
         echo "$(awk '/^'"$PAM_ENV_SO"'/{print $0 RS "'"$SYSTEM_AUTH_PAM_SUCCEED"'" RS "'"$SYSTEM_AUTH_PAM_PKCS11"'";next}1' "$SYSTEM_AUTH_CONF")" > "$SYSTEM_AUTH_CONF"
-        chmod 0644 $SYSTEM_AUTH_CONF
+        chmod 0644 "$SYSTEM_AUTH_CONF"
     else
         echo "$(awk '/^'"$PAM_FAIL_DELAY"'/{print $0 RS "'"$SYSTEM_AUTH_PAM_SUCCEED"'" RS "'"$SYSTEM_AUTH_PAM_PKCS11"'";next}1' "$SYSTEM_AUTH_CONF")" > "$SYSTEM_AUTH_CONF"
-        chmod 0644 $SYSTEM_AUTH_CONF
+        chmod 0644 "$SYSTEM_AUTH_CONF"
     fi
 
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -54,8 +54,10 @@ then
     if ! grep -q 'pam_faildelay.so' "$SYSTEM_AUTH_CONF"
     then
         echo "$(awk '/^'"$PAM_ENV_SO"'/{print $0 RS "'"$SYSTEM_AUTH_PAM_SUCCEED"'" RS "'"$SYSTEM_AUTH_PAM_PKCS11"'";next}1' "$SYSTEM_AUTH_CONF")" > "$SYSTEM_AUTH_CONF"
+        chmod 0644 $SYSTEM_AUTH_CONF
     else
         echo "$(awk '/^'"$PAM_FAIL_DELAY"'/{print $0 RS "'"$SYSTEM_AUTH_PAM_SUCCEED"'" RS "'"$SYSTEM_AUTH_PAM_PKCS11"'";next}1' "$SYSTEM_AUTH_CONF")" > "$SYSTEM_AUTH_CONF"
+        chmod 0644 $SYSTEM_AUTH_CONF
     fi
 
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/bash/ubuntu.sh
@@ -2,6 +2,7 @@
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+    chmod 0644 /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
 if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "ca"; then

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
@@ -2,6 +2,7 @@
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+    chmod 0644 /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
 if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "ocsp_on"; then

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/bash/ubuntu.sh
@@ -2,6 +2,7 @@
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+    chmod 0644 /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
 if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -Eqv 'crl_auto|crl_offline'; then

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
@@ -9,6 +9,7 @@ Auth-Type: Primary
 Auth:
     [success=end default=ignore]	pam_pkcs11.so
 EOF
+chmod 0644 /usr/share/pam-configs/cac_pkcs11
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_pkcs11
 {{% else %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
@@ -11,3 +11,4 @@
     dest: /etc/default/useradd
     regexp: ^INACTIVE
     line: "INACTIVE={{ var_account_disable_post_pw_expiration }}"
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
@@ -11,3 +11,4 @@
     dest: {{{ login_defs_path }}}
     regexp: ^#?PASS_MAX_DAYS
     line: "PASS_MAX_DAYS {{ var_accounts_maximum_age_login_defs }}"
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/ansible/shared.yml
@@ -11,3 +11,4 @@
       dest: {{{ login_defs_path }}}
       regexp: ^#?PASS_MIN_DAYS
       line: "PASS_MIN_DAYS {{ var_accounts_minimum_age_login_defs }}"
+      mode: 0644

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
@@ -12,3 +12,4 @@
     state: present
     line: "PASS_MIN_LEN        {{ var_accounts_password_minlen_login_defs }}"
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
@@ -23,4 +23,5 @@
     state: present
     line: "PASS_WARN_AGE        {{ var_accounts_password_warn_age_login_defs }}"
     create: yes
+    mode: 0644
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/ansible/shared.yml
@@ -9,6 +9,7 @@
     src: /etc/group
     dest: /etc/group-
     remote_src: true
+    mode: 0644
 
 - name: "{{{ rule_title }}} - Remove Lines Starting with + From /etc/group"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/bash/shared.sh
@@ -3,5 +3,6 @@
 if grep -q '^\+' /etc/group; then
 # backup old file to /etc/group-
 	cp /etc/group /etc/group-
+	chmod 0644 /etc/group-
 	sed -i '/^\+.*$/d' /etc/group
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/ansible/shared.yml
@@ -9,6 +9,7 @@
     src: /etc/passwd
     dest: /etc/passwd-
     remote_src: true
+    mode: 0644
 
 - name: "{{{ rule_title }}} - Remove Lines Starting with + From /etc/passwd"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/bash/shared.sh
@@ -3,5 +3,6 @@
 if grep -q '^\+' /etc/passwd; then
 # backup old file to /etc/passwd-
 	cp /etc/passwd /etc/passwd-
+	chmod 0644 /etc/passwd-
 	sed -i '/^\+.*$/d' /etc/passwd
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/ansible/shared.yml
@@ -9,6 +9,7 @@
     src: /etc/shadow
     dest: /etc/shadow-
     remote_src: true
+    mode: 0000
 
 - name: "{{{ rule_title }}} - Remove Lines Starting with + From /etc/shadow"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/bash/shared.sh
@@ -3,5 +3,6 @@
 if grep -q '^\+' /etc/shadow; then
 # backup old file to /etc/shadow-
 	cp /etc/shadow /etc/shadow-
+	chmod 0000 /etc/shadow-
 	sed -i '/^\+.*$/d' /etc/shadow
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -8,3 +8,4 @@
   ansible.builtin.copy:
     dest: /etc/securetty
     content: ""
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/bash/shared.sh
@@ -1,3 +1,4 @@
 # platform = multi_platform_all
 
 echo > /etc/securetty
+chmod 0644 /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
@@ -11,3 +11,4 @@
     regexp: ^FAIL_DELAY
     line: "FAIL_DELAY {{ var_accounts_fail_delay }}"
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
@@ -29,4 +29,5 @@
     regexp: "^#?\\*.*maxlogins"
     line: "*          hard    maxlogins     {{ var_accounts_max_concurrent_login_sessions }}"
     create: yes
+    mode: 0644
   when: maxlogins.matched == 0 # no files found on /etc/security/limits.d matching maxlogins

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -27,5 +27,5 @@
     replace: typeset -xr TMOUT={{ var_accounts_tmout }}
   register: profile_replaced
 
-{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', insensitive=false, new_line='typeset -xr TMOUT={{ var_accounts_tmout }}',
+{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", mode='0644', regex='TMOUT=', insensitive=false, new_line='typeset -xr TMOUT={{ var_accounts_tmout }}',
     create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ["ol7"], rule_title=rule_title) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -24,4 +24,5 @@ done
 if [ $tmout_found -eq 0 ]; then
         echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/tmout.sh
         echo "typeset -xr TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
+        chmod 0644 /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -33,5 +33,6 @@
     create: true
     path: {{{ etc_bash_rc }}}
     line: umask {{ var_accounts_user_umask }}
+    mode: 0644
   when:
   - umask_replace.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
@@ -27,5 +27,6 @@
     create: true
     path: /etc/csh.cshrc
     line: umask {{ var_accounts_user_umask }}
+    mode: 0644
   when:
   - umask_replace.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
@@ -29,4 +29,4 @@
     line: umask {{ var_accounts_user_umask }}
     mode: 0644
   when:
-  - umask_replace.found == 0
+    - umask_replace.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -20,7 +20,7 @@
     regexp: ^(\s*)UMASK(\s+).*
     replace: \g<1>UMASK\g<2>{{ var_accounts_user_umask }}
   when:
-  - result_umask_is_set.found > 0
+    - result_umask_is_set.found > 0
 
 - name: Ensure the Default UMASK is Appended Correctly
   ansible.builtin.lineinfile:
@@ -29,4 +29,4 @@
     line: UMASK {{ var_accounts_user_umask }}
     mode: 0644
   when:
-  - result_umask_is_set.found == 0
+    - result_umask_is_set.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -27,5 +27,6 @@
     create: true
     path: {{{ login_defs_path }}}
     line: UMASK {{ var_accounts_user_umask }}
+    mode: 0644
   when:
   - result_umask_is_set.found == 0

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/shared.yml
@@ -24,6 +24,7 @@
     state: touch
     access_time: preserve
     modification_time: preserve
+    mode: 0644
 
 - name: "{{{ rule_title }}}: Gather conf.d files"
   ansible.builtin.find:
@@ -55,5 +56,6 @@
     line: "{{ item.item.0.selector }} {{ item.item.0.location }}"
     insertafter: ^.*\/var\/log\/secure.*$
     create: yes
+    mode: 0644
   loop: '{{ remote_method_values.results }}'
   when: item.found == 0

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/ubuntu.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/ubuntu.yml
@@ -8,15 +8,15 @@
   ansible.builtin.set_fact:
       conf_files: [ '/etc/rsyslog.d/50-default.conf' ]
       remote_methods:
-        - selector: 'auth.*'
-          regexp: ^.*auth\.\*.*$
-          log_path_name: secure
-        - selector: 'authpriv.*'
-          regexp: ^.*authpriv\.\*.*$
-          log_path_name: secure
-        - selector: 'daemon.*'
-          regexp: ^.*daemon\.\*.*$
-          log_path_name: messages
+          - selector: 'auth.*'
+            regexp: ^.*auth\.\*.*$
+            log_path_name: secure
+          - selector: 'authpriv.*'
+            regexp: ^.*authpriv\.\*.*$
+            log_path_name: secure
+          - selector: 'daemon.*'
+            regexp: ^.*daemon\.\*.*$
+            log_path_name: messages
 
 - name: "{{{ rule_title }}} - Ensure /etc/rsyslog.d/50-default.conf Exists"
   ansible.builtin.file:

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/ubuntu.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/ubuntu.yml
@@ -22,6 +22,7 @@
   ansible.builtin.file:
       path: "{{ conf_files.0 }}"
       state: touch
+      mode: 0644
 
 - name: "{{{ rule_title }}} - Check for Existing Values in Conf Files"
   ansible.builtin.lineinfile:
@@ -39,5 +40,6 @@
       line: "{{ item.item.0.selector }} /var/log/{{ item.item.0.log_path_name }}"
       insertafter: ^.*\/var\/log\/secure.*$
       create: yes
+      mode: 0644
   loop: '{{ remote_method_values.results }}'
   when: item.found == 0

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
@@ -6,6 +6,7 @@ declare -A LOCATIONS=( ['auth.*']='/var/log/secure' ['authpriv.*']='/var/log/sec
 if [[ ! -f /etc/rsyslog.conf ]]; then
 	# Something is not right, create the file
 	touch /etc/rsyslog.conf
+	chmod 0644 /etc/rsyslog.conf
 fi
 
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/ubuntu.sh
@@ -2,7 +2,9 @@
 
 if [ ! -f /etc/rsyslog.d/50-default.conf ]; then
     mkdir -p /etc/rsyslog.d/
+    chmod 0755 /etc/rsyslog.d/
     touch /etc/rsyslog.d/50-default.conf
+    chmod 0644 /etc/rsyslog.d/50-default.conf
 fi
 
 # Check to see if auth exists

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/ansible/shared.yml
@@ -12,6 +12,7 @@
       regexp: "^#?ServerKeyFile="
       line: ServerKeyFile={{ var_journal_upload_server_key_file }}
       create: yes
+      mode: 0644
 
 {{{ ansible_instantiate_variables("var_journal_upload_server_certificate_file") }}}
 
@@ -21,6 +22,7 @@
       regexp: "^#?ServerCertificateFile="
       line: ServerCertificateFile={{ var_journal_upload_server_certificate_file }}
       create: yes
+      mode: 0644
 
 {{{ ansible_instantiate_variables("var_journal_upload_server_trusted_certificate_file") }}}
 
@@ -30,3 +32,4 @@
       regexp: "^#?TrustedCertificateFile="
       line: TrustedCertificateFile={{ var_journal_upload_server_trusted_certificate_file }}
       create: yes
+      mode: 0644

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/bash/shared.sh
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/bash/shared.sh
@@ -2,7 +2,9 @@
 {{% if 'ubuntu' in product %}}
 dropin_conf=/etc/systemd/journal-upload.conf.d/60-journald_upload.conf
 mkdir -p /etc/systemd/journal-upload.conf.d
+chmod 0755 /etc/systemd/journal-upload.conf.d
 touch "${dropin_conf}"
+chmod 0644 "${dropin_conf}"
 {{% else %}}
 dropin_conf=/etc/systemd/journal-upload.conf
 {{% endif %}}

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/ansible/shared.yml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/ansible/shared.yml
@@ -11,3 +11,4 @@
       regexp: "^#?URL="
       line: URL={{ var_journal_upload_url }}
       create: yes
+      mode: 0644

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/bash/shared.sh
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/bash/shared.sh
@@ -2,7 +2,9 @@
 {{% if 'ubuntu' in product %}}
 dropin_conf=/etc/systemd/journal-upload.conf.d/60-journald_upload.conf
 mkdir -p /etc/systemd/journal-upload.conf.d
+chmod 0755 /etc/systemd/journal-upload.conf.d
 touch "${dropin_conf}"
+chmod 0644 "${dropin_conf}"
 {{% else %}}
 dropin_conf=/etc/systemd/journal-upload.conf
 {{% endif %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -17,6 +17,7 @@
     line: "daily"
     state: present
     insertbefore: BOF
+    mode: 0644
 
 - name: "Make sure daily log rotation setting is not overridden in {{{ LOGROTATE_CONF_FILE }}}"
   ansible.builtin.lineinfile:
@@ -41,10 +42,12 @@
         line: "#!/bin/sh"
         insertbefore: BOF
         create: yes
+        mode: 0755
     - name: Add logrotate call
       ansible.builtin.lineinfile:
         path: "/etc/cron.daily/logrotate"
         line: '/usr/sbin/logrotate {{{ LOGROTATE_CONF_FILE }}}'
         regexp: '^[\s]*/usr/sbin/logrotate[\s\S]*{{{ LOGROTATE_CONF_FILE }}}$'
         create: yes
+        mode: 0755
 {{% endif %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -30,7 +30,7 @@ fi
 # configure cron.daily if not already
 if ! grep -q "^[[:space:]]*/usr/sbin/logrotate[[:alnum:][:blank:][:punct:]]*$LOGROTATE_CONF_FILE$" $CRON_DAILY_LOGROTATE_FILE; then
 	echo '#!/bin/sh' > $CRON_DAILY_LOGROTATE_FILE
- chmod 0755 $CRON_DAILY_LOGROTATE_FILE
+	chmod 0755 "$CRON_DAILY_LOGROTATE_FILE"
 	echo "/usr/sbin/logrotate $LOGROTATE_CONF_FILE" >> $CRON_DAILY_LOGROTATE_FILE
 fi
 {{% endif %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -30,6 +30,7 @@ fi
 # configure cron.daily if not already
 if ! grep -q "^[[:space:]]*/usr/sbin/logrotate[[:alnum:][:blank:][:punct:]]*$LOGROTATE_CONF_FILE$" $CRON_DAILY_LOGROTATE_FILE; then
 	echo '#!/bin/sh' > $CRON_DAILY_LOGROTATE_FILE
+ chmod 0755 $CRON_DAILY_LOGROTATE_FILE
 	echo "/usr/sbin/logrotate $LOGROTATE_CONF_FILE" >> $CRON_DAILY_LOGROTATE_FILE
 fi
 {{% endif %}}

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
@@ -13,6 +13,7 @@ if ! grep -qE '^\s*\$FileCreateMode\s+0640' /etc/rsyslog.conf; then
     fi
     ## Assume there is no filter named as 00-, otherwise those filters might be included before this configuration and create file with different permissions
     echo '$FileCreateMode 0640' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf
+    chmod 0644 /etc/rsyslog.d/00-rsyslog_filecreatemode.conf
     changes_made=true
 fi
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
@@ -11,3 +11,4 @@
     regexp: "^\\*\\.\\*"
     line: "*.* @@{{ rsyslog_remote_loghost_address }}"
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/sle.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/sle.yml
@@ -35,3 +35,4 @@
     regexp: "^\\*\\.\\*\\s+.*$"
     line: "*.* @@{{ rsyslog_remote_loghost_address }}"
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -85,4 +85,5 @@
     dest: /etc/rsyslog.conf
     line: 'action(type="omfwd" protocol="tcp" Target="{{ rsyslog_remote_loghost_address }}" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")'
     create: yes
+    mode: 0644
   when: not rsyslog_includes_with_directive.matched and not rsyslog_main_file_with_directive.matched

--- a/linux_os/guide/system/logging/syslogng/syslogng_filecreatemode/bash/shared.sh
+++ b/linux_os/guide/system/logging/syslogng/syslogng_filecreatemode/bash/shared.sh
@@ -10,5 +10,6 @@ find /etc/syslog-ng/conf.d/ -name "*.conf" -exec sed -i '/^\s*perm(/d' {} \;
 
 # Add perm(0640) via a drop-in options block
 echo 'options { perm(0640); };' > /etc/syslog-ng/conf.d/00-syslogng_filecreatemode.conf
+chmod 0644 /etc/syslog-ng/conf.d/00-syslogng_filecreatemode.conf
 
 systemctl restart syslog-ng.service

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/ansible/shared.yml
@@ -10,6 +10,7 @@
     dest: "/etc/modprobe.d/ipv6.conf"
     regexp: "^options\\s+ipv6\\s+disable=\\d"
     line: "options ipv6 disable=1"
+    mode: 0644
 
 - name: Ensure disable_ipv6 (all and default) is set to 1
   ansible.posix.sysctl:

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/bash/shared.sh
@@ -2,6 +2,7 @@
 
 # Prevent the IPv6 kernel module (ipv6) from loading the IPv6 networking stack
 echo "options ipv6 disable=1" > /etc/modprobe.d/ipv6.conf
+chmod 0644 /etc/modprobe.d/ipv6.conf
 
 # Since according to: https://access.redhat.com/solutions/72733
 # "ipv6 disable=1" options doesn't always disable the IPv6 networking stack from

--- a/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/ansible/sle15.yml
+++ b/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/ansible/sle15.yml
@@ -14,6 +14,7 @@
     path: "{{ var_nftables_master_config_file }}"
     line: 'include "/etc/nftables/{{ item }}-filter"'
     create: yes
+    mode: 0644
   loop:
     - bridge
     - arp

--- a/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/bash/sle15.sh
+++ b/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/bash/sle15.sh
@@ -10,6 +10,7 @@
 
 if [ ! -f "${var_nftables_master_config_file}" ]; then
     touch "${var_nftables_master_config_file}"
+    chmod 0644 "${var_nftables_master_config_file}"
 fi
 
 {{% for family in nftables_family_names %}}

--- a/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/bash/ubuntu.sh
+++ b/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/bash/ubuntu.sh
@@ -10,9 +10,11 @@
 
 if [ ! -f "${var_nftables_master_config_file}" ]; then
     touch "${var_nftables_master_config_file}"
+    chmod 0644 "${var_nftables_master_config_file}"
 fi
 
 nft list ruleset > "/etc/${var_nftables_family}-filter.rules"
+chmod 0644 /etc/${var_nftables_family}-filter.rules
 
 grep -qxF 'include "/etc/'"${var_nftables_family}"'-filter.rules"' "${var_nftables_master_config_file}" \
     || echo 'include "/etc/'"${var_nftables_family}"'-filter.rules"' >> "${var_nftables_master_config_file}"

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
@@ -29,4 +29,5 @@ fi
 
 {{% if "ubuntu" in product %}}
 nft list ruleset > "/etc/${var_nftables_family}-filter.rules"
+chmod 0644 /etc/${var_nftables_family}-filter.rules
 {{% endif %}}

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/ubuntu.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/ubuntu.yml
@@ -36,6 +36,7 @@
   ansible.builtin.blockinfile:
     path: /etc/modprobe.d/disable_wireless.conf
     create: yes
+    mode: 0644
     block: |
       {% for r in wireless_drivers.results %}
       install {{ r.stdout }} /bin/false

--- a/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
@@ -17,6 +17,7 @@
     value: "{{ item.value }}"
     no_extra_spaces: yes
     create: yes
+    mode: 0644
   loop:
     - { option: 'Identity', value: 'default' }
     - { option: 'Action', value: 'org.freedesktop.NetworkManager.*' }

--- a/linux_os/guide/system/network/network_nmcli_permissions/bash/shared.sh
+++ b/linux_os/guide/system/network/network_nmcli_permissions/bash/shared.sh
@@ -6,3 +6,4 @@
 
 {{{ bash_package_install("polkit-pkla-compat") }}}
 printf "[Disable General User Access to NetworkManager]\nIdentity=default\nAction=org.freedesktop.NetworkManager.*\nResultAny=no\nResultInactive=no\nResultActive=auth_admin\n" > /etc/polkit-1/localauthority/20-org.d/10-nm-harden-access.pkla
+chmod 0644 /etc/polkit-1/localauthority/20-org.d/10-nm-harden-access.pkla

--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
@@ -11,4 +11,5 @@
      recurse: "yes"
      state: "directory"
      follow: "yes"
+     mode: 0755
    with_items: [ '/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'  ]

--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
@@ -11,5 +11,4 @@
      recurse: "yes"
      state: "directory"
      follow: "yes"
-     mode: 0755
    with_items: [ '/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'  ]

--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 
 -  name: "{{{ rule_title }}} - Set group ownership of directories that contain system commands to root"
-   ansible.builtin.file: 
+   ansible.builtin.file:
      path: "{{ item }}"
      group: "root"
      recurse: "yes"

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
@@ -11,4 +11,5 @@
      recurse: "yes"
      state: "directory"
      follow: "yes"
+     mode: 0755
    with_items: [ '/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'  ]

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
@@ -11,5 +11,4 @@
      recurse: "yes"
      state: "directory"
      follow: "yes"
-     mode: 0755
    with_items: [ '/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'  ]

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 
 -  name: "{{{ rule_title }}} - Set ownership of directories that contain system commands to root"
-   ansible.builtin.file: 
+   ansible.builtin.file:
      path: "{{ item }}"
      owner: "root"
      recurse: "yes"

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/ansible/shared.yml
@@ -22,5 +22,5 @@
     regexp: '^C\s+/root/\.{{{ file }}}.+$'
     state: absent
   loop: "{{ {{{ rule_id }}}_{{{ file }}}_found_files.files }}"
-{{{ ansible_lineinfile(msg='', path='/etc/tmpfiles.d/rootfiles.conf', new_line=new_line, create='yes', state='present', insert_after='', insert_before='', regex=source_path, rule_title=rule_title)  -}}}
+{{{ ansible_lineinfile(msg='', path='/etc/tmpfiles.d/rootfiles.conf', mode='0644', new_line=new_line, create='yes', state='present', insert_after='', insert_before='', regex=source_path, rule_title=rule_title)  -}}}
 {{%- endfor %}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/bash/debian13.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/bash/debian13.sh
@@ -21,10 +21,12 @@ option_check=$(echo $current_options | grep $mount_option | wc -l)
 # add systemd drop in to add missing option
 if [ $option_check == "0" ]; then
     mkdir -p /etc/systemd/system/$unit.d
+    chmod 0755 /etc/systemd/system/$unit.d
     cat > /etc/systemd/system/$unit.d/mount_options.conf <<EOF
 [Mount]
 Options=$current_options,$mount_option
 EOF
+    chmod 0644 /etc/systemd/system/$unit.d/mount_options.conf
 
     # unit changed on disk. reload.
     systemctl daemon-reload

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/bash/shared.sh
@@ -12,5 +12,5 @@ umount /var/tmp
 printf "%-24s%-24s%-8s%-32s%-3s\n" "/tmp" "/var/tmp" "none" "rw,nodev,noexec,nosuid,bind" "0 0" >> /etc/fstab
 
 mkdir -p /var/tmp
-chmod 0755 /var/tmp
+chmod 1777 /var/tmp
 mount -B /tmp /var/tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/bash/shared.sh
@@ -12,4 +12,5 @@ umount /var/tmp
 printf "%-24s%-24s%-8s%-32s%-3s\n" "/tmp" "/var/tmp" "none" "rw,nodev,noexec,nosuid,bind" "0 0" >> /etc/fstab
 
 mkdir -p /var/tmp
+chmod 0755 /var/tmp
 mount -B /tmp /var/tmp

--- a/linux_os/guide/system/permissions/permissions_local/permissions_local_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/permissions_local/permissions_local_var_log_audit/ansible/shared.yml
@@ -4,7 +4,7 @@
 # strategy = configure
 # disruption = low
 
-{{{ ansible_lineinfile(msg='Configure permission for /var/log/audit', path='/etc/permissions.local', regex='^\/var\/log\/audit\s+root.*', insensitive=false, new_line='/var/log/audit root:root 600', create='yes', state='present', register='update_permissions_var_log_audit', rule_title=rule_title) }}}
+{{{ ansible_lineinfile(msg='Configure permission for /var/log/audit', path='/etc/permissions.local', mode='0644', regex='^\/var\/log\/audit\s+root.*', insensitive=false, new_line='/var/log/audit root:root 600', create='yes', state='present', register='update_permissions_var_log_audit', rule_title=rule_title) }}}
 
 - name: "Correct file permissions after update /var/log/audit"
   ansible.builtin.shell: >
@@ -12,7 +12,7 @@
     chkstat --set --system
   when: update_permissions_var_log_audit.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /var/log/audit.log', path='/etc/permissions.local', regex='^\/var\/log\/audit\/audit.log\s+root.*', insensitive=false, new_line='/var/log/audit/audit.log root:root 600', create='yes', state='present', register='update_permissions_var_log_audit_audit_log', rule_title=rule_title) }}}
+{{{ ansible_lineinfile(msg='Configure permission for /var/log/audit.log', path='/etc/permissions.local', mode='0644', regex='^\/var\/log\/audit\/audit.log\s+root.*', insensitive=false, new_line='/var/log/audit/audit.log root:root 600', create='yes', state='present', register='update_permissions_var_log_audit_audit_log', rule_title=rule_title) }}}
 
 - name: "Correct file permissions after update /var/log/audit/audit.log"
   ansible.builtin.shell: >
@@ -20,7 +20,7 @@
     chkstat --set --system
   when: update_permissions_var_log_audit_audit_log.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /etc/audit/audit.rules', path='/etc/permissions.local', regex='^\/etc\/audit\/audit.rules\s+root.*', insensitive=false, new_line='/etc/audit/audit.rules root:root 640', create='yes', state='present', register='update_permissions_etc_audit_audit_rules', rule_title=rule_title) }}}
+{{{ ansible_lineinfile(msg='Configure permission for /etc/audit/audit.rules', path='/etc/permissions.local', mode='0644', regex='^\/etc\/audit\/audit.rules\s+root.*', insensitive=false, new_line='/etc/audit/audit.rules root:root 640', create='yes', state='present', register='update_permissions_etc_audit_audit_rules', rule_title=rule_title) }}}
 
 - name: "Correct file permissions after update /etc/audit/audit.rules"
   ansible.builtin.shell: >
@@ -28,7 +28,7 @@
     chkstat --set --system
   when: update_permissions_etc_audit_audit_rules.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /etc/audit/rules.d/audit.rules', path='/etc/permissions.local', regex='^\/etc\/audit\/rules.d\/audit.rules\s+root.*', insensitive=false, new_line='/etc/audit/rules.d/audit.rules root:root 640', create='yes', state='present', register='update_permissions_etc_audit_rules_d_audit_rules', rule_title=rule_title) }}}
+{{{ ansible_lineinfile(msg='Configure permission for /etc/audit/rules.d/audit.rules', path='/etc/permissions.local', mode='0644', regex='^\/etc\/audit\/rules.d\/audit.rules\s+root.*', insensitive=false, new_line='/etc/audit/rules.d/audit.rules root:root 640', create='yes', state='present', register='update_permissions_etc_audit_rules_d_audit_rules', rule_title=rule_title) }}}
 
 - name: "Correct file permissions after update /etc/audit/rules.d/audit.rules"
   ansible.builtin.shell: >

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ansible/shared.yml
@@ -60,10 +60,12 @@
     ansible.builtin.file:
         path: "{{ limits_dropin_dir }}"
         state: directory
+        mode: 0755
     when: not core_limit_valid
 
 -   name: "{{{ rule_title }}} - Deploy 10-ssg-hardening.conf drop-in with correct core limit"
     ansible.builtin.copy:
         dest: "{{ limits_dropin_file }}"
         content: "*     hard   core    0\n"
+        mode: 0644
     when: not core_limit_valid

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ansible/shared.yml
@@ -60,12 +60,12 @@
     ansible.builtin.file:
         path: "{{ limits_dropin_dir }}"
         state: directory
-        mode: 0755
+        mode: '0755'
     when: not core_limit_valid
 
 -   name: "{{{ rule_title }}} - Deploy 10-ssg-hardening.conf drop-in with correct core limit"
     ansible.builtin.copy:
         dest: "{{ limits_dropin_file }}"
         content: "*     hard   core    0\n"
-        mode: 0644
+        mode: '0644'
     when: not core_limit_valid

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -19,5 +19,6 @@ elif [ ! -d "$DROPIN_DIR" ] && grep -qE "$REGEX_CORRECT_VALUE" "$SECURITY_LIMITS
     exit 0
 else
     mkdir -p "$DROPIN_DIR"
+    chmod 0755 "$DROPIN_DIR"
     echo "*     hard   core    0" >> $DROPIN_FILE
 fi

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -21,4 +21,5 @@ else
     mkdir -p "$DROPIN_DIR"
     chmod 0755 "$DROPIN_DIR"
     echo "*     hard   core    0" >> $DROPIN_FILE
+    chmod 0644 "$DROPIN_FILE"
 fi

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/ansible/ol.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/ansible/ol.yml
@@ -24,6 +24,7 @@
       dest: /etc/modules-load.d/vfat.conf
       regexp: ^\s*\bvfat\b
       line: "vfat"
+      mode: 0644
 
 - name: {{{ rule_title }}} - Regenerate initramfs
   ansible.builtin.command:

--- a/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
@@ -22,4 +22,5 @@
         state: touch
         access_time: preserve
         modification_time: preserve
+        mode: 0644
   when: selinux_config_state.stdout not in ['enforcing', 'permissive']

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -20,4 +20,5 @@
     state: touch
     access_time: preserve
     modification_time: preserve
+    mode: 0644
   when: current_selinux_state.stdout | lower != var_selinux_state

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME disablement of Login Restart and Shutdown Buttons"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/login-screen/disable-restart-buttons'
     line: '/org/gnome/login-screen/disable-restart-buttons'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     no_extra_spaces: yes
     create: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME3 disablement of Login User List"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/login-screen/disable-user-list$'
     line: '/org/gnome/login-screen/disable-user-list'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 {{% if product in ['sle15', 'sle16'] %}}

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME3 disablement of Smartcard Authentication"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/login-screen/enable-smartcard-authentication$'
     line: '/org/gnome/login-screen/enable-smartcard-authentication'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "3"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME3 Login Number of Failures"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/login-screen/allowed-failures$'
     line: '/org/gnome/login-screen/allowed-failures'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
@@ -11,3 +11,4 @@
     value: "false"
     no_extra_spaces: yes
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/ansible/shared.yml
@@ -11,3 +11,4 @@
     value: "false"
     no_extra_spaces: yes
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Disable GNOME3 Automounting - automount"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: /etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME3 Automounting - automount"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Disable GNOME3 Automounting - automount-open"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: /etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME3 Automounting - automount-open"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Disable GNOME3 Automounting - autorun-never"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: /etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME3 Automounting - autorun-never"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME3 Thumbnailers"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/desktop/thumbnailers/disable-all$'
     line: '/org/gnome/desktop/thumbnailers/disable-all'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/nm-applet/disable-wifi-create$'
     line: '/org/gnome/nm-applet/disable-wifi-create'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available$'
     line: '/org/gnome/nm-applet/suppress-wireless-networks-available'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Require Credential Prompting for Remote Access in GNOME3"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: /etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME3 Credential Prompting for Remote Access"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Require Encryption for Remote Access in GNOME3"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: /etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME3 Encryption for Remote Access"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Enable GNOME3 Screensaver Idle Activation"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: "/etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings"
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME idle-activation-enabled"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
@@ -9,6 +9,7 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled$'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -7,6 +7,7 @@
 
 - name: "Set GNOME3 Screensaver Inactivity Timeout"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: "/etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings"
 {{% else %}}
@@ -22,6 +23,7 @@
 {{% if 'ubuntu' in product or product in ["sle15", "sle16"] %}}
 - name: "Prevent user modification of GNOME Screensaver Inactivity Timeout"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -7,6 +7,7 @@
 
 - name: "Set GNOME3 Screensaver Lock Delay After Activation Period"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: "/etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings"
 {{% else %}}
@@ -26,6 +27,7 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-delay$'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
+    mode: 0644
   register: result_lineinfile
 {{% endif %}}
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -12,6 +12,7 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   when: ansible_distribution != 'SLES'
   register: screensaver_config
 
@@ -21,6 +22,7 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled$'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
+    mode: 0644
   when: ansible_distribution != 'SLES'
   register: screensaver_lock
 
@@ -32,6 +34,7 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   when: ansible_distribution == 'SLES'
   register: lockdown_config
 
@@ -41,6 +44,7 @@
     regexp: '^/org/gnome/desktop/lockdown/disable-lock-screen$'
     line: '/org/gnome/desktop/lockdown/disable-lock-screen'
     create: yes
+    mode: 0644
   when: ansible_distribution == 'SLES'
   register: lockdown_lock
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
@@ -9,6 +9,7 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled$'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Implement Blank Screensaver"
   community.general.ini_file:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     dest: "/etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings"
 {{% else %}}
@@ -19,6 +20,7 @@
 
 - name: "Prevent user modification of GNOME picture-uri"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME show-full-name-in-top-bar"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar$'
     line: '/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 - name: "Prevent user modification of GNOME lock-delay"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
@@ -6,6 +6,7 @@
 
 - name: "Prevent user modification of GNOME Session idle-delay"
   ansible.builtin.lineinfile:
+    mode: 0644
 {{% if product in ['sle15', 'sle16'] %}}
     path: /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock
 {{% else %}}

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "['']"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini
 
 - name: "Prevent user modification of GNOME disablement of Ctrl-Alt-Del"
@@ -19,6 +20,7 @@
     regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout$'
     line: '/org/gnome/settings-daemon/plugins/media-keys/logout'
     create: yes
+    mode: 0644
   register: result_lineinfile
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -11,6 +11,7 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+    mode: 0644
   register: result_ini1
 
 - name: "Disable Geolocation in GNOME3 - clock location tracking"
@@ -20,6 +21,7 @@
     option: gelocation
     value: "false"
     create: yes
+    mode: 0644
   register: result_ini2
 
 - name: "Prevent user modification of GNOME geolocation - location tracking"
@@ -28,6 +30,7 @@
     regexp: '^/org/gnome/system/location/enabled$'
     line: '/org/gnome/system/location/enabled'
     create: yes
+    mode: 0644
   register: result_lineinfile1
 
 - name: "Prevent user modification of GNOME geolocation - clock location tracking"
@@ -36,6 +39,7 @@
     regexp: '^/org/gnome/clocks/geolocation$'
     line: '/org/gnome/clocks/geolocation'
     create: yes
+    mode: 0644
   register: result_lineinfile2
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/xwayland_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/xwayland_disabled/ansible/shared.yml
@@ -12,3 +12,4 @@
     value: "false"
     create: yes
     state: present
+    mode: 0644

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
@@ -21,6 +21,7 @@
     regexp: "{{ lineinfile_reg }}"
     line: "{{ correct_value }}"
     create: yes
+    mode: 0644
   when: not gnutls_file.stat.exists or gnutls_file.stat.size <= correct_value|length
 
 - name: "{{{ rule_title }}}"

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
@@ -9,3 +9,4 @@
     path: /etc/ipsec.conf
     line: "include /etc/crypto-policies/back-ends/libreswan.config"
     create: yes
+    mode: 0644

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -39,6 +39,7 @@
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
     line: {{{ ansible_openssl_include_directive }}}
     path: "{{{ openssl_cnf_dir }}}/{{{ openssl_cnf_file }}}"
+    mode: 0644
   when:
     - test_crypto_policy_group.matched > 0
     - test_crypto_policy_include_directive.matched == 0
@@ -48,5 +49,6 @@
     create: yes
     line: "[crypto_policy]\n{{{ ansible_openssl_include_directive }}}"
     path: "{{{ openssl_cnf_dir }}}/{{{ openssl_cnf_file }}}"
+    mode: 0644
   when:
     - test_crypto_policy_group.matched == 0

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/ansible/shared.yml
@@ -39,7 +39,7 @@
     # The newline at the beginning of the content is important
     mode: 0644
     content: |
-      
+
       Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256
   when: not opensslcnf_config_stat.stat.exists or opensslcnf_config_ciphersuites | length == 0 or opensslcnf_config_ciphersuites | last != correct_ciphersuites
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/ansible/shared.yml
@@ -37,6 +37,7 @@
   ansible.builtin.copy:
     dest: "/etc/crypto-policies/local.d/opensslcnf-ospp.config"
     # The newline at the beginning of the content is important
+    mode: 0644
     content: |
       
       Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -56,6 +56,7 @@
     ansible.builtin.file:
         path: "{{ local_path | dirname }}"
         state: directory
+        mode: 0755
 
 -   name: "{{{ rule_title }}}: Write CRYPTO_POLICY to local config"
     ansible.builtin.lineinfile:
@@ -63,6 +64,7 @@
         line: "{{ '\n' ~ updated_crypto_policy }}"
         create: yes
         insertafter: EOF
+        mode: 0644
     register: local_config
     when: not cipher_is_correct
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -28,11 +28,11 @@ if [[ -n "$last_crypto_policy" ]]; then
         fi
         # Write updated line to LOCAL_CONF_FILE
         echo -e "\n$last_crypto_policy" > "$LOCAL_CONF_FILE"
-        chmod 0644 $LOCAL_CONF_FILE
+        chmod 0644 "$LOCAL_CONF_FILE"
     fi
 else
     echo -e "\nCRYPTO_POLICY='${correct_value}'" > ${LOCAL_CONF_FILE}
-    chmod 0644 ${LOCAL_CONF_FILE}
+    chmod 0644 "${LOCAL_CONF_FILE}"
 fi
 
 update-crypto-policies --no-reload

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -28,9 +28,11 @@ if [[ -n "$last_crypto_policy" ]]; then
         fi
         # Write updated line to LOCAL_CONF_FILE
         echo -e "\n$last_crypto_policy" > "$LOCAL_CONF_FILE"
+        chmod 0644 $LOCAL_CONF_FILE
     fi
 else
     echo -e "\nCRYPTO_POLICY='${correct_value}'" > ${LOCAL_CONF_FILE}
+    chmod 0644 ${LOCAL_CONF_FILE}
 fi
 
 update-crypto-policies --no-reload

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
@@ -5,5 +5,6 @@ file=/etc/crypto-policies/local.d/opensshserver-ospp.config
 
 #blank line at the beginning to ease later readability
 echo '' > "$file"
+chmod 0644 $file
 echo "$cp" >> "$file"
 update-crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
@@ -5,6 +5,6 @@ file=/etc/crypto-policies/local.d/opensshserver-ospp.config
 
 #blank line at the beginning to ease later readability
 echo '' > "$file"
-chmod 0644 $file
+chmod 0644 "$file"
 echo "$cp" >> "$file"
 update-crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -56,6 +56,7 @@
     ansible.builtin.file:
         path: "{{ local_path | dirname }}"
         state: directory
+        mode: 0755
 
 -   name: "{{{ rule_title }}}: Write CRYPTO_POLICY to local config"
     ansible.builtin.lineinfile:
@@ -63,6 +64,7 @@
         line: "{{ '\n' ~ updated_crypto_policy }}"
         create: yes
         insertafter: EOF
+        mode: 0644
     register: local_config
     when: not mac_is_correct
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -28,11 +28,11 @@ if [[ -n "$last_crypto_policy" ]]; then
         fi
         # Write updated line to LOCAL_CONF_FILE
         echo -e "\n$last_crypto_policy" > "$LOCAL_CONF_FILE"
-        chmod 0644 $LOCAL_CONF_FILE
+        chmod 0644 "$LOCAL_CONF_FILE"
     fi
 else
     echo -e "\nCRYPTO_POLICY='${correct_value}'" > ${LOCAL_CONF_FILE}
-    chmod 0644 ${LOCAL_CONF_FILE}
+    chmod 0644 "${LOCAL_CONF_FILE}"
 fi
 
 update-crypto-policies --no-reload

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -28,9 +28,11 @@ if [[ -n "$last_crypto_policy" ]]; then
         fi
         # Write updated line to LOCAL_CONF_FILE
         echo -e "\n$last_crypto_policy" > "$LOCAL_CONF_FILE"
+        chmod 0644 $LOCAL_CONF_FILE
     fi
 else
     echo -e "\nCRYPTO_POLICY='${correct_value}'" > ${LOCAL_CONF_FILE}
+    chmod 0644 ${LOCAL_CONF_FILE}
 fi
 
 update-crypto-policies --no-reload

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/bash/shared.sh
@@ -3,3 +3,4 @@
 cat > /etc/profile.d/openssl-rand.sh <<- 'EOM'
 {{{ openssl_strong_entropy_config_file() }}}
 EOM
+chmod 0644 /etc/profile.d/openssl-rand.sh

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
@@ -4,4 +4,5 @@ if {{{ bash_bootc_build() }}}; then
 	cat > /usr/lib/bootc/kargs.d/01-fips.toml << EOF
 kargs = ["fips=1"]
 EOF
+ chmod 0644 /usr/lib/bootc/kargs.d/01-fips.toml
 fi

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/debian.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/debian.yml
@@ -48,6 +48,7 @@
     path: /etc/aide/aide.conf
     line: database=file:/var/lib/aide/aide.db
     create: true
+    mode: 0644
   when: database_replace.found == 0
 
 - name: "{{{ rule_title }}} - Ensure the Default Out Path is Added"
@@ -55,6 +56,7 @@
     path: /etc/aide/aide.conf
     line: database_out=file:/var/lib/aide/aide.db.new
     create: true
+    mode: 0644
   when: database_out_replace.found == 0
 
 - name: "{{{ rule_title }}} - Build and Test AIDE Database"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -43,6 +43,7 @@
     dest: {{{ aide_stage_dest }}}
     backup: yes
     remote_src: yes
+    mode: 0644
   when:
     - aide_database_init is changed
     - not ansible_check_mode

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/ubuntu.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/ubuntu.yml
@@ -48,6 +48,7 @@
     path: /etc/aide/aide.conf
     line: database=file:/var/lib/aide/aide.db
     create: true
+    mode: 0644
   when: database_replace.found == 0
 
 - name: "{{{ rule_title }}} - Ensure the Default Out Path is Added"
@@ -55,6 +56,7 @@
     path: /etc/aide/aide.conf
     line: database_out=file:/var/lib/aide/aide.db.new
     create: true
+    mode: 0644
   when: database_out_replace.found == 0
 
 - name: "{{{ rule_title }}} - Build and Test AIDE Database"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -34,6 +34,7 @@
     regexp: ^{{ item }}\s
     line: "{{ item }} {{{ aide_string() }}}"
     create: true
+    mode: 0644
   with_items: "{{ audit_tools }}"
   when:
     - '"aide" in ansible_facts.packages'
@@ -43,6 +44,7 @@
     path: {{{ aide_conf_path }}}
     line: "{{ item }} {{{ aide_string() }}}"
     create: true
+    mode: 0644
   with_items: "{{ audit_tools }}"
   when:
     - '"aide" in ansible_facts.packages'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 - name: "{{{ rule_title }}} - Gather List of Packages"
   tags:
-  - aide_check_audit_tools
+    - aide_check_audit_tools
   ansible.builtin.package_facts:
     manager: auto
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/bash/shared.sh
@@ -12,6 +12,7 @@ ExecStart={{{ aide_bin_path }}} --check
 [Install]
 WantedBy=multi-user.target
 EOF
+chmod 0644 /etc/systemd/system/aidecheck.service
 
 # create unit file for the aide check timer
 cat > /etc/systemd/system/aidecheck.timer <<EOF

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -53,5 +53,6 @@
   ansible.builtin.copy:
     src: /usr/share/aide/config/cron.daily/dailyaidecheck
     dest: /etc/cron.daily/dailyaidecheck
+    mode: 0755
   when: not line_check.found
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -16,6 +16,7 @@ cat > /etc/systemd/system/aidecheck.service <<CHECKEOF
         [Install]
         WantedBy=multi-user.target
 CHECKEOF
+chmod 0644 /etc/systemd/system/aidecheck.service
 cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
 [Unit]
         Description=Status email for AIDE check result
@@ -24,6 +25,7 @@ cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
         Type=forking
         ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  $var_aide_scan_notification_email'
 NOTIFYEOF
+chmod 0644 /etc/systemd/system/aidecheck-notify.service
 {{% else %}}
 CRONTAB=/etc/crontab
 CRONDIRS='/etc/cron.d /etc/cron.daily /etc/cron.weekly /etc/cron.monthly'

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
@@ -18,6 +18,7 @@ fi
 
 if /usr/sbin/visudo -qcf /etc/sudoers; then
     cp /etc/sudoers /etc/sudoers.bak
+    chmod 0440 /etc/sudoers.bak
     if ! grep -P '^[\s]*Defaults.*timestamp_timeout[\s]*=[\s]*[-]?\w+.*$' /etc/sudoers; then
         # sudoers file doesn't define Option timestamp_timeout
         echo "Defaults timestamp_timeout=${var_sudo_timestamp_timeout}" >> /etc/sudoers

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
@@ -19,6 +19,7 @@
     regexp: ^(\/\/)?\\s*{{ item }}.*$
     line: '{{ item }} "true";'
     create: true
+    mode: 0644
   with_items:
   - Unattended-Upgrade::Remove-Unused-Dependencies
   - Unattended-Upgrade::Remove-Unused-Kernel-Packages
@@ -30,4 +31,5 @@
     line: clean_requirements_on_remove=1
     insertafter: '\[main\]'
     create: yes
+    mode: 0644
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/disable_weak_deps/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/disable_weak_deps/ansible/shared.yml
@@ -12,3 +12,4 @@
     value: 0
     create: yes
     state: present
+    mode: 0644

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/ansible/shared.yml
@@ -10,3 +10,4 @@
     option: apply_updates
     value: "yes"
     create: True
+    mode: 0644

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/ansible/shared.yml
@@ -10,3 +10,4 @@
     option: upgrade_type
     value: security
     create: True
+    mode: 0644

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -24,3 +24,4 @@
         value: 1
         no_extra_spaces: yes
         create: True
+        mode: 0644

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -398,6 +398,7 @@ value: :code:`Setting={{ varname1 }}`
     content: |+
         {{{ contents|indent(8) }}}
     force: yes
+    mode: 0644
 {{%- endmacro %}}
 
 
@@ -1490,6 +1491,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
             [default=die]                   pam_faillock.so authfail
             sufficient                      pam_faillock.so authsucc
         force: yes
+        mode: 0644
       when: not faillock_file_stat.stat.exists
 
     - name: {{{ rule_title }}} - Put the content into cac_faillock_notify if it does not exist
@@ -1507,6 +1509,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
           Account:
             required                        pam_faillock.so
         force: yes
+        mode: 0644
       when: not faillock_notify_file_stat.stat.exists
 
     {{{ ansible_apply_pam_auth_update_changes('cac_faillock') | indent(4) }}}
@@ -1677,6 +1680,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
           Password:
             requisite           pam_pwquality.so retry=3
         force: yes
+        mode: 0644
       when: not pwquality_file_stat.stat.exists
 
     {{{ ansible_apply_pam_auth_update_changes('cac_pwquality', rule_title=rule_title) | indent(4) }}}
@@ -2410,6 +2414,7 @@ Part of the grub2_bootloader_argument_absent template.
     ansible.builtin.file:
         path: /etc/rsyslog.conf
         state: touch
+        mode: 0644
         modification_time: preserve
         access_time: preserve
 
@@ -2417,6 +2422,7 @@ Part of the grub2_bootloader_argument_absent template.
     ansible.builtin.file:
         path: /etc/rsyslog.d
         state: directory
+        mode: 0755
 {{%- endmacro -%}}
 
 
@@ -2492,6 +2498,7 @@ lines will be inserted at the beginning of the profile.
     path: "/etc/dconf/profile/{{{ profile }}}"
     line: "{{ item }}"
     create: yes
+    mode: 0644
     state: present
   loop:
     - "user-db:user"

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -265,7 +265,7 @@ value: :code:`Setting={{ varname1 }}`
     modification_time: preserve
     access_time: preserve
 {{%- else %}}
-{{{ ansible_set_config_file(msg, sshd_main_config, parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="BOF", rule_title=rule_title) }}}
+{{{ ansible_set_config_file(msg, sshd_main_config, parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="BOF", mode="0600", rule_title=rule_title) }}}
 {{%- endif %}}
 {{%- endmacro %}}
 
@@ -363,7 +363,7 @@ value: :code:`Setting={{ varname1 }}`
 
 #}}
 {{%- macro ansible_auditd_set(msg='', parameter='', value='', rule_title=None) %}}
-{{{ ansible_set_config_file(msg, "/etc/audit/auditd.conf", parameter=parameter, value=value, create="yes", prefix_regex='(?i)^\s*', separator=" = ", separator_regex="\s*=\s*", rule_title=rule_title) }}}
+{{{ ansible_set_config_file(msg, "/etc/audit/auditd.conf", parameter=parameter, value=value, create="yes", prefix_regex='(?i)^\s*', separator=" = ", separator_regex="\s*=\s*", mode="0640", rule_title=rule_title) }}}
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -221,6 +221,7 @@ done
 {{%- set hardening_config_basename = config_basename or sshd_hardening_config_basename %}}
 {{%- set line_regex = prefix_regex ~ parameter ~ separator_regex %}}
 mkdir -p {{{ sshd_drop_in_dir }}}
+chmod 0700 {{{ sshd_drop_in_dir }}}
 touch {{{ sshd_drop_in_dir }}}/{{{ hardening_config_basename }}}
 chmod 0600 {{{ sshd_drop_in_dir }}}/{{{ hardening_config_basename }}}
 {{{ lineinfile_absent(sshd_config_path, line_regex, insensitive=true, rule_id=rule_id) }}}
@@ -254,9 +255,11 @@ chmod 0600 {{{ sshd_drop_in_dir }}}/{{{ hardening_config_basename }}}
 #}}
 {{%- macro bash_create_audit_remediation_unsuccessful_file_modification_detailed(filename) -%}}
 mkdir -p "$(dirname '{{{ filename }}}')"
+chmod 0750 "$(dirname '{{{ filename }}}')"
 cat <<EOF > "{{{ filename }}}"
 {{{ audit_remediation_unsuccessful_file_modification_detailed_audit_file_content() }}}
 EOF
+chmod 0600 "{{{ filename }}}"
 {{%- endmacro -%}}
 
 
@@ -613,6 +616,7 @@ DCONFFILE="/etc/dconf/db/{{{ db }}}/{{{ setting_file }}}"
 DBDIR="/etc/dconf/db/{{{ db }}}"
 
 mkdir -p "${DBDIR}"
+chmod 0755 "${DBDIR}"
 
 # Comment out the configurations in databases different from the target one
 if [ "${#SETTINGSFILES[@]}" -ne 0 ]
@@ -662,6 +666,7 @@ LOCKFILES=$(grep -r "^/{{{ key }}}/{{{ setting }}}$" "/etc/dconf/db/" \
 LOCKSFOLDER="/etc/dconf/db/{{{ db }}}/locks"
 
 mkdir -p "${LOCKSFOLDER}"
+chmod 0755 "${LOCKSFOLDER}"
 
 # Comment out the configurations in databases different from the target one
 if [[ ! -z "${LOCKFILES}" ]]
@@ -889,6 +894,7 @@ Auth-Type: Primary
 Auth:
     [default=die]                   pam_faillock.so authfail
 EOF
+    chmod 0644 /usr/share/pam-configs/"$conf_name"
 fi
 
 if [ ! -f /usr/share/pam-configs/"$conf_name"_notify ]; then
@@ -904,6 +910,7 @@ Account-Type: Primary
 Account:
     required                        pam_faillock.so
 EOF
+    chmod 0644 /usr/share/pam-configs/"$conf_name"_notify
 fi
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
@@ -948,6 +955,7 @@ Password-Type: Primary
 Password:
     requisite                   pam_pwquality.so
 EOF
+    chmod 0644 /usr/share/pam-configs/"$conf_name"
 fi
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
@@ -966,6 +974,7 @@ if [ ! -f "$conf_path"/"$conf_name" ]; then
     if [ -f "$conf_path"/unix ]; then
         if grep -q "$(md5sum "$conf_path"/unix | cut -d ' ' -f 1)" /var/lib/dpkg/info/libpam-runtime.md5sums;then
             cp "$conf_path"/unix "$conf_path"/"$conf_name"
+            chmod 0644 "$conf_path"/"$conf_name"
             sed -i 's/Priority: [0-9]\+/Priority: 257\
 Conflicts: unix/' "$conf_path"/"$conf_name"
             DEBIAN_FRONTEND=noninteractive pam-auth-update
@@ -1105,6 +1114,7 @@ Password-Type: Primary
 Password: {{{ control }}} pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
 Password-Initial: {{{ control }}} pam_pwhistory.so remember=24 enforce_for_root try_first_pass
 EOF
+    chmod 0644 "$conf_path"/"$conf_name"
 fi
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
@@ -1323,6 +1333,7 @@ if [ -e "{{{ path }}}" ] ; then
 else
     {{%- if create %}}
     touch "{{{ path }}}"
+    chmod 0644 "{{{ path }}}"
     {{%- else %}}
     {{{ die("Path '" + path + "' wasn't found on this system. Refusing to continue.", action="return") | indent(4) }}}
     {{%- endif %}}
@@ -1421,6 +1432,7 @@ rm "{{{ path }}}.bak"
 cat << 'EOF' > {{{ filepath }}}
 {{{ contents }}}
 EOF
+chmod 0644 {{{ filepath }}}
 {{%- endmacro %}}
 
 
@@ -1545,8 +1557,10 @@ done
 #}}
 {{% macro bash_sssd_ensure_default_config(sssd_conf, sssd_conf_dir) -%}}
 mkdir -p "$(dirname "{{{ sssd_conf }}}")"
+chmod 0711 "$(dirname "{{{ sssd_conf }}}")"
 if [ ! -f "{{{ sssd_conf }}}" ]; then
     touch "{{{ sssd_conf }}}"
+    chmod 0600 "{{{ sssd_conf }}}"
 fi
 if ! grep -qsrP '^\s*\[domain\/[^]]*]' "{{{ sssd_conf }}}" "{{{ sssd_conf_dir }}}"/*.conf 2>/dev/null; then
     {{{ bash_ensure_ini_config(sssd_conf, "sssd", "domains", "default") }}}
@@ -2375,6 +2389,7 @@ done
 if ! $found ; then
     file=$(echo "{{{ files }}}" | cut -f1 -d ' ')
     mkdir -p "$(dirname "$file")"
+    chmod 0755 "$(dirname "$file")"
 {{% if no_quotes %}}
     echo -e "[{{{ section }}}]\n{{{ key }}}={{{ value }}}" >> "$file"
 {{% else %}}
@@ -2797,9 +2812,11 @@ lines will be inserted at the beginning of the profile.
 {{% macro bash_enable_dconf_user_profile(profile, database) -%}}
 
 mkdir -p /etc/dconf/profile
+chmod 0755 /etc/dconf/profile
 dconf_profile_path=/etc/dconf/profile/{{{ profile }}}
 
 [[ -s "${dconf_profile_path}" ]] || echo > "${dconf_profile_path}"
+chmod 0644 "${dconf_profile_path}"
 
 if ! grep -Pzq "(?s)^\s*user-db:user.*\n\s*system-db:{{{ database }}}" "${dconf_profile_path}"; then
     sed -i --follow-symlinks "1s/^/user-db:user\nsystem-db:{{{ database }}}\n/" "${dconf_profile_path}"
@@ -2807,6 +2824,7 @@ fi
 
 # Make sure the corresponding directories exist
 mkdir -p /etc/dconf/db/{{{ database }}}.d
+chmod 0755 /etc/dconf/db/{{{ database }}}.d
 
 # Make sure permissions allow regular users to read dconf settings.
 # Also define the umask to avoid `dconf update` changing permissions.

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -184,7 +184,7 @@ test "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)"
         insensitive=true,
         separator=" ",
         separator_regex="\s\+",
-        prefix_regex="^\s*", rule_id=rule_id)
+        prefix_regex="^\s*", rule_id=rule_id, mode="0600")
     }}}
 {{%- endmacro -%}}
 
@@ -283,7 +283,7 @@ chmod 0600 "{{{ filename }}}"
         insensitive=true,
         separator=" = ",
         separator_regex="\s*=\s*",
-        prefix_regex="^\s*", rule_id=rule_id)
+        prefix_regex="^\s*", rule_id=rule_id, mode="0640")
     }}}
 {{%- endmacro -%}}
 
@@ -1324,7 +1324,7 @@ printf '%s\n' "{{{ message | replace('"', '\\"') }}}" >&2
 :type sed_path_separator: char
 
 #}}
-{{%- macro set_config_file(path, parameter, value, create, insert_after, insert_before, insensitive=true, separator=" ", separator_regex="\s\+", prefix_regex="^\s*", sed_path_separator="/", rule_id=None) -%}}
+{{%- macro set_config_file(path, parameter, value, create, insert_after, insert_before, insensitive=true, separator=" ", separator_regex="\s\+", prefix_regex="^\s*", sed_path_separator="/", rule_id=None, mode="0644") -%}}
     {{%- set new_line = parameter+separator~value -%}}
     {{#- An escaped dollar in the parameter is escaped because of its significance for the shell, so when making a regex out of the parameter, we remove the shell escape, as the regex escape will do its thing. -#}}
     {{%- set line_regex = prefix_regex + ((parameter | replace("\\$", "$") | escape_regex) | replace("/", "\/")) + separator_regex -%}}
@@ -1333,7 +1333,7 @@ if [ -e "{{{ path }}}" ] ; then
 else
     {{%- if create %}}
     touch "{{{ path }}}"
-    chmod 0644 "{{{ path }}}"
+    chmod {{{ mode }}} "{{{ path }}}"
     {{%- else %}}
     {{{ die("Path '" + path + "' wasn't found on this system. Refusing to continue.", action="return") | indent(4) }}}
     {{%- endif %}}

--- a/shared/templates/accounts_password/ansible.template
+++ b/shared/templates/accounts_password/ansible.template
@@ -53,3 +53,4 @@
     dest: "{{{ pwquality_path }}}"
     regexp: '^#?\s*{{{ VARIABLE }}}'
     line: "{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}"
+    mode: 0644

--- a/shared/templates/audit_rules_syscall_events/ansible.template
+++ b/shared/templates/audit_rules_syscall_events/ansible.template
@@ -45,12 +45,14 @@
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     create: yes
+    mode: 0600
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on 64bit
   ansible.builtin.lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     create: yes
+    mode: 0600
   when: audit_arch is defined and audit_arch == 'b64'
 #
 # Inserts/replaces the rule in /etc/audit/audit.rules
@@ -61,6 +63,7 @@
     state: present
     dest: /etc/audit/rules.d/audit.rules
     create: yes
+    mode: 0600
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/rules.d/audit.rules when on 64bit
   ansible.builtin.lineinfile:
@@ -68,4 +71,5 @@
     state: present
     dest: /etc/audit/rules.d/audit.rules
     create: yes
+    mode: 0600
   when: audit_arch is defined and audit_arch == 'b64'

--- a/shared/templates/cis_banner/ansible.template
+++ b/shared/templates/cis_banner/ansible.template
@@ -10,3 +10,4 @@
   ansible.builtin.copy:
     content: "{{ cis_banner_text }}"
     dest: {{{ FILEPATH }}}
+    mode: 0644

--- a/shared/templates/cis_banner/bash.template
+++ b/shared/templates/cis_banner/bash.template
@@ -5,3 +5,4 @@
 # disruption = low
 {{{ bash_instantiate_variables("cis_banner_text") }}}
 echo "$cis_banner_text" > "{{{ FILEPATH }}}"
+chmod 0644 "{{{ FILEPATH }}}"

--- a/shared/templates/dconf_ini_file/ansible.template
+++ b/shared/templates/dconf_ini_file/ansible.template
@@ -18,6 +18,7 @@
     option: {{{ PARAMETER }}}
     value: "{{{ VALUE }}}"
     create: yes
+    mode: 0644
   when: {{{ rule_id }}}_config_files is defined and {{{ rule_id }}}_config_files.matched == 0
   register: default_file
 
@@ -28,6 +29,7 @@
     option: {{{ PARAMETER }}}
     value: "{{{ VALUE }}}"
     create: yes
+    mode: 0644
   with_items: "{{ {{{ rule_id }}}_config_files.files }}"
   when: {{{ rule_id }}}_config_files is defined and {{{ rule_id }}}_config_files.matched > 0
   register: existing_files
@@ -44,6 +46,7 @@
     regexp: '^/{{{ SECTION }}}/{{{ PARAMETER }}}$'
     line: '/{{{ SECTION }}}/{{{ PARAMETER }}}'
     create: yes
+    mode: 0644
   when: {{{ rule_id }}}_lock_files is defined and {{{ rule_id }}}_lock_files.matched == 0
 
 - name: "Prevent user modification {{{ PARAMETER }}} - existing files"
@@ -52,6 +55,7 @@
     regexp: '^/{{{ SECTION }}}/{{{ PARAMETER }}}$'
     line: '/{{{ SECTION }}}/{{{ PARAMETER }}}'
     create: yes
+    mode: 0644
   with_items: "{{ {{{ rule_id }}}_lock_files.files }}"
   when: {{{ rule_id }}}_lock_files is defined and {{{ rule_id }}}_lock_files.matched > 0
 

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -9,6 +9,7 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: 'install\s+{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/false"
+    mode: 0644
 {{% if 'ol' in families or 'rhel' in product or 'sle' in product or 'slmicro' in product or 'ubuntu' in product %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
   ansible.builtin.lineinfile:
@@ -16,4 +17,5 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: '^blacklist {{{ KERNMODULE }}}$'
     line: "blacklist {{{ KERNMODULE }}}"
+    mode: 0644
 {{% endif %}}

--- a/shared/templates/pam_account_password_faillock/bash.template
+++ b/shared/templates/pam_account_password_faillock/bash.template
@@ -4,6 +4,7 @@
 PAM_FAILLOCK_DEFAULTS_FILE_NAME="/usr/etc/security/faillock.conf"
 if ! [ -e "{{{ pam_faillock_conf_path }}}" ] ; then
     cp "${PAM_FAILLOCK_DEFAULTS_FILE_NAME}" "{{{ pam_faillock_conf_path }}}"
+    chmod 0644 "{{{ pam_faillock_conf_path }}}"
 fi
 {{% endif %}}
 

--- a/shared/templates/systemd_dropin_configuration/ansible.template
+++ b/shared/templates/systemd_dropin_configuration/ansible.template
@@ -56,4 +56,5 @@
     state: present
     no_extra_spaces: true
     create: true
+    mode: 0644
   when: count_of_systemd_dropin_files_with_section | int == 0

--- a/shared/templates/zipl_bls_entries_option/ansible.template
+++ b/shared/templates/zipl_bls_entries_option/ansible.template
@@ -40,6 +40,7 @@
         create: yes
         path: "/etc/kernel/cmdline"
         line: '{{{ ARG_NAME }}}={{{ ARG_VALUE }}}'
+        mode: 0644
       when: cmdline_stat is defined and not cmdline_stat.stat.exists
 
     - name: "Append /etc/kernel/cmdline contains {{{ ARG_NAME }}}={{{ ARG_VALUE }}}"

--- a/shared/templates/zipl_bls_entries_option/bash.template
+++ b/shared/templates/zipl_bls_entries_option/bash.template
@@ -6,6 +6,7 @@ grubby --update-kernel=ALL --args="{{{ ARG_NAME }}}={{{ ARG_VALUE }}}"
 # Ensure new kernels and boot entries retain the boot option
 if [ ! -f /etc/kernel/cmdline ]; then
     echo "{{{ ARG_NAME }}}={{{ ARG_VALUE }}}" > /etc/kernel/cmdline
+    chmod 0644 /etc/kernel/cmdline
 elif ! grep -q '^(.*\s)?{{{ ARG_NAME }}}={{{ ARG_VALUE }}}(\s.*)?$' /etc/kernel/cmdline; then
     {{% if '/' in ARG_NAME %}}
     {{{ raise("ARG_NAME (" + ARG_NAME + ") uses sed path separator (" + sed_separator + ") in " + rule_id) }}}


### PR DESCRIPTION
### Description

Ansible and bash remediations create files without setting permissions explicitly. The resulting permissions depend on the process
`umask`. On default RHEL (`umask 0022`) that produces `0644`, but on hardened systems with a stricter `umask` the result is
unpredictable.

This PR adds explicit permissions to file-creating remediations in:

- Macros (Ansible and bash)
- Templates
- Standalone remediations

### Rationale

Remediation output must be deterministic. File permissions must not depend on the runtime `umask`.

#### Permissions by path pattern

Each remediation explicitly enforces the mode for the file or directory it creates, sourced one
of the following ways:

- An OVAL check exists
  - the mode matches what that check expects
- No OVAL check, but an RPM package ships the file
  - the mode matches the RPM default (`rpm -qlv`)
- No OVAL check, no RPM (the remediation creates the file from scratch)
  - the mode matches what the default `umask 0022` produces on most systems
  - made explicit anyway, because other hardening controls (STIG or CIS `UMASK` settings in
    `/etc/login.defs`) can tighten the `umask`, which would silently change this result if left
    implicit

Files restricted to `root`, not world-readable, because each contains something sensitive or
security-critical:
- `0600` — `/etc/audit/rules.d/*.rules` (OVAL enforced), `/etc/ssh/sshd_config` and
  `/etc/ssh/sshd_config.d/*.conf`, `/etc/sssd/` files
- `0640` — `/etc/audit/auditd.conf` (RPM default)
- `0440` — `/etc/sudoers`, `/etc/sudoers.d/*` (must never be group or world writable, editable
  only through `visudo`)
- `0000` — `/etc/shadow-` (password hash backup, readable only by `root`)

Directories, permission set by what needs to reach the files inside:
- `0755` — `/etc/cron.daily/*`, directories in general (traversable by everyone, matching the
  world-readable files they usually contain)
- `0711` — `/etc/sssd/` directories (traversable so the `sssd` service can reach a specific file,
  not listable, hides which files exist)
- `0700` — `/etc/ssh/sshd_config.d/` (fully private, matching the `0600` files inside)

World-readable, because none of these files contain sensitive data and each is read by a
non-root process or user (all `0644`):
- `/etc/profile.d/*.sh` (shell profile scripts, sourced by every user's login shell)
- `/etc/systemd/system/*.service.d/*.conf` (systemd drop-ins, read by `systemd` at service start)
- `/etc/security/limits.d/*.conf` (PAM limits drop-ins, read by the PAM stack during any user's
  login)
- `/etc/tmpfiles.d/*.conf` (systemd tmpfiles, read by `systemd-tmpfiles` at boot)
- `/etc/permissions.local` (SUSE permissions config)
- everything else

#### What this PR does not change, and why

- `owner:` and `group:` are not set, because remediations run as `root` and every created file is
  already owned by `root:root`. Adding `owner: root` and `group: root` explicitly to every task
  inflates the diff without changing the resulting file ownership.

- `/etc/sssd/sssd.conf` keeps mode `0600` even though the RPM default is `0640`:
  - Every rule using the [`bash_sssd_ensure_default_config`](https://github.com/ComplianceAsCode/content/blob/main/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh#L9-L10)
    macro wraps the fix in `umask u=rw,go=`
  - The comment there reads: "sssd configuration files must be created with 600 permissions if
    they don't exist otherwise the sssd module fails to start"
  - Changing to `0640` risks breaking SSSD startup on affected systems

- The `ansible.posix.sysctl`, `ansible.builtin.cron`, and `ansible.posix.mount` Ansible modules
  don't accept a `mode:` parameter (confirmed from `ansible-doc`). Nothing to fix here.

- The `ansible.builtin.replace` Ansible module never creates files. Fails with "Path does not
  exist" if the target is missing (confirmed from its module source
  `ansible/modules/replace.py` line 254).

- The `ansible_shell_set`, `ansible_selinux_config_set`, and `ansible_login_defs` macros call
  the `ansible.builtin.lineinfile` Ansible module with `create: yes` and no `mode` parameter.
  The RPM package that installs each target file already sets it to `0644`, so the result is
  correct anyway. The `ansible_selinux_config_set` and `ansible_login_defs` macros always write
  to the same file; `ansible_shell_set` writes to whatever path its caller passes in instead:
  - `ansible_selinux_config_set` always writes to `/etc/selinux/config`
  - `ansible_login_defs` always writes to `/etc/login.defs`
  - `ansible_shell_set` writes to whatever path its caller passes, `/etc/sysconfig/sshd` is one
    example caller

### Changes

- Macros (`shared/macros/10-ansible.jinja`, `shared/macros/10-bash.jinja`): added `mode:`/`chmod`
  so every caller inherits explicit permissions automatically.

- Templates (`shared/templates/`): added `mode:`/`chmod` to file-creating templates so every rule
  using them is covered in one place.

- Handwritten remediations (`linux_os/`): rule-specific `bash/shared.sh` or `ansible/shared.yml`
  files that don't call a macro or template, added `mode:` or `chmod` directly.

- Bash remediations that create drop-in files via shell redirect (`>>`, `>`, `cat >`) without
  `chmod`. See "Permissions by path pattern" above for why each mode was chosen. Affects these
  rules:
  - `require_emergency_target_auth` (systemd drop-in
    `/etc/systemd/system/emergency.service.d/10-oscap.conf`)
  - `disable_users_coredumps` (PAM limits drop-in `/etc/security/limits.d/10-ssg-hardening.conf`)
  - `sshd_use_directory_configuration` (`/etc/ssh/sshd_config` had no explicit `chmod`, so it
    landed at `0644` implicitly via the default `umask` instead of the `0600` it needs)
  - `accounts_tmout` (`/etc/profile.d/tmout.sh`)
  - `audit_rules_immutable_login_uids` (`/etc/audit/rules.d/immutable.rules`)

- Ansible remediations using the `ansible_lineinfile` macro with `create: yes` but no `mode=`
  parameter, so the file it creates gets no explicit mode. Affects these rules:
  - `accounts_tmout` (`/etc/profile.d/tmout.sh`)
  - `rootfiles_configured` (`/etc/tmpfiles.d/rootfiles.conf`)
  - `permissions_local_var_log_audit` (`/etc/permissions.local`, 4 `ansible_lineinfile` calls)

- Ansible remediations with unquoted octal `mode:` values. This PR introduces roughly 200 of
  these across `linux_os/`. All of them produce the correct permission today (for example,
  `mode: 0644` renders as `mode: 420` in the built playbook, which Ansible still applies as
  `rw-r--r--`), but would break under a stricter YAML 1.2 parser. These rules were quoted after
  review:
  - `require_emergency_target_auth`
  - `disable_users_coredumps`
  - `require_singleuser_auth`

  The rest will be fixed in a future PR.

- The macros `ansible_auditd_set` and `ansible_sshd_set` were missing `mode:`. The
  `ansible_set_config_file` macro they call already accepts a `mode=` parameter, so the fix
  was adding `mode="0640"` and `mode="0600"` to these two call sites, not new plumbing:
  - `ansible_auditd_set` (`shared/macros/10-ansible.jinja`) is unused by any ComplianceAsCode
    rule today, but is now correct if a future rule calls it
  - `ansible_sshd_set` writes directly into `/etc/ssh/sshd_config` in one mode, and to a
    separate drop-in file under `/etc/ssh/sshd_config.d/` in another (controlled by
    `config_is_distributed`). Only the first way was missing `mode:`; the drop-in way already
    sets it via a separate task. Verified on the `ol8` product with the `sshd_rekey_limit` rule.

### How to test

- Run `./build_product rhel10` and confirm it passes.
- Run in Contest: the daily test suite, and the per-rule tests covering both `ansible` and
  `oscap` (bash).

Assisted by Claude.
