### PR TITLE
Remove audispd from Alma Linux

### DIFF
--- a/product_properties/10-aide-audit.yml
+++ b/product_properties/10-aide-audit.yml
@@ -7,7 +7,7 @@ default:
     {{% if product not in ['rhel10', 'ol10', 'sle16', 'fedora'] %}}
     - "autrace"
     {{% endif %}}
-    {{% if 'rhel' not in product and 'ol' not in families and 'debian' not in families and 'ubuntu' not in families %}}
+    {{% if 'rhel' not in product and 'ol' not in families and 'debian' not in families and 'ubuntu' not in families and 'almalinux' not in product %}}
     - "audispd"
     {{% endif %}}
     {{% if 'ol' in families %}}

--- a/product_properties/10-audit-binaries.yml
+++ b/product_properties/10-audit-binaries.yml
@@ -7,7 +7,7 @@ default:
     - /sbin/autrace
     {{% endif %}}
     - /sbin/auditd
-    {{% if 'rhel' not in product and 'ubuntu' not in product and 'ol' not in families and product not in ['anolis8', 'anolis23', 'sle16'] %}}
+    {{% if 'rhel' not in product and 'ubuntu' not in product and 'ol' not in families and product not in ['anolis8', 'anolis23', 'sle16', 'almalinux9'] %}}
     - /sbin/audispd
     {{% endif %}}
     - /sbin/augenrules

--- a/tests/data/product_stability/almalinux9.yml
+++ b/tests/data/product_stability/almalinux9.yml
@@ -1,0 +1,127 @@
+aide_audit_binaries:
+- auditctl
+- auditd
+- ausearch
+- aureport
+- autrace
+- augenrules
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+audit_binaries:
+- /sbin/auditctl
+- /sbin/aureport
+- /sbin/ausearch
+- /sbin/autrace
+- /sbin/auditd
+- /sbin/augenrules
+audit_watches_style: legacy
+auid: 1000
+basic_properties_derived: true
+benchmark_id: ALMALINUX-9
+benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
+chrony_conf_path: /etc/chrony.conf
+chrony_d_path: /etc/chrony.d/
+components_root: ../../components
+cpes:
+- almalinux9:
+    check_id: installed_OS_is_almalinux9
+    name: cpe:/o:almalinux:almalinux:9
+    title: AlmaLinux OS 9
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
+faillock_path: /var/run/faillock
+full_name: AlmaLinux OS 9
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/grub2
+grub_helper_executable: grubby
+init_system: systemd
+login_defs_defaults_path: /usr/etc/login.defs
+login_defs_drop_in_path: /etc/login.defs.d/oscap.login.defs
+login_defs_path: /etc/login.defs
+major_version_ordinal: 9
+nobody_gid: 65534
+nobody_uid: 65534
+openssh_client_crypto_policy_config_file: /etc/crypto-policies/back-ends/openssh.config
+openssh_server_crypto_policy_config_file: /etc/crypto-policies/back-ends/opensshserver.config
+oval_feed_url: https://security.almalinux.org/oval/org.almalinux.alsa-9.xml.bz2
+pam_faillock_conf_path: /etc/security/faillock.conf
+pkg_manager: dnf
+pkg_manager_config_file: /etc/dnf/dnf.conf
+pkg_release: 61e69f29
+pkg_system: rpm
+pkg_version: b86b3716
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: login
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: almalinux9
+product_dir: /home/mburket/Developer/github.com/ComplianceAsCode/content/products/almalinux9
+profiles_root: ./profiles
+pwhistory_path: /etc/security/pwhistory.conf
+pwquality_path: /etc/security/pwquality.conf
+reference_uris:
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
+  app-srg: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security
+  bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
+  cis: https://www.cisecurity.org/benchmark/almalinuxos_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://www.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/contents/data/standard/05/45/54534.html
+  nerc-cip: https://www.nerc.com/standards/reliability-standards/cip
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://www.cyber.mil/stigs/srg-stig-tools/
+  stigref_vulnerability_id: https://www.cyber.mil/stigs/srg-stig-tools#vulnerability_id
+release_key_fingerprint: BF18AC2876178908D6E71267D36CB86CB86B3716
+rsyslog_cafile: /etc/pki/tls/cert.pem
+ssh_client_config_dir: /etc/ssh/ssh_config.d
+ssh_client_main_config_file: /etc/ssh/ssh_config
+sshd_config_base_dir: /etc/ssh
+sshd_config_dir: /etc/ssh/sshd_config.d
+sshd_distributed_config: 'false'
+sshd_hardening_config_basename: 00-complianceascode-hardening.conf
+sshd_main_config_file: /etc/ssh/sshd_config
+sshd_runtime_check: 'false'
+sshd_sysconfig_file: /etc/sysconfig/sshd
+sysctl_remediate_drop_in_file: 'false'
+target_oval_version:
+- 5
+- 11
+target_oval_version_str: '5.11'
+type: platform
+uid_min: 1000
+xwindows_packages:
+- xorg-x11-server-Xorg
+- xorg-x11-server-common
+- xorg-x11-server-utils
+- xorg-x11-server-Xwayland


### PR DESCRIPTION
#### Description:
Remove audispd EL9 derivatives.
#### Rationale:
Fixes #14963

#### Review Hints:
Build and review the affect `product.yml` under `build`.