### PR TITLE
Update description and ocil of ensure_gpgcheck_local_packages

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -6,7 +6,8 @@ title: 'Ensure gpgcheck Enabled for Local Packages'
 description: |-
     <tt>{{{ pkg_manager }}}</tt> should be configured to verify the signature(s) of local packages
     prior to installation. To configure <tt>{{{ pkg_manager }}}</tt> to verify signatures of local
-    packages, set the <tt>localpkg_gpgcheck</tt> to <tt>1</tt> in <tt>{{{ pkg_manager_config_file }}}</tt>.
+    packages, set the <tt>localpkg_gpgcheck</tt> to <tt>1</tt>, <tt>True</tt>, or <tt>yes</tt> in
+    <tt>{{{ pkg_manager_config_file }}}</tt>.
 
 rationale: |-
     Changes to any software components can have significant effects to the overall security
@@ -50,7 +51,7 @@ ocil: |-
 
     <pre>localpkg_gpgcheck=1</pre>
 
-    If "localpkg_gpgcheck" is not set to "1", or if the option is missing or commented out, ask the System Administrator how the certificates for patches and other operating system components are verified.
+    If "localpkg_gpgcheck" is not set to "1", "True", or "yes", or if the option is missing or commented out, ask the System Administrator how the certificates for patches and other operating system components are verified.
 
 platform: package[{{{ pkg_manager }}}]
 


### PR DESCRIPTION
#### Description:

- Extend the rule text to support all accepted parameters by the OVAL check. Including True, 1 or yes.


#### Rationale:

- Matches what OVAL checks looks for.
- I'm not sure if updating the policy/* files make sense here since the RHEL STIG versions have slightly inconsistent text here even though they all do the same, but only RHEL8 seems to have gained the update to include all the three options (True/1/yes) values.
