### PR TITLE
Restore the k8scontent publish workflow

### DIFF
--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -1,0 +1,23 @@
+---
+name: Kubernetes content
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  container-main:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: k8scontent
+      tag: ${GITHUB_SHA}
+      latest: true
+      registry_org: complianceascode
+      dockerfile_path: ./Dockerfiles/ocp4_content
+      licenses: BSD
+      vendor: ComplianceAsCode authors
+      platforms: 'linux/amd64,linux/ppc64le,linux/s390x,linux/arm64'


### PR DESCRIPTION
#### Description:

Restore the push-triggered `k8s-content.yaml` workflow that publishes `ghcr.io/complianceascode/k8scontent` (`:latest` + per-commit SHA tags). Restored from before the removal (yamllint findings fixed); the `metal-toolbox/container-push` reusable workflow it depends on still exists. The removed PR-test variants stay removed.

#### Rationale:

The k8s GitHub Actions were removed in #13567 as "no longer needed", but the Compliance Operator CI still consumes this image: every prow e2e lane builds its content image from `images/testcontent/Dockerfile.ci` in the compliance-operator repo, which is literally `FROM ghcr.io/complianceascode/k8scontent:latest` - and that tag has been frozen at the **2025-06-13** build since the removal. CO e2e has been scanning 14-month-old content ever since. (The Konflux `compliance-operator-content-dev` image cannot substitute: it has no floating tag and its productization ship-list intentionally excludes dev profiles.)

Concrete breakage this masked: 82fc125c0e (June 2026) moved the kubelet rule filepath to `/tmp/runtime/openscap-kubeletconfig`, but the frozen image still reads the old path. The operator-side half (ComplianceAsCode/compliance-operator#1255) cannot pass e2e against the stale image, while current CO master only passes *because* the image is stale.

Alternative considered: making `Dockerfile.ci` build content from source per CI run (no publisher dependency, always fresh) - at the cost of ~5-10 min per CO CI run. Happy to go that route instead if preferred; restoring the publisher is the minimal change and keeps local `make e2e` defaults working too.

Sequencing note: once `:latest` refreshes, compliance-operator master's serial kubelet tests will fail until compliance-operator#1255 merges - that PR is approved and ready, so the window can be kept short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)