### PR TITLE
CMP-4442: Add rule kubevirt-cache-directory-permissions (CIS OCP-Virt 1.9)

### DIFF
--- a/applications/openshift-virtualization/kubevirt-cache-directory-permissions/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-cache-directory-permissions/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+platform: '{{{ product }}}-node'
+
+{{%- set kubevirt_cache_dir = "/var/run/kubevirt-private/" %}}
+
+title: 'Ensure kubevirt cache directory permission is set to 755 or more restrictive'
+
+description: |-
+    {{{ describe_file_permissions(file=kubevirt_cache_dir, perms="0755") }}}
+
+rationale: |-
+    Setting the kubevirt private directory to 755 or more restrictive limits access to
+    security related administrative functionality to approved administrators.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file=kubevirt_cache_dir, perms="-rwxr-xr-x") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file=kubevirt_cache_dir, perms="-rwxr-xr-x") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: {{{ kubevirt_cache_dir }}}
+        filemode: '0755'

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -28,4 +28,5 @@ description: |-
     cis-vm-extension profile.
 
 selections:
+    - kubevirt-cache-directory-permissions
     - kubevirt-nested-virtualization-disabled


### PR DESCRIPTION
## Summary

- Adds OpenSCAP node rule `kubevirt-cache-directory-permissions` checking that
  `/var/run/kubevirt-private/` has mode 0755 or more restrictive
- Uses the `file_permissions` template — passes when the directory is absent
  (compliant by default on non-virt nodes)
- Adds the rule to the `cis-vm-extension-node` profile selections

## Depends on

- #14930 (adds the `cis-vm-extension-node` profile and `kubevirt-nested-virtualization-disabled` rule)

## Test plan

Validated on a live OCP cluster (OCP 4.22, RHEL 10, TechPreviewNoUpgrade):
- [x] Directory absent → PASS
- [x] Directory present with wrong permissions (0777) → FAIL
- [x] Directory present with correct permissions (0755) → PASS