### PR TITLE
fix: cis banner oval check to detect the full product name

### DIFF
--- a/shared/templates/cis_banner/oval.template
+++ b/shared/templates/cis_banner/oval.template
@@ -31,7 +31,7 @@
 
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
     <ind:filepath>{{{ FILEPATH }}}</ind:filepath>
-    <ind:pattern operation="pattern match">(\\v|\\r|\\m|\\s|{{{ product }}})</ind:pattern>
+    <ind:pattern operation="pattern match">(\\v|\\r|\\m|\\s|{{{ product }}}|{{{ full_name }}})</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
#### Description:

`/etc/issue` and `/etc/issue.net` are evaluated as *pass* with default content and remediation is not being applied.

#### Rationale:
The files content is not being evaluated correctly. Product name present in these files are not being evaluated as not compliant.

#### Review Hints:
Before: 
```
root@ubuntu2404:/vagrant# cat /etc/issue{,.net}
Ubuntu 24.04 LTS \n \l
Ubuntu 24.04 LTS
root@ubuntu2404:/vagrant# oscap xccdf eval \
  --profile xccdf_org.ssgproject.content_profile_cis_level2_server \
  --rule xccdf_org.ssgproject.content_rule_banner_etc_issue_net_cis \
  --rule xccdf_org.ssgproject.content_rule_banner_etc_issue_cis  \
  --remediate \
  build/ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Ensure Local Login Warning Banner Is Configured Properly
Rule    xccdf_org.ssgproject.content_rule_banner_etc_issue_cis
Result  pass

Title   Ensure Remote Login Warning Banner Is Configured Properly
Rule    xccdf_org.ssgproject.content_rule_banner_etc_issue_net_cis
Result  pass
```

After:
```
root@ubuntu2404:/vagrant# cat /etc/issue{,.net}
Ubuntu 24.04 LTS \n \l
Ubuntu 24.04 LTS
root@ubuntu2404:/vagrant# oscap xccdf eval \
  --profile xccdf_org.ssgproject.content_profile_cis_level2_server \
  --rule xccdf_org.ssgproject.content_rule_banner_etc_issue_net_cis \
  --rule xccdf_org.ssgproject.content_rule_banner_etc_issue_cis  \
  --remediate \
  build/ssg-ubuntu2404-ds.xml
--- Starting Evaluation ---

Title   Ensure Local Login Warning Banner Is Configured Properly
Rule    xccdf_org.ssgproject.content_rule_banner_etc_issue_cis
Result  fail

Title   Ensure Remote Login Warning Banner Is Configured Properly
Rule    xccdf_org.ssgproject.content_rule_banner_etc_issue_net_cis
Result  fail


--- Starting Remediation ---

Title   Ensure Local Login Warning Banner Is Configured Properly
Rule    xccdf_org.ssgproject.content_rule_banner_etc_issue_cis
Result  fixed

Title   Ensure Remote Login Warning Banner Is Configured Properly
Rule    xccdf_org.ssgproject.content_rule_banner_etc_issue_net_cis
Result  fixed

root@ubuntu2404:/vagrant# cat /etc/issue{,.net}
Authorized users only. All activity may be monitored and reported.
Authorized users only. All activity may be monitored and reported.
```