### PR TITLE
Make no_shelllogin_for_systemaccounts oval consistent in uid_min usage

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
@@ -108,7 +108,11 @@
     <ind:subexpression datatype="int" operation="less than">0</ind:subexpression>
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_state id="state_uid_greater_than_or_equal_uid_min" version="1">
+    {{% if product in [ 'slmicro6', 'sle15', 'sle16' ] %}}
+    <ind:subexpression datatype="int" operation="greater than or equal">{{{ uid_min }}}</ind:subexpression>
+    {{% else %}}
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="variable_uid_min_value" />
+    {{% endif %}}
   </ind:textfilecontent54_state>
 
   <!-- Test if SYS_UID_MIN not defined in /etc/login.defs -->


### PR DESCRIPTION
#### Description:

- The no_shelllogin_for_systemaccounts rule OVAL so far used UID_MIN variable dynamically extracted from login_defs_path, while the remediation used the uid_min definition in product properties Unified that for sle platforms to use only the uid_min variable from product properties in order to simplify the logic

#### Rationale:

- Use uid_min product property instead of UID_MIN oval variable extracted from login.defs file to unify logic between remediation and oval check