### PR TITLE
accounts_password_all_shadowed_sha512: Fix test file and add yescrypt support for RHEL 10+

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -17,6 +17,11 @@
     <filter action="exclude">state_accounts_password_all_shadowed_has_no_password</filter>
     <filter action="exclude">state_accounts_password_all_shadowed_has_locked_password</filter>
     <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
+{{# yescrypt support for RHEL 10+, OL 10+, Fedora (version 10 = major_version_ordinal >= 10) #}}
+{{% if product == "fedora" or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+    <filter action="exclude">state_accounts_password_all_shadowed_yescrypt</filter>
+    <filter action="exclude">state_accounts_password_all_shadowed_has_locked_yescrypt</filter>
+{{% endif %}}
   </unix:shadow_object>
   <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
       <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked)$</unix:password>
@@ -27,6 +32,15 @@
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
       <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>
   </unix:shadow_state>
+{{# yescrypt support for RHEL 10+, OL 10+, Fedora (version 10 = major_version_ordinal >= 10) #}}
+{{% if product == "fedora" or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+  <unix:shadow_state id="state_accounts_password_all_shadowed_yescrypt" version="1">
+      <unix:password operation="pattern match">^\$y\$.*$</unix:password>
+  </unix:shadow_state>
+  <unix:shadow_state id="state_accounts_password_all_shadowed_has_locked_yescrypt" version="1">
+      <unix:password operation="pattern match">^(!\$y\$|!!\$y\$).*$</unix:password>
+  </unix:shadow_state>
+{{% endif %}}
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512_hidepass" version="1">
       <unix:password operation="pattern match" mask="true">.*</unix:password>
   </unix:shadow_state>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
@@ -13,8 +13,14 @@ description: |-
     $6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/</pre>
     Password hashes <tt>!</tt> or <tt>*</tt> indicate inactive accounts not
     available for logon and are not evaluated.
+{{# For RHEL 10+, OL 10+, Fedora: yescrypt is also acceptable #}}
+{{% if product == "fedora" or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+    If any interactive user password hash does not begin with <tt>$6</tt>
+    (SHA-512) or <tt>$y$</tt> (yescrypt), this is a finding.
+{{% else %}}
     If any interactive user password hash does not begin with <tt>$6</tt>,
     this is a finding.
+{{% endif %}}
 
 rationale: |-
     Passwords need to be protected at all times, and encryption is the standard method for
@@ -40,7 +46,12 @@ references:
     stigid@ol8: OL08-00-010120
     stigid@sle12: SLES-12-010220
 
+{{# For RHEL 10+, OL 10+, Fedora: yescrypt is also acceptable #}}
+{{% if product == "fedora" or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+ocil_clause: 'any interactive user password hash does not begin with "$6" or "$y$"'
+{{% else %}}
 ocil_clause: 'any interactive user password hash does not begin with "$6"'
+{{% endif %}}
 
 ocil: |-
     Verify that the interactive user account passwords are using a strong
@@ -52,6 +63,12 @@ ocil: |-
 
     Password hashes <tt>!</tt> or <tt>*</tt> indicate inactive accounts not
     available for logon and are not evaluated.
+{{# For RHEL 10+, OL 10+, Fedora: yescrypt is also acceptable #}}
+{{% if product == "fedora" or (('rhel' in product or 'ol' in families) and product not in ['ol7', 'ol8', 'ol9', 'rhel8', 'rhel9']) %}}
+
+    On {{{ full_name }}} and later versions, yescrypt (<tt>$y$</tt>) is also acceptable
+    as it provides stronger password hashing than SHA-512.
+{{% endif %}}
 
 fixtext: |-
     Lock all interactive user accounts not using SHA-512 hashing until the passwords can be regenerated with SHA-512.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/md5_password_rhel10.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/md5_password_rhel10.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Oracle Linux 10,Red Hat Enterprise Linux 10
+
+echo 'test1:$1$i7b0anAK$5uDHbPSrnl4b.e4aXQSe80:18793:0:99999:7:::' >> /etc/shadow

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
@@ -7,5 +7,5 @@ echo 'locked2:!!:18793:0:99999:7:::'
 echo 'locked3:!*:18793:0:99999:7:::'
 echo 'locked4:*:18793:0:99999:7:::'
 echo 'locked5:!locked:18793:0:99999:7:::'
-echo 'locked6:!!$6$.2mKSYajcpiOnmC7$2/H9H9vGwhlqKuRH7Jbn8UdwvOtz8KBx.QRYlYIvFy0BGPozWSI6xAoA8p.QA7yIOA/goUrV2X7pjSE762gwh1::0:99999:7:::'
+echo 'locked6:!!$6$.2mKSYajcpiOnmC7$2/H9H9vGwhlqKuRH7Jbn8UdwvOtz8KBx.QRYlYIvFy0BGPozWSI6xAoA8p.QA7yIOA/goUrV2X7pjSE762gwh1:18793:0:99999:7:::'
 } >> /etc/shadow

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/yescrypt_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/yescrypt_password.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = Oracle Linux 10,Red Hat Enterprise Linux 10
+
+{
+echo 'test1:$y$j9T$F8yGM6FNeIn6V3k/MbAlU.$vtKD4DPmq.sSMBYmSPHqxQ42r/cTNfMc1yGa/qGKL3D:18793:0:99999:7:::'
+echo 'test2:$6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/:18793:0:99999:7:::'
+echo 'locked1:!:18793:0:99999:7:::'
+echo 'locked2:!!:18793:0:99999:7:::'
+echo 'locked3:!*:18793:0:99999:7:::'
+echo 'locked4:*:18793:0:99999:7:::'
+echo 'locked5:!locked:18793:0:99999:7:::'
+echo 'locked6:!!$6$.2mKSYajcpiOnmC7$2/H9H9vGwhlqKuRH7Jbn8UdwvOtz8KBx.QRYlYIvFy0BGPozWSI6xAoA8p.QA7yIOA/goUrV2X7pjSE762gwh1:18793:0:99999:7:::'
+echo 'locked7:!!$y$j9T$AAAABBBBCCCCDDDDEEEEEE$FFFGGGHHHIIIJJJKKKLLLMMMNNNOOOPPPQQQRRRSSSTTTUUUVVVWWWXXXYYYZZZ:18793:0:99999:7:::'
+} >> /etc/shadow


### PR DESCRIPTION
#### Description:

Fixes two issues with the `accounts_password_all_shadowed_sha512` rule:

1. Fixed malformed shadow entry in test file (missing last-changed date field)
2. Added yescrypt password hash support for RHEL 10+, Oracle Linux 10+, and Fedora

#### Rationale:

- Fixes #14832

**Test file fix:**
The `sha512_password.pass.sh` test had an invalid shadow entry with an empty field, causing test failures.

**Yescrypt support:**
RHEL 10 uses yescrypt as the default password hashing algorithm instead of SHA-512. Both are FIPS 140-3 approved, but without this change, RHEL 10 systems would fail STIG checks despite using stronger security. The implementation uses family-based conditionals to automatically support future RHEL/OL versions.

**Technical note:** The OVAL Unix schema doesn't include `yescrypt` in the `encrypt_method` enumeration, so the implementation uses password pattern matching instead.

#### Review Hints:

**Test on RHEL 10:**
```bash
./build_product rhel10 --rule-id accounts_password_all_shadowed_sha512
cd tests
./automatus.py rule --libvirt qemu:///system <vm-name> \
    --datastream ../build/ssg-rhel10-ds.xml \
    accounts_password_all_shadowed_sha512