### PR TITLE
controls/cis_debian13: fix section 5 title typos and complete 5.1.13

### DIFF
--- a/controls/cis_debian13.yml
+++ b/controls/cis_debian13.yml
@@ -1656,7 +1656,7 @@ controls:
 
 
     - id: 5.1.1
-      title: Ensure access_to /etc/ssh/sshd_config is configured (Automated)
+      title: Ensure access to /etc/ssh/sshd_config is configured (Automated)
       levels:
           - l1_server
           - l1_workstation
@@ -1778,7 +1778,14 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: pending
+      rules:
+          - sshd_strong_kex=cis_debian13
+          - sshd_use_strong_kex
+      status: automated
+      notes: |
+          Same KexAlgorithms line and rule as 5.1.12. The cis_debian13 value of
+          sshd_strong_kex already lists the post-quantum algorithms
+          mlkem768x25519-sha256 and sntrup761x25519-sha512@openssh.com first.
 
     - id: 5.1.14
       title: Ensure sshd LoginGraceTime is configured (Automated)
@@ -1921,7 +1928,7 @@ controls:
       status: automated
 
     - id: 5.2.6
-      title: Ensure sudo authentication timeout is configured correctly (Automated)
+      title: Ensure sudo timestamp_timeout is configured (Automated)
       levels:
           - l1_server
           - l1_workstation
@@ -2048,7 +2055,7 @@ controls:
       status: automated
 
     - id: 5.3.3.2.2
-      title: Ensure minimum password length is configured (Automated)
+      title: Ensure password length is configured (Automated)
       levels:
           - l1_server
           - l1_workstation


### PR DESCRIPTION
#### Description:

- Fix three title mismatches against the CIS Debian Linux 13 Benchmark v1.0.0 PDF, and complete control `5.1.13` (post-quantum SSH key exchange), converting it from `pending` to `automated`.

#### Rationale:

- `5.1.1`: title had a typo, `access_to` instead of `access to`.
- `5.2.6`: title read "Ensure sudo authentication timeout is configured correctly"; the benchmark's actual title is "Ensure sudo timestamp_timeout is configured". Rule mapping (`var_sudo_timestamp_timeout`, `sudo_require_reauthentication`) was already correct, only the title was off.
- `5.3.3.2.2`: title read "Ensure minimum password length is configured"; the benchmark's actual title is "Ensure password length is configured". Rule mapping was already correct.
- `5.1.13` ("Ensure sshd post-quantum cryptography key exchange algorithms are configured"): the PDF's Audit section for 5.1.13 checks the same `KexAlgorithms` line in `/etc/ssh/sshd_config` as control 5.1.12, just verifying that the post-quantum algorithms (`sntrup761x25519-sha512`, and for OpenSSH >= 9.9, `mlkem768x25519-sha256`) are present in it. The `cis_debian13` value of the `sshd_strong_kex` variable (`linux_os/guide/services/ssh/sshd_strong_kex.var`) already lists both of those algorithms first. So the same rule mapping used for 5.1.12 (`sshd_strong_kex=cis_debian13` + `sshd_use_strong_kex`) satisfies 5.1.13 too — there's no separate check or remediation needed. Added a `notes:` entry explaining the reuse, following the same pattern already used for 5.1.7's `partial` status.

#### Review Hints:

- All changes are in `controls/cis_debian13.yml`, section 5 (SSH Server / Privilege Escalation / PAM / User Accounts).
- Build: `./build_product --datastream-only debian13`
- Relevant variable: `linux_os/guide/services/ssh/sshd_strong_kex.var` (see the `cis_debian13` key).
- These four controls were verified independently of PR #14781 (Debian 13 PAM support) — none of the touched controls (5.1.1, 5.1.13, 5.2.6, 5.3.3.2.2) reference rules affected by that PR.
