### PR TITLE
CMP-4444: Add rule kubevirt-vcpu-metrics-enabled (CIS OCP-Virt 6.2)

### DIFF
--- a/applications/openshift-virtualization/kubevirt-vcpu-metrics-enabled/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-vcpu-metrics-enabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+platform: '{{{ product }}}-node'
+
+title: 'Ensure vCPU metrics are enabled'
+
+description: |-
+    OpenShift Virtualization provides metrics that you can use to monitor the
+    consumption of cluster infrastructure resources, including virtual CPU
+    (vCPU). In order to use the vCPU metric, the <tt>schedstats=enable</tt>
+    kernel argument must be applied.
+
+rationale: |-
+    Metrics are a fundamental mechanism for understanding if the guest is
+    behaving in an anomalous or otherwise suspicious manner.
+
+severity: medium
+
+ocil_clause: 'schedstats is not enabled in the kernel command line'
+
+ocil: |-
+    Verify if the option is enabled in the kernel command line:
+    <pre>$ cat /proc/cmdline | grep schedstats=enable</pre>
+
+template:
+    name: coreos_kernel_option
+    vars:
+        arg_name: schedstats
+        arg_value: enable

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -29,3 +29,4 @@ description: |-
 
 selections:
     - kubevirt-nested-virtualization-disabled
+    - kubevirt-vcpu-metrics-enabled


### PR DESCRIPTION
## Summary

- Adds OpenSCAP node rule `kubevirt-vcpu-metrics-enabled` checking that
  `schedstats=enable` is present in the kernel command line and boot loader entries
- Uses the `coreos_kernel_option` template which checks both `/proc/cmdline`
  and `/boot/loader/entries/ostree-*.conf`
- Adds the rule to the `cis-vm-extension-node` profile selections

## Depends on

- #14930 (adds the `cis-vm-extension-node` profile and `kubevirt-nested-virtualization-disabled` rule)

## Test plan

Validated on a live OCP cluster (OCP 4.22, RHEL 10, TechPreviewNoUpgrade):
- [x] `schedstats=enable` absent → FAIL
- [x] `schedstats=enable` present (via MachineConfig) → PASS