### PR TITLE
SLE16  fixes in ansible for pcidss rules

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -39,8 +39,8 @@
     mode: "0600"
     create: yes
   when:
-    - ('"auditd.service" in ansible_facts.services' or
-        '"augenrules.service" in ansible_facts.services')
+    - ('auditd.service' in ansible_facts.services or
+       'augenrules.service' in ansible_facts.services)
   register: augenrules_audit_rules_privilege_function_update_result
   with_items: "{{ suid_audit_rules }}"
 
@@ -52,8 +52,8 @@
     create: yes
     mode: 0600
   when:
-    - ('"auditd.service" in ansible_facts.services' or
-        '"augenrules.service" in ansible_facts.services')
+    - ('auditd.service' in ansible_facts.services or
+       'augenrules.service' in ansible_facts.services)
   register: auditctl_audit_rules_privilege_function_update_result
   with_items: "{{ suid_audit_rules }}"
 
@@ -67,7 +67,7 @@
   ansible.builtin.command: /usr/sbin/service auditd restart
 {{%- endif %}}
   when:
-    - (augenrules_audit_rules_privilege_function_update_result.changed or
-       auditctl_audit_rules_privilege_function_update_result.changed)
-    - ("auditd.service" in ansible_facts.services and
-       ansible_facts.services["auditd.service"].state == "running")
+    - augenrules_audit_rules_privilege_function_update_result.changed or
+      auditctl_audit_rules_privilege_function_update_result.changed
+    - ('auditd.service' in ansible_facts.services and
+        ansible_facts.services['auditd.service'].state == 'running')

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle.yml
@@ -8,7 +8,7 @@
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='TMOUT', separator='=', separator_regex='=', value='{{ var_accounts_tmout }}', create='yes', rule_title=rule_title) }}}
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='readonly', separator=' ', value='TMOUT', create='yes', rule_title=rule_title) }}}
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='export', separator=' ', value='TMOUT', create='yes', rule_title=rule_title) }}}
- 
+
 - name: Check if /etc/profile.d/autologout.sh exists
   ansible.builtin.stat:
     path: /etc/profile.d/autologout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle.yml
@@ -8,9 +8,14 @@
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='TMOUT', separator='=', separator_regex='=', value='{{ var_accounts_tmout }}', create='yes', rule_title=rule_title) }}}
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='readonly', separator=' ', value='TMOUT', create='yes', rule_title=rule_title) }}}
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='export', separator=' ', value='TMOUT', create='yes', rule_title=rule_title) }}}
+ 
+- name: Check if /etc/profile.d/autologout.sh exists
+  ansible.builtin.stat:
+    path: /etc/profile.d/autologout.sh
+  register: autologout_file
 
 - name: Set the permission for /etc/profile.d/autologout.sh
   ansible.builtin.file:
     path: /etc/profile.d/autologout.sh
     mode: '0755'
-  when: lookup('ansible.builtin.file', '/etc/profile.d/autologout.sh', errors='warn')
+  when: autologout_file.stat.exists

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/slmicro.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/slmicro.yml
@@ -8,9 +8,13 @@
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='TMOUT', separator='=', separator_regex='=', value='{{ var_accounts_tmout }}', create='yes', rule_title=rule_title) }}}
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='readonly', separator=' ', value='TMOUT', create='yes', rule_title=rule_title) }}}
 {{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='export', separator=' ', value='TMOUT', create='yes', rule_title=rule_title) }}}
+- name: Check if /etc/profile.d/autologout.sh exists
+  ansible.builtin.stat:
+    path: /etc/profile.d/autologout.sh
+  register: autologout_file
 
 - name: Set the permission for /etc/profile.d/autologout.sh
   ansible.builtin.file:
     path: /etc/profile.d/autologout.sh
     mode: '0755'
-  when: lookup('ansible.builtin.file', '/etc/profile.d/autologout.sh', errors='warn')
+  when: autologout_file.stat.exists

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -38,7 +38,7 @@
     regexp: '^(\s*{{{ TYPE }}}\s+)\S+(\s+{{{ MODULE }}}\s+.*)'
     line: '\g<1>{{{ CONTROL_FLAG }}}\g<2>'
     backrefs: yes
-  when: check_pam_module_result is not skipped and control_flag|length
+  when: check_pam_module_result is not skipped and control_flag|length > 0
 
 {{% for arg in ARGUMENTS %}}
 # NOTE: if 'remove_argument' is present and set to some value, we assume
@@ -94,7 +94,7 @@
     regexp: '^(\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}(?:\s+\S+)*\s+{{{ arg['argument'] }}}=)(?!{{{ arg['argument_match'] }}})\S*((\s+\S+)*\s*\\*\s*)$'
     line: '\g<1>{{{ arg['argument_value'] }}}\g<2>'
     backrefs: yes
-  when: argument_value|length
+  when: argument_value|length > 0
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
   ansible.builtin.shell: |


### PR DESCRIPTION
#### Description:

- Fix ansible remediation for some SLE16 pcidss related rules, concerning new anible version with more strict conditionals

#### Rationale:

- Adapt pam_options template to new ansible version using more strict conditionals
- Fix ansible remediation when clauses for audit_rules_suid_privilege_function rules
- Fix ansible remediation for accounts_tmout in sle platforms

#### Review Hints:

- All patches are related to new ansible version applied in sle16 but should be also backward compatible just more strict than older versions require