### PR TITLE
Prevent duplicate keys in YAML files

### DIFF
--- a/applications/openshift/api-server/api_server_tls_security_profile_custom_min_tls_version/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_security_profile_custom_min_tls_version/rule.yml
@@ -48,7 +48,6 @@ warnings:
     - general: |-
         {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/apiservers/cluster") | indent(8) }}}
 
-template:
 template: 
     name: yamlfile_value
     vars: 

--- a/applications/openshift/networking/ingress_controller_tls_security_profile_custom_min_tls_version/rule.yml
+++ b/applications/openshift/networking/ingress_controller_tls_security_profile_custom_min_tls_version/rule.yml
@@ -48,7 +48,6 @@ warnings:
     - general: |-
         {{{ openshift_cluster_setting("/apis/operator.openshift.io/v1/namespaces/openshift-ingress-operator/ingresscontrollers/default") | indent(8) }}}
 
-template:
 template: 
     name: yamlfile_value
     vars: 

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
@@ -65,15 +65,3 @@ template:
             - value: '\"audit-log-path\"\s*:\s*\[\s*\".+\"\s*\]'
               type: "string"
               operation: "pattern match"
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.apiServerArguments[:]'
-        check_existence: "none_exist"
-        values:
-            - key: 'basic-auth-file'
-              type: "string"
-              operation: "pattern match"
-

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
@@ -59,8 +59,6 @@ references:
     stigid@ol8: OL08-00-030490
     stigid@sle12: SLES-12-020460
 
-ocil_clause: 'the system is not configured to audit permission changes'
-
 {{{ complete_ocil_entry_audit_syscall(syscall="chmod") }}}
 
 warnings:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -59,9 +59,6 @@ ocil: |-
 
 ocil_clause: the command does not return a line, or the line is commented out
 
-fixtext: |-
-    {{{ fixtext_audit_rules("rename", "perm_mod", "perm_mod") | indent(4) }}}
-
 srg_requirement: '{{{ srg_requirement_audit_syscall("rename") }}}'
 
 warnings:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -65,8 +65,6 @@ ocil: |-
 
 ocil_clause: the command does not return a line, or the line is commented out
 
-fixtext: |-
-    {{{ fixtext_audit_rules("renameat", "perm_mod", "perm_mod") | indent(4) }}}
 
 srg_requirement: '{{{ srg_requirement_audit_syscall("renameat") }}}'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -71,9 +71,6 @@ ocil: |-
 
 ocil_clause: the command does not return a line, or the line is commented out
 
-fixtext: |-
-    {{{ fixtext_audit_rules("unlink", "perm_mod", "perm_mod") | indent(4) }}}
-
 srg_requirement: '{{{ srg_requirement_audit_syscall("unlink") }}}'
 
 warnings:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -68,9 +68,6 @@ ocil: |-
 
 ocil_clause: the command does not return a line, or the line is commented out
 
-fixtext: |-
-    {{{ fixtext_audit_rules("unlinkat", "perm_mod", "perm_mod") | indent(4)}}}
-
 srg_requirement: '{{{ srg_requirement_audit_syscall("unlinkat") }}}'
 
 warnings:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
@@ -55,6 +55,4 @@ references:
     nist-csf: DE.AE-3,DE.AE-5,DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.AC-3,PR.PT-1,PR.PT-4,RS.AN-1,RS.AN-4
     pcidss: Req-10.4.2.b
 
-ocil_clause: 'the system is not configured to audit time changes'
-
 {{{ complete_ocil_entry_audit_syscall(syscall="adjtimex") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/rule.yml
@@ -52,7 +52,5 @@ references:
     nist-csf: DE.AE-3,DE.AE-5,DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.AC-3,PR.PT-1,PR.PT-4,RS.AN-1,RS.AN-4
     pcidss: Req-10.4.2.b
 
-ocil_clause: 'the system is not configured to audit time changes'
-
 {{{ complete_ocil_entry_audit_syscall(syscall="clock_settime") }}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
@@ -55,6 +55,4 @@ references:
     nist-csf: DE.AE-3,DE.AE-5,DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.AC-3,PR.PT-1,PR.PT-4,RS.AN-1,RS.AN-4
     pcidss: Req-10.4.2.b
 
-ocil_clause: 'the system is not configured to audit time changes'
-
 {{{ complete_ocil_entry_audit_syscall(syscall="settimeofday") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
@@ -62,8 +62,6 @@ references:
     nist-csf: DE.AE-3,DE.AE-5,DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.AC-3,PR.PT-1,PR.PT-4,RS.AN-1,RS.AN-4
     pcidss: Req-10.4.2.b
 
-ocil_clause: 'the system is not configured to audit time changes'
-
 ocil: |-
     If the system is not configured to audit time changes, this is a finding.
     If the system is 64-bit only, this is not applicable<br />

--- a/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
+++ b/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
@@ -21,5 +21,3 @@ rationale: |-
 severity: high
 
 platform: machine  # The check uses service_... extended definition, which doesn't support offline mode
-
-platform: machine

--- a/linux_os/guide/services/docker/docker_storage_configured/rule.yml
+++ b/linux_os/guide/services/docker/docker_storage_configured/rule.yml
@@ -18,5 +18,3 @@ rationale: |-
 severity: low
 
 platform: machine  # The check uses service_... extended definition, which doesn't support offline mode
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -24,8 +24,6 @@ rationale: |-
 
 severity: high
 
-platform: system_with_kernel
-
 identifiers:
     cce@rhcos4: CCE-82553-9
     cce@rhel8: CCE-80841-0
@@ -101,4 +99,6 @@ warnings:
 
 {{% if 'ubuntu' in product %}}
 platform: package[pam]
+{{% else %}}
+platform: system_with_kernel
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
@@ -30,8 +30,6 @@ references:
     cis@sle12: '5.6'
     cis@sle15: '5.6'
 
-platform: package[pam]
-
 ocil_clause: 'group {{{ var_pam_wheel_group_for_su }}} exists and has no user members'
 
 ocil: |-
@@ -53,4 +51,4 @@ warnings:
         configure <tt>pam_wheel.so</tt> module. The <tt>pam_wheel.so</tt> module configuration is
         accomplished by <tt>use_pam_wheel_group_for_su</tt> rule.
 
-platform: system_with_kernel
+platform: package[pam] and system_with_kernel

--- a/linux_os/guide/system/kernel_build_config/kernel_config_unmap_kernel_at_el0/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_unmap_kernel_at_el0/rule.yml
@@ -14,8 +14,6 @@ description: |-
 rationale: |-
     This is a countermeasure to the Meltdown attack.
 
-platform: aarch64_arch
-
 warnings:
     {{{ warning_kernel_build_config() | indent(4) }}}
 

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
@@ -11,8 +11,6 @@ rationale: |-
 
 severity: medium
 
-platform: package[iptables]
-
 identifiers:
     cce@rhel8: CCE-85955-3
     cce@rhel9: CCE-85960-3
@@ -27,7 +25,7 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: system_with_kernel
+platform: package[iptables] and system_with_kernel
 
 ocil: |-
     If IPv6 is disabled, this is not applicable.

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -32,8 +32,6 @@ references:
     stigid@ol8: OL08-00-040283
     stigid@sle12: SLES-12-030320
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.kptr_restrict", value="1") }}}
-
 ocil: |-
     The runtime status of the <code>kernel.kptr_restrict</code> kernel parameter can be queried
     by running the following command:

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -41,7 +41,7 @@ references:
 
 # In aarch64 cpus the bit is XN and it is not disableable
 # In ppc64le cpus the bit is not applicable
-platform: system_with_kernel and not aarch64_arch and not ppc64le_arch
+platform: machine and not aarch64_arch and not ppc64le_arch
 
 ocil: |-
     Verify the NX (no-execution) bit flag is set on the system.
@@ -66,5 +66,3 @@ fixtext: |-
     The NX bit execute protection must be enabled in the system BIOS.
 
 srg_requirement: '{{{ full_name }}} must implement non-executable data to protect its memory from unauthorized code execution.'
-
-platform: machine

--- a/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/rule.yml
@@ -15,12 +15,6 @@ rationale: |-
     User namespaces are used primarily for Linux containers. The value 0
     disallows the use of user namespaces.
 
-warnings:
-    - general: |-
-       This configuration baseline was created to deploy the base operating system for general purpose
-       workloads. When the operating system is configured for certain purposes, such as to host Linux Containers,
-       it is expected that <tt>user.max_user_namespaces</tt> will be enabled.
-
 severity: medium
 
 identifiers:
@@ -63,6 +57,10 @@ template:
         datatype: int
 
 warnings:
+    - general: |-
+       This configuration baseline was created to deploy the base operating system for general purpose
+       workloads. When the operating system is configured for certain purposes, such as to host Linux Containers,
+       it is expected that <tt>user.max_user_namespaces</tt> will be enabled.
     - functionality: |-
        Remediation of this rule might impair or prevent functionality of certain applications.
        This stands especially for general container usage and for certain desktop applications.

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -121,11 +121,10 @@ args:
     {{% if pkg_system == "rpm" %}}
     {{% if 'sle' in product or 'slmicro' in product or product in ["kylinserver10", "kylinsecserver6", "openeuler2203"] %}}
       pkgname: shadow
+    {{% elif product in ["openembedded"] %}}
+      pkgname: shadow-base
     {{% else %}}
       pkgname: shadow-utils
-    {{% endif %}}
-    {{% if product in ["openembedded"] %}}
-      pkgname: shadow-base
     {{% endif %}}
     {{% else %}}
       pkgname: login

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -38,28 +38,9 @@ def _bool_constructor(self, node):
     """
     return self.construct_scalar(node)
 
-
-def _unicode_constructor(self, node):
-    """
-    Constructs a Unicode string from a YAML node.
-
-    This method takes a YAML node, extracts its scalar value, and converts it to a Unicode string.
-
-    Args:
-        node (yaml.Node): The YAML node to be converted.
-
-    Returns:
-        str: The Unicode string representation of the node's scalar value.
-    """
-    string_like = self.construct_scalar(node)
-    return str(string_like)
-
-
 # keep YAML booleans as Python strings (on/off/yes/no/true/false,...)
 # instead of converting them to Python bools
 yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:bool', _bool_constructor)
-# Python2-relevant - become able to resolve "unicode strings"
-yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:python/unicode', _unicode_constructor)
 
 def _standard_bool_constructor(loader, node):
     # Delegates to SafeConstructor to get real Python True/False (not the project's
@@ -143,8 +124,6 @@ DuplicateKeyCheckLoader.add_constructor(
 
 # Keep YAML booleans as Python strings for DuplicateKeyCheckLoader too
 DuplicateKeyCheckLoader.add_constructor(u'tag:yaml.org,2002:bool', _bool_constructor)
-# Python2-relevant - become able to resolve "unicode strings"
-DuplicateKeyCheckLoader.add_constructor(u'tag:yaml.org,2002:python/unicode', _unicode_constructor)
 
 
 class DocumentationNotComplete(Exception):

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -79,6 +79,74 @@ _AnsibleSafeLoader.add_constructor(
 )
 
 
+class DuplicateKeyCheckLoader(yaml_SafeLoader):
+    """
+    Custom YAML SafeLoader that detects duplicate keys in mappings.
+
+    This loader extends the standard SafeLoader to raise an error when duplicate keys
+    are encountered in a YAML mapping. This prevents the silent overwriting behavior
+    of standard YAML parsers where the last value for a duplicate key wins.
+    """
+    pass
+
+
+def _construct_mapping_no_duplicates(loader, node):
+    """
+    Construct a mapping while checking for duplicate keys.
+
+    This custom constructor is used to detect duplicate keys during YAML parsing.
+    If a duplicate key is found, it raises a ValueError with information about
+    the duplicate key and its location in the file.
+
+    Args:
+        loader: The YAML loader instance
+        node: The YAML node being processed
+
+    Raises:
+        ValueError: If duplicate keys are detected in the mapping
+
+    Returns:
+        dict: The constructed mapping from the YAML node
+    """
+    loader.flatten_mapping(node)
+    mapping = {}
+
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=False)
+
+        # Check if we've already seen this key
+        if key in mapping:
+            # Extract line information from the key_node's mark
+            line_info = ""
+            if hasattr(key_node, 'start_mark') and key_node.start_mark:
+                line_num = key_node.start_mark.line + 1
+                line_info = f" at line {line_num}"
+
+            error_msg = (
+                f"Duplicate key '{key}' found{line_info}. "
+                "YAML files must not contain duplicate keys."
+            )
+            raise ValueError(error_msg)
+
+        # Construct the value and add to mapping
+        value = loader.construct_object(value_node, deep=False)
+        mapping[key] = value
+
+    return mapping
+
+
+# Register the duplicate-checking constructor for all mappings
+DuplicateKeyCheckLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_no_duplicates
+)
+
+# Keep YAML booleans as Python strings for DuplicateKeyCheckLoader too
+DuplicateKeyCheckLoader.add_constructor(u'tag:yaml.org,2002:bool', _bool_constructor)
+# Python2-relevant - become able to resolve "unicode strings"
+DuplicateKeyCheckLoader.add_constructor(u'tag:yaml.org,2002:python/unicode', _unicode_constructor)
+
+
 class DocumentationNotComplete(Exception):
     pass
 
@@ -148,16 +216,28 @@ def _open_yaml(stream, original_file=None, substitutions_dict=None):
     Raises:
         DocumentationNotComplete: If the YAML content contains the key "documentation_complete"
                                   set to "false".
+        ValueError: If duplicate keys are detected in the YAML file.
         Exception: For any other exceptions, including tab indentation errors in the file.
     """
     if substitutions_dict is None:
         substitutions_dict = {}
     try:
-        yaml_contents = yaml.load(stream, Loader=yaml_SafeLoader)
+        yaml_contents = yaml.load(stream, Loader=DuplicateKeyCheckLoader)
 
         return _get_yaml_contents_without_documentation_complete(yaml_contents, substitutions_dict)
     except DocumentationNotComplete as e:
         raise e
+    except ValueError as e:
+        # Handle duplicate key errors with enhanced error reporting
+        _file = original_file if original_file else stream
+        print("Error: Duplicate key found in YAML file", file=sys.stderr)
+        print("  File: %s" % _file, file=sys.stderr)
+        print("  %s" % str(e), file=sys.stderr)
+        print("", file=sys.stderr)
+        print("This YAML file contains a key more than once.", file=sys.stderr)
+        print("Please remove the duplicate entry. The YAML parser silently", file=sys.stderr)
+        print("uses the last value, which can lead to unexpected behavior.", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
         count = 0
         _file = original_file

--- a/tests/unit/ssg-module/test_yaml.py
+++ b/tests/unit/ssg-module/test_yaml.py
@@ -1,4 +1,6 @@
 import os
+import io
+import pytest
 
 import ssg.yaml
 
@@ -66,3 +68,144 @@ def test_open_and_macro_expand_from_dir(tmpdir):
 
     result = ssg.yaml.open_and_macro_expand_from_dir(str(yaml_file), str(content_dir))
     assert result['macro'] == 'test'
+
+
+def test_duplicate_key_detection_top_level():
+    """Test that duplicate keys at the top level are detected."""
+    yaml_content = """
+title: First Title
+description: A description
+title: Second Title
+"""
+    stream = io.StringIO(yaml_content)
+
+    with pytest.raises(SystemExit) as exc_info:
+        ssg.yaml._open_yaml(stream)
+
+    assert exc_info.value.code == 1
+
+
+def test_duplicate_key_detection_nested():
+    """Test that duplicate keys in nested structures are detected."""
+    yaml_content = """
+metadata:
+    name: test
+    version: 1.0
+    name: duplicate
+"""
+    stream = io.StringIO(yaml_content)
+
+    with pytest.raises(SystemExit) as exc_info:
+        ssg.yaml._open_yaml(stream)
+
+    assert exc_info.value.code == 1
+
+
+def test_duplicate_key_detection_in_rule_yml():
+    """Test duplicate key detection with a realistic rule.yml structure."""
+    yaml_content = """
+documentation_complete: true
+title: Test Rule
+description: First description
+rationale: A rationale
+severity: medium
+description: Second description
+"""
+    stream = io.StringIO(yaml_content)
+
+    with pytest.raises(SystemExit) as exc_info:
+        ssg.yaml._open_yaml(stream)
+
+    assert exc_info.value.code == 1
+
+
+def test_no_duplicate_keys_valid_yaml():
+    """Test that valid YAML without duplicates is parsed correctly."""
+    yaml_content = """
+documentation_complete: true
+title: Test Rule
+description: A description
+rationale: A rationale
+severity: medium
+identifiers:
+    cce@rhel9: CCE-12345-6
+references:
+    nist: CM-6
+"""
+    stream = io.StringIO(yaml_content)
+    result = ssg.yaml._open_yaml(stream)
+
+    # documentation_complete is removed by _open_yaml
+    assert result['title'] == 'Test Rule'
+    assert result['description'] == 'A description'
+    assert result['severity'] == 'medium'
+
+
+def test_duplicate_keys_in_nested_mapping():
+    """Test duplicate key detection in deeply nested structures."""
+    yaml_content = """
+template:
+    name: yamlfile_value
+    vars:
+        filepath: /api/path
+        yamlpath: .spec.field
+        filepath: /duplicate/path
+"""
+    stream = io.StringIO(yaml_content)
+
+    with pytest.raises(SystemExit) as exc_info:
+        ssg.yaml._open_yaml(stream)
+
+    assert exc_info.value.code == 1
+
+
+def test_list_items_not_treated_as_duplicates():
+    """Test that list items are not incorrectly flagged as duplicates."""
+    yaml_content = """
+selections:
+    - rule_one
+    - rule_two
+    - rule_three
+values:
+    - value: first
+      type: string
+    - value: second
+      type: string
+"""
+    stream = io.StringIO(yaml_content)
+    result = ssg.yaml._open_yaml(stream)
+
+    assert len(result['selections']) == 3
+    assert len(result['values']) == 2
+
+
+def test_open_raw_with_duplicates(tmpdir):
+    """Test that open_raw also detects duplicate keys."""
+    yaml_file = tmpdir / "test_dup.yaml"
+    yaml_file.write("""
+key1: value1
+key2: value2
+key1: duplicate_value
+""")
+
+    with pytest.raises(SystemExit) as exc_info:
+        ssg.yaml.open_raw(str(yaml_file))
+
+    assert exc_info.value.code == 1
+
+
+def test_open_raw_without_duplicates(tmpdir):
+    """Test that open_raw works correctly with valid YAML."""
+    yaml_file = tmpdir / "test_valid.yaml"
+    yaml_file.write("""
+documentation_complete: true
+key1: value1
+key2: value2
+key3: value3
+""")
+
+    result = ssg.yaml.open_raw(str(yaml_file))
+
+    assert result['key1'] == 'value1'
+    assert result['key2'] == 'value2'
+    assert result['key3'] == 'value3'


### PR DESCRIPTION
#### Description:

The build system will detect duplicate keys during YAML parsing.  If a duplicate key is found, it raises a ValueError with information about the duplicate key and its location in the file. 

Existing duplicate key occurrences from rule.yml files are also removed in this PR.

#### Rationale:

This prevents the silent overwriting behavior of standard YAML parsers where the last value for a duplicate key wins.

#### Review Hints:

Add a duplicate key to your favorite rule.yml file. Then, build the content and observe that the build fails and the error message is emitted.