### PR TITLE
CMP-4441: Add rule kubevirt-seccomp-profile-permissions (CIS OCP-Virt 1.8)

### DIFF
--- a/applications/openshift-virtualization/kubevirt-seccomp-profile-permissions/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-seccomp-profile-permissions/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+
+platform: '{{{ product }}}-node'
+
+{{%- set kubeletconf_path = "/var/lib/kubelet/seccomp/kubevirt/kubevirt.json" %}}
+
+
+title: 'Ensure kubevirt seccomp profile file permission is set to 700 or more restrictive'
+
+description: |-
+    {{{ describe_file_permissions(file=kubeletconf_path, perms="0700") }}}
+
+rationale: |-
+    This configuration ensures that only authorized users have access to modify the 
+    seccomp profile, thereby preventing unauthorized alterations to the allowed system calls for 
+    virt-launcher pods. By enforcing stringent permission controls, potential security risks 
+    associated with unrestricted access to sensitive system calls can be mitigated.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file=kubeletconf_path, perms="-rwx------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file=kubeletconf_path, perms="-rwx------") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: {{{ kubeletconf_path }}}
+        filemode: '0700'

--- a/applications/openshift-virtualization/kubevirt-seccomp-profile-permissions/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-seccomp-profile-permissions/rule.yml
@@ -1,10 +1,8 @@
 documentation_complete: true
 
-
 platform: '{{{ product }}}-node'
 
 {{%- set kubeletconf_path = "/var/lib/kubelet/seccomp/kubevirt/kubevirt.json" %}}
-
 
 title: 'Ensure kubevirt seccomp profile file permission is set to 700 or more restrictive'
 
@@ -12,9 +10,9 @@ description: |-
     {{{ describe_file_permissions(file=kubeletconf_path, perms="0700") }}}
 
 rationale: |-
-    This configuration ensures that only authorized users have access to modify the 
-    seccomp profile, thereby preventing unauthorized alterations to the allowed system calls for 
-    virt-launcher pods. By enforcing stringent permission controls, potential security risks 
+    This configuration ensures that only authorized users have access to modify the
+    seccomp profile, thereby preventing unauthorized alterations to the allowed system calls for
+    virt-launcher pods. By enforcing stringent permission controls, potential security risks
     associated with unrestricted access to sensitive system calls can be mitigated.
 
 severity: medium

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -29,3 +29,4 @@ description: |-
 
 selections:
     - kubevirt-nested-virtualization-disabled
+    - kubevirt-seccomp-profile-permissions


### PR DESCRIPTION
## Summary

- Adds OpenSCAP node rule `kubevirt-seccomp-profile-permissions` checking that
  `/var/lib/kubelet/seccomp/kubevirt/kubevirt.json` has mode 0700 or more restrictive
- Uses the `file_permissions` template — passes when the file is absent (compliant
  by default on non-virt nodes)
- Adds the rule to the `cis-vm-extension-node` profile selections

## Depends on

- #14930 (adds the `cis-vm-extension-node` profile and `kubevirt-nested-virtualization-disabled` rule)

## Test plan

Validated on a live OCP cluster (OCP 4.22, RHEL 10, TechPreviewNoUpgrade):
- [x] File absent → PASS
- [x] File present with wrong permissions (0777) → FAIL
- [x] File present with correct permissions (0700) → PASS