### PR TITLE
CMP-4513: Ship the CIS OCP-Virt profiles in the Konflux content image

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -63,6 +63,8 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-v2r3.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r2.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r3.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/cis-vm-extension.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/cis-vm-extension-node.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/bsi.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/bsi-2022.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r2.profile; \


### PR DESCRIPTION
#### Description:

Add `cis-vm-extension` and `cis-vm-extension-node` to the profile enable list in the Konflux Containerfile (x86_64 block, matching OpenShift Virtualization's supported architecture).

#### Rationale:

The Containerfile disables all profiles and re-enables an explicit ship list; neither CIS OCP-Virt profile is in it, even though all their rules are merged:

- The built datastream carries the kubevirt node rules (via default.profile) but no `cis-vm-extension-node` profile selecting them - the Compliance Operator cannot create the node Profile CR from this image. Verified in the live `content-dev:master` image: zero `cis-vm-extension` references in `ssg-ocp4-ds.xml`.
- The `cis-vm-extension` CEL profile currently ships only because `build_cel_content.py` happens to ignore `documentation_complete` - an accident, not a contract. Enabling it makes the intent explicit and protects against future loader changes. It does NOT add the profile to the XCCDF datastream: CEL profiles are excluded by `scanner_type` regardless (verified: the live image's CEL bundle carries all 23 rules and the profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)