### PR TITLE
CMP-4444: Add rule kubevirt-vcpu-metrics-enabled (CIS OCP-Virt 6.2)

### DIFF
--- a/applications/openshift-virtualization/kubevirt-vcpu-metrics-enabled/rule.yml
+++ b/applications/openshift-virtualization/kubevirt-vcpu-metrics-enabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+platform: '{{{ product }}}-node'
+
+title: 'Ensure vCPU metrics are enabled'
+
+description: |-
+    OpenShift Virtualization provides metrics that you can use to monitor the
+    consumption of cluster infrastructure resources, including virtual CPU
+    (vCPU). In order to use the vCPU metric, the <tt>schedstats=enable</tt>
+    kernel argument must be applied.
+
+rationale: |-
+    Metrics are a fundamental mechanism for understanding if the guest is
+    behaving in an anomalous or otherwise suspicious manner.
+
+severity: medium
+
+ocil_clause: 'schedstats is not enabled in the kernel command line'
+
+ocil: |-
+    Verify if the option is enabled in the kernel command line:
+    <pre>$ cat /proc/cmdline | grep schedstats=enable</pre>
+
+template:
+    name: coreos_kernel_option
+    vars:
+        arg_name: schedstats
+        arg_value: enable

--- a/products/ocp4/profiles/cis-vm-extension-node.profile
+++ b/products/ocp4/profiles/cis-vm-extension-node.profile
@@ -29,4 +29,5 @@ description: |-
 
 selections:
     - kubevirt-nested-virtualization-disabled
+    - kubevirt-vcpu-metrics-enabled
     - kubevirt-seccomp-profile-permissions


### PR DESCRIPTION
Supersedes https://github.com/ComplianceAsCode/content/pull/14961

Tested on OCP 4.22 
```
oc get csv -n openshift-cnv
NAME                                         DISPLAY                          VERSION               RELEASE   REPLACES                                   PHASE
kubevirt-hyperconverged-operator.v4.22.2     OpenShift Virtualization         4.22.2                          kubevirt-hyperconverged-operator.v4.22.0   Succeeded
```
Result when there is no schedstats=enable
```
oc get ccr -n openshift-compliance 
NAME                                                             STATUS   SEVERITY
cis-vm-ext-node-worker-kubevirt-nested-virtualization-disabled   PASS     medium
cis-vm-ext-node-worker-kubevirt-seccomp-profile-permissions      PASS     medium
cis-vm-ext-node-worker-kubevirt-vcpu-metrics-enabled             FAIL     medium
```

Result with schedstats=enable
```
oc get ccr -n openshift-compliance 
NAME                                                             STATUS   SEVERITY
cis-vm-ext-node-worker-kubevirt-nested-virtualization-disabled   PASS     medium
cis-vm-ext-node-worker-kubevirt-seccomp-profile-permissions      PASS     medium
cis-vm-ext-node-worker-kubevirt-vcpu-metrics-enabled             PASS     medium
```
