### PR TITLE
Revert the bootc_build platoform change for disk_partitioning group

### DIFF
--- a/linux_os/guide/system/permissions/partitions/group.yml
+++ b/linux_os/guide/system/permissions/partitions/group.yml
@@ -11,5 +11,5 @@ description: |-
 {{% if 'ubuntu' in product %}}
 platform: not container
 {{% else %}}
-platform: not container and not bootc_build
+platform: not container and not bootc
 {{% endif %}}

--- a/linux_os/guide/system/software/disk_partitioning/group.yml
+++ b/linux_os/guide/system/software/disk_partitioning/group.yml
@@ -26,4 +26,8 @@ description: |-
     modify it to create separate logical volumes for the directories
     listed above. The Logical Volume Manager (LVM) makes this possible.
 
-platform: not container and not bootc_build
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
+platform: not container and not bootc
+{{% endif %}}


### PR DESCRIPTION


#### Description:

Revert platform changes for partition groups.

#### Rationale:

There is some issues with this platform for Ansible that are not easily solved, see #14992.

