### PR TITLE
Set minimal permissions (contents: read) for export-to-gemara workflow

### DIFF
--- a/.github/workflows/export-to-gemara.yml
+++ b/.github/workflows/export-to-gemara.yml
@@ -30,6 +30,9 @@ on:
           - 'true'
           - 'false'
 
+permissions:
+  contents: read
+
 jobs:
   export-to-gemara:
     name: Export NIST 800-53 to Gemara


### PR DESCRIPTION
#### Description:

- Set minimal permissions (contents: read) to follow the principle of least privilege.