### PR TITLE
Prevent file_ownership/groupownership_home_directories from chowning /

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/ansible/shared.yml
@@ -24,6 +24,7 @@
   when:
     - item.value[1]|int >= {{{ uid_min }}}
     - item.value[1]|int != {{{ nobody_uid }}}
+    - item.value[4] != "/"
 
 - name: Ensure interactive local users are the group-owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chgrp -f " $4" "$6) }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && $6 != "/") system("chgrp -f " $4" "$6) }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/ansible/shared.yml
@@ -24,6 +24,7 @@
   when:
     - item.value[1]|int >= {{{ uid_min }}}
     - item.value[1]|int != {{{ nobody_uid }}}
+    - item.value[4] != "/"
 
 - name: Ensure interactive local users are the owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chown -f " $3" "$6) }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && $6 != "/") system("chown -f " $3" "$6) }' /etc/passwd


### PR DESCRIPTION
#### Description:
- Prevent file_ownership_home_directories and file_groupownership_home_directories from chowning /
  - A user whose /etc/passwd home-directory field is "/" (e.g. a systemd DynamicUser service account like chrony-wait, which uses "/" as a placeholder home and a nologin shell) falls inside the interactive UID range, causing these rules' remediation to chown/chgrp the root filesystem to that account. The OVAL check already excludes nologin/false-shell accounts and never flags this, so the corruption only shows up via other rules (e.g. rpm_verify_ownership) after an ansible-based remediation run. Add the same "home dir != /" guard already present in the sibling accounts_users_home_files_ownership/accounts_users_home_files_groupownership rules to both rules, for example.


#### Rationale:
- Fixes #14933

#### Review Hints

Since we are talking about a very specific architecture here, the best way to test this pull request is to run contest on EL 10 on either emulated ppc64le or online available systems and run the BSI profile verification with the ansible remediation aka /hardening/host-os/ansible/bsi

In my tests, the waiver started waiving a pass test as observed by the comment below.