### PR TITLE
Fix unit tests metadata

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disable_recommends/tests/recommends_disabled.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disable_recommends/tests/recommends_disabled.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 
 cat > /etc/apt/apt.conf.d/00-disable-recommends <<EOF
 APT::Install-Recommends "0";

--- a/linux_os/guide/services/apt/apt_conf_disable_suggests/tests/suggests_disabled.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disable_suggests/tests/suggests_disabled.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 
 cat > /etc/apt/apt.conf.d/00-disable-suggests <<EOF
 APT::Install-Suggests "0";


### PR DESCRIPTION
Setting `remediation=none` doesn't make sense for a `.pass.sh` test. Fixes failing test `/static-checks/unit-tests-metadata` in daily productization.


