### PR TITLE
Fix SHA-512 password test to handle RHEL10 yescrypt defaults

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Remove any existing password hashes that are not SHA-512 (e.g., yescrypt on RHEL10)
+# This ensures the test starts with a clean state and only SHA-512 hashes remain
+sed -i '/:\$[^6]/d' /etc/shadow
+
 {
 echo 'test1:$6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/:18793:0:99999:7:::'
 echo 'locked1:!:18793:0:99999:7:::'


### PR DESCRIPTION

#### Description:
- Fix SHA-512 password test to handle RHEL10 yescrypt defaults
  - Remove non-SHA-512 password hashes (including yescrypt) from /etc/shadow before running the test. RHEL10 uses yescrypt by default, which is not FIPS 140-3 approved. This ensures the test validates only SHA-512 hashes as required by the security policy.
