### PR TITLE
Fix sysctl_kernel_exec_shield OVAL to check grubenv on RHEL 8

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -12,7 +12,10 @@
       {{% endif %}}
       <criteria operator="AND">
         <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
-        <criterion comment="NX is supported and is not disabled" test_ref="test_nx_disabled_grub" />
+        <criterion comment="NX is not disabled in boot entries" test_ref="test_nx_disabled_grub" />
+        {{% if product in ["rhel8", "ol8"] %}}
+        <criterion comment="NX is not disabled in grubenv" test_ref="test_nx_disabled_grubenv" />
+        {{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -56,4 +59,16 @@
     <ind:pattern operation="pattern match">[\s]*noexec[\s]*=[\s]*off</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{% if product in ["rhel8", "ol8"] %}}
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="NX is not disabled in grubenv" id="test_nx_disabled_grubenv" version="1">
+    <ind:object object_ref="object_nx_disabled_grubenv" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_nx_disabled_grubenv" version="1">
+    <ind:filepath>{{{ grub2_boot_path }}}/grubenv</ind:filepath>
+    <ind:pattern operation="pattern match">[\s]*noexec[\s]*=[\s]*off</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% endif %}}
 </def-group>


### PR DESCRIPTION
On RHEL 8, BLS entries use `$kernelopts` indirection and grubby puts kernel arguments in `/boot/grub2/grubenv` rather than directly in the BLS entry files. The OVAL only checked BLS entries, so `noexec=off` in grubenv was not detected.

Add a separate check for `/boot/grub2/grubenv` on RHEL 8 and OL 8.

Follow-up to #14957.