### PR TITLE
controls/cis_debian13: fix 1.7.2 GDM banner variable selection

### DIFF
--- a/controls/cis_debian13.yml
+++ b/controls/cis_debian13.yml
@@ -699,7 +699,8 @@ controls:
           - l1_server
           - l1_workstation
       rules:
-          - login_banner_text=cis_default
+          - dconf_login_banner_text=cis_default
+          - dconf_login_banner_contents=cis_default
           - dconf_gnome_banner_enabled
           - dconf_gnome_login_banner_text
       status: automated


### PR DESCRIPTION
#### Description:

- Fix CIS Debian 13 control `1.7.2` ("Ensure GDM login banner is configured") to select `dconf_login_banner_text=cis_default` and `dconf_login_banner_contents=cis_default` instead of `login_banner_text=cis_default`.

#### Rationale:

- The rule selected by this control, `dconf_gnome_login_banner_text`, does not consume a variable named `login_banner_text` anywhere in its OVAL check or bash/ansible remediation. Its OVAL check uses `external_variable id="dconf_login_banner_text"`,  and its bash/ansible remediation populates `dconf_login_banner_contents`. So the control's current selection on master has no effect on this rule at all - it's a functional bug, not just a naming preference.
- `dconf_login_banner_text` (used in the OVAL regex match) and `dconf_login_banner_contents` (used in remediation) both define a `cis_default` value key with the CIS-specific banner wording ("Authorized uses only...").

#### Review Hints:

- Single control entry changed in `controls/cis_debian13.yml`, section 1.7 (GNOME Display Manager).
- Relevant files: `linux_os/guide/system/accounts/accounts-banners/dconf_login_banner_text.var`, `dconf_login_banner_contents.var`, and `.../gui_login_banner/dconf_gnome_login_banner_text/oval/shared.xml` (external_variable) / `bash/shared.sh` (remediation) — confirms which variables the rule actually reads.
- Build: `./build_product --datastream-only debian13`
