### PR TITLE
controls/cis_debian13: map 1.2.1.2 to apt_disable_weak_dependencies

### DIFF
--- a/controls/cis_debian13.yml
+++ b/controls/cis_debian13.yml
@@ -363,8 +363,7 @@ controls:
           - l2_server
           - l2_workstation
       rules:
-          - apt_conf_disable_recommends
-          - apt_conf_disable_suggests
+          - apt_disable_weak_dependencies
       status: automated
 
     - id: 1.2.1.3


### PR DESCRIPTION
#### Description:

- Update CIS Debian 13 control `1.2.1.2` ("Ensure weak dependencies are configured") to map to `apt_disable_weak_dependencies` instead of `apt_conf_disable_recommends` + `apt_conf_disable_suggests`.

#### Rationale:

- `apt_conf_disable_recommends` and `apt_conf_disable_suggests` only have SCE checks, which are known to fail silently on systems with a noexec `/tmp` (the exact condition CIS control 1.1.2.4 in this same benchmark recommends configuring). `apt_disable_weak_dependencies` covers the same requirement with a real OVAL check in addition to bash remediation, so it isn't exposed to that failure mode.

#### Review Hints:

- Single-line change in `controls/cis_debian13.yml`, section 1.2 (Configure Software Updates).
- Build: `./build_product --datastream-only debian13`
- Related to #14806 (CIS Debian 13 section 1 completion): that PR intentionally left 1.2.1.2 out at reviewer request, to let a maintainer decide this mapping independently. This PR is that follow-up; it doesn't touch any control also modified by #14806.
