### PR TITLE
macros: stop pam-auth-update reporting a conflict it resolves itself

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -32,7 +32,7 @@ Password-Initial:
 	[success=end default=ignore]	pam_unix.so obscure yescrypt
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix --disable unix
 
 rm "$config_file"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
@@ -32,7 +32,7 @@ Password-Initial:
 	[success=end default=ignore]	pam_unix.so obscure yescrypt # nullok
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix --disable unix
 
 rm "$config_file"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -32,7 +32,7 @@ Password-Initial:
 	[success=end default=ignore]	pam_unix.so obscure yescrypt nullok
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix --disable unix
 
 rm "$config_file"
 {{% else %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/no_nullok.pass.sh
@@ -6,7 +6,6 @@ config_file=/usr/share/pam-configs/tmp_unix
 
 cat << EOF > "$config_file"
 Name: Unix authentication
-Conflicts: unix
 Default: yes
 Priority: 257
 Conflicts: unix
@@ -32,6 +31,6 @@ Password-Initial:
 	[success=end default=ignore]	pam_unix.so obscure yescrypt
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix --disable unix
 
 rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_commented.pass.sh
@@ -6,7 +6,6 @@ config_file=/usr/share/pam-configs/tmp_unix
 
 cat << EOF > "$config_file"
 Name: Unix authentication
-Conflicts: unix
 Default: yes
 Priority: 257
 Conflicts: unix
@@ -32,6 +31,6 @@ Password-Initial:
 	[success=end default=ignore]	pam_unix.so obscure yescrypt # nullok
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix --disable unix
 
 rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_present.fail.sh
@@ -6,7 +6,6 @@ config_file=/usr/share/pam-configs/tmp_unix
 
 cat << EOF > "$config_file"
 Name: Unix authentication
-Conflicts: unix
 Default: yes
 Priority: 257
 Conflicts: unix
@@ -32,7 +31,7 @@ Password-Initial:
 	[success=end default=ignore]	pam_unix.so obscure yescrypt nullok
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix --disable unix
 
 rm "$config_file"
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -975,9 +975,10 @@ if [ ! -f "$conf_path"/"$conf_name" ]; then
         if grep -q "$(md5sum "$conf_path"/unix | cut -d ' ' -f 1)" /var/lib/dpkg/info/libpam-runtime.md5sums;then
             cp "$conf_path"/unix "$conf_path"/"$conf_name"
             chmod 0644 "$conf_path"/"$conf_name"
+            sed -i 's/^Name: .*/Name: Unix authentication (ComplianceAsCode)/' "$conf_path"/"$conf_name"
             sed -i 's/Priority: [0-9]\+/Priority: 257\
 Conflicts: unix/' "$conf_path"/"$conf_name"
-            DEBIAN_FRONTEND=noninteractive pam-auth-update
+            DEBIAN_FRONTEND=noninteractive pam-auth-update --enable "$conf_name" --disable unix
         else
             echo "Not applicable - checksum of $conf_path/unix does not match the original." >&2
         fi


### PR DESCRIPTION
#### Description:

bash_pam_unix_enable copies the packaged unix pam-config to cac_unix, adds a Conflicts line naming unix, and runs pam-auth-update. The configuration that comes out is the right one, but getting there looks like a failure. pam-auth-update finds both profiles selected, drops unix to settle the conflict, and then reports what it just did as a debconf error. Nothing else in the copy changes, so both profiles still answer to the name "Unix authentication" and the error names the same profile twice. What a reader sees is a complaint about a conflict the remediation created and pam-auth-update already dealt with, with no hint that it exited 0 having written exactly what was asked of it.

So we do it explicitly. Enable cac_unix and disable unix in the same pam-auth-update call, leaving no conflict for pam-auth-update to report, and give the copy a name of its own so it can be told apart from the profile it replaces.

The disable option arrived in libpam-runtime 1.5, so Ubuntu 22.04 prints the message either way. There the rename is the whole of the improvement, which is not much, but it beats naming one profile twice.

The six no_empty_passwords and no_empty_passwords_unix scenarios that stand up a competing profile of their own hit the same message, so they disable unix too.

