### PR TITLE
Add missing tests for rules selected in RHEL 10 STIG profile

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/auditctl_correct_rule.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = audit
+
+{{{ setup_auditctl_environment() }}}
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+
+echo "-a always,exit -F arch=b32 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_correct_rule.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+
+echo "-a always,exit -F arch=b32 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_correct_with_other_syscalls.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_correct_with_other_syscalls.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+
+echo "-a always,exit -F arch=b32 -S umount,umount2 -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_rules_not_there.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_rules_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_wrong_list_action.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_wrong_list_action.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+
+echo "-a never,exit -F arch=b32 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_wrong_syscall.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/tests/augenrules_wrong_syscall.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+
+echo "-a always,exit -F arch=b32 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/tests/key_with_passphrase.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/tests/key_with_passphrase.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = openssh-clients
+# check = sce
+
+# Remove any existing SSH key pairs for all interactive users
+for dir in $(awk -F: '$7 !~ /\/s?bin\/(false|nologin)/ {print $6}' /etc/passwd | sort -u); do
+    for pubkey in $(find "${dir}/.ssh/" -type f -name '*.pub' 2>/dev/null); do
+        rm -f "${pubkey}" "${pubkey%.pub}"
+    done
+done
+
+# Create an SSH key pair with a passphrase for root
+ssh-keygen -t rsa -b 2048 -f /root/.ssh/test_key -N "testpassphrase" -q

--- a/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/tests/key_without_passphrase.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/tests/key_without_passphrase.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = openssh-clients
+# check = sce
+# remediation = none
+
+# Remove any existing SSH key pairs for all interactive users
+for dir in $(awk -F: '$7 !~ /\/s?bin\/(false|nologin)/ {print $6}' /etc/passwd | sort -u); do
+    for pubkey in $(find "${dir}/.ssh/" -type f -name '*.pub' 2>/dev/null); do
+        rm -f "${pubkey}" "${pubkey%.pub}"
+    done
+done
+
+# Create an SSH key pair without a passphrase for root
+ssh-keygen -t rsa -b 2048 -f /root/.ssh/test_key -N "" -q

--- a/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/tests/no_keys.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/tests/no_keys.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = openssh-clients
+# check = sce
+
+# Remove any existing SSH key pairs for all interactive users
+# Preserve authorized_keys and other non-key files so Automatus can still SSH in
+for dir in $(awk -F: '$7 !~ /\/s?bin\/(false|nologin)/ {print $6}' /etc/passwd | sort -u); do
+    for pubkey in $(find "${dir}/.ssh/" -type f -name '*.pub' 2>/dev/null); do
+        rm -f "${pubkey}" "${pubkey%.pub}"
+    done
+done

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -47,8 +47,9 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_nx_disabled_grub" version="1">
-    {{% if product in ['ol9'] %}}
-    <ind:filepath>/etc/default/grub</ind:filepath>
+    {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhel10"] %}}
+    <ind:path>/boot/loader/entries</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{% else %}}
     <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     {{% endif %}}

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -47,7 +47,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_nx_disabled_grub" version="1">
-    {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhel10"] %}}
+    {{% if 'rhel' in product or product in ["fedora", "ol8", "ol9"] %}}
     <ind:path>/boot/loader/entries</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{% else %}}

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/tests/noexec_absent.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/tests/noexec_absent.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_rhel
+
+grubby --update-kernel=ALL --remove-args=noexec

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/tests/noexec_off.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/tests/noexec_off.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_rhel
+
+grubby --update-kernel=ALL --args="noexec=off"

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -273,7 +273,7 @@
   The uses_* flags control which locations are verified per product.
 -#}}
 
-{{% set uses_boot_loader_entries   = product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhel10"] %}}
+{{% set uses_boot_loader_entries   = 'rhel' in product or product in ["fedora", "ol8", "ol9"] %}}
 {{% set uses_kernelopts            = product in ["ol8", "rhel8"] %}}
 {{% set uses_etc_default_grub_d    = 'ubuntu' in product or 'debian' in product %}}
 {{% set uses_grub_cfg              = product in ["ol7"] or 'ubuntu' in product or 'debian' in product %}}


### PR DESCRIPTION
Introducing test scenarios for the following rules:
```
audit_rules_dac_modification_umount
ssh_keys_passphrase_protected
sysctl_kernel_exec_shield
```

Related to https://redhat.atlassian.net/browse/OPENSCAP-7022
