### PR TITLE
Sle16 dropin hipaa fixes

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/ansible/shared.yml
@@ -9,6 +9,7 @@
     regexp: 'ttyS[0-9]'
     state: absent
 
-{{% if product == "sle16" %}}
+{{% if product in ['sle16', 'slmicro6'] %}}
+{{{ ansible_copy_distro_defaults('/usr/lib/pam.d/login', '/etc/pam.d/login', rule_title=rule_title) }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_securetty.so', 'noconsole', '', '', rule_id=rule_id, rule_title=rule_title) }}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/ansible/shared.yml
@@ -9,7 +9,7 @@
     regexp: 'ttyS[0-9]'
     state: absent
 
-{{% if product in ['sle16', 'slmicro6'] %}}
+{{% if product in ['sle16'] %}}
 {{{ ansible_copy_distro_defaults('/usr/lib/pam.d/login', '/etc/pam.d/login', rule_title=rule_title) }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_securetty.so', 'noconsole', '', '', rule_id=rule_id, rule_title=rule_title) }}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/bash/shared.sh
@@ -1,6 +1,7 @@
 # platform = multi_platform_all
 sed -i '/ttyS/d' /etc/securetty
 
-{{% if product == "sle16" %}}
+{{% if product in ['sle16', 'slmicro6'] %}}
+{{{ bash_copy_distro_defaults("/usr/lib/pam.d/login", "/etc/pam.d/login") }}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_securetty.so', 'noconsole', '', '') }}}
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
@@ -3,6 +3,20 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
+
+{{% if product in [ 'sle16', 'slmicro6' ] %}}
+- name: "{{{ rule_title }}} - set package manager config path fact"
+  ansible.builtin.set_fact:
+    _pkg_manager_config_file: {{{ pkg_manager_config_file }}}
+
+- name: "{{{ rule_title }}} - ensure package manager config directory exists"
+  ansible.builtin.file:
+    path: "{{ _pkg_manager_config_file | dirname }}"
+    state: directory
+    mode: '0755'
+
+{{{ ansible_copy_distro_defaults("/usr/etc/zypp/zypp.conf", pkg_manager_config_file, rule_title=rule_title) }}}
+{{% endif %}}
 - name: Ensure GPG check is globally activated
   community.general.ini_file:
     dest: {{{ pkg_manager_config_file }}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
@@ -5,16 +5,6 @@
 # disruption = medium
 
 {{% if product in [ 'sle16', 'slmicro6' ] %}}
-- name: "{{{ rule_title }}} - set package manager config path fact"
-  ansible.builtin.set_fact:
-    _pkg_manager_config_file: {{{ pkg_manager_config_file }}}
-
-- name: "{{{ rule_title }}} - ensure package manager config directory exists"
-  ansible.builtin.file:
-    path: "{{ _pkg_manager_config_file | dirname }}"
-    state: directory
-    mode: '0755'
-
 {{{ ansible_copy_distro_defaults("/usr/etc/zypp/zypp.conf", pkg_manager_config_file, rule_title=rule_title) }}}
 {{% endif %}}
 - name: Ensure GPG check is globally activated
@@ -24,4 +14,8 @@
     option: gpgcheck
     value: 1
     no_extra_spaces: yes
+{{% if product in ['sle16', 'slmicro6'] %}}
+    create: True
+{{% else %}}
     create: False
+{{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
@@ -1,7 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
 
 {{% if product in ['sle16', 'slmicro6'] %}}
-    mkdir -p "$(dirname '{{{ pkg_manager_config_file }}}')"
     {{{ bash_copy_distro_defaults("/usr/etc/zypp/zypp.conf", pkg_manager_config_file) }}}
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
@@ -1,3 +1,8 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
 
+{{% if product in ['sle16', 'slmicro6'] %}}
+    mkdir -p "$(dirname '{{{ pkg_manager_config_file }}}')"
+    {{{ bash_copy_distro_defaults("/usr/etc/zypp/zypp.conf", pkg_manager_config_file) }}}
+{{% endif %}}
+
 {{{ bash_replace_or_append( pkg_manager_config_file , '^gpgcheck', '1', cce_identifiers=cce_identifiers) }}}


### PR DESCRIPTION
#### Description:

- Add some fixes for HIPAA profile for SLE16 platform

#### Rationale:

- Make sure to have existing pkg_manager_config_file and containing dir for ensure_gpgcheck_globally_activated rule

-  Fix remediations for restrict_serial_port_logins to copy vendor config in case /etc/pam.d/login file does not exist in etc

