### PR TITLE
Require 0600 permissions for SSH private keys on non-immutable systems

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml
@@ -6,14 +6,8 @@
 
 {{% set find_command_base = 'find -H /etc/ssh/ -maxdepth 1 -user root -regex ".*_key$" -type f' %}}
 {{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name") %}}
-
-{{% if product in ["ol9", "sle12", "sle15", "slmicro5", "slmicro6"] %}}
-{{% set find_command_permissions = 'u+xs,g+xws,o+xwrt' %}}
-{{% set permissions_mode = 'u-xs,g-xws,o-xwrt' %}}
-{{% else %}}
 {{% set find_command_permissions = 'u+xs,g+xwrs,o+xwrt' %}}
 {{% set permissions_mode = 'u-xs,g-xwrs,o-xwrt' %}}
-{{% endif %}}
 
 - name: Find root:root-owned keys
   ansible.builtin.command: '{{{ find_command_base }}} -group root -perm /{{{ find_command_permissions }}}'
@@ -32,7 +26,11 @@
 
 {{% if dedicated_ssh_groupname -%}}
 - name: Find root:{{{ dedicated_ssh_groupname }}}-owned keys
+{{% if product == "rhcos4" %}}
   ansible.builtin.command: '{{{ find_command_base }}} -group {{{ dedicated_ssh_groupname }}} -perm /u+xs,g+xws,o+xwrt'
+{{% else %}}
+  ansible.builtin.command: '{{{ find_command_base }}} -group {{{ dedicated_ssh_groupname }}} -perm /u+xs,g+xwrs,o+xwrt'
+{{% endif %}}
   register: dedicated_group_owned_keys
   changed_when: False
   failed_when: False
@@ -41,7 +39,11 @@
 - name: Set permissions for root:{{{ dedicated_ssh_groupname }}}-owned keys
   ansible.builtin.file:
     path: "{{ item }}"
+{{% if product == "rhcos4" %}}
     mode: "u-xs,g-xws,o-xwrt"
+{{% else %}}
+    mode: "u-xs,g-xwrs,o-xwrt"
+{{% endif %}}
     state: file
   with_items:
     - "{{ dedicated_group_owned_keys.stdout_lines }}"

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/bash/shared.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/bash/shared.sh
@@ -8,14 +8,14 @@ test root:{{{ groupname }}} = "$(stat -c "%U:%G" "$keyfile")"
 for keyfile in /etc/ssh/*_key; do
     test -f "$keyfile" || continue
     if {{{ keyfile_owned_by("root") }}}; then
-    {{% if product in ["ol9", "sle12", "sle15", "slmicro5", "slmicro6"] %}}
+	chmod u-xs,g-xwrs,o-xwrt "$keyfile"
+    {{% if dedicated_ssh_groupname -%}}
+    elif {{{ keyfile_owned_by(dedicated_ssh_groupname) }}}; then
+    {{% if product == "rhcos4" %}}
 	chmod u-xs,g-xws,o-xwrt "$keyfile"
     {{% else %}}
 	chmod u-xs,g-xwrs,o-xwrt "$keyfile"
     {{% endif %}}
-    {{% if dedicated_ssh_groupname -%}}
-    elif {{{ keyfile_owned_by(dedicated_ssh_groupname) }}}; then
-	chmod u-xs,g-xws,o-xwrt "$keyfile"
     {{%- endif %}}
     else
         echo "Key-like file '$keyfile' is owned by an unexpected user:group combination"

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/oval/shared.xml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/oval/shared.xml
@@ -58,8 +58,8 @@
       {{# intentionally not considered: <unix:uread datatype="boolean">true</unix:uread> #}}
       {{# intentionally not considered: <unix:uwrite datatype="boolean">true</unix:uwrite> #}}
       <unix:uexec datatype="boolean">false</unix:uexec>
-      
-      {{% if product in ["ol9", "sle12", "sle15", "slmicro5", "slmicro6"] -%}}
+
+      {{% if product == "rhcos4" -%}}
       {{# intentionally not considered: <unix:gread datatype="boolean">true</unix:gread> #}}
       {{%- else %}}
       <unix:gread datatype="boolean">false</unix:gread>

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -4,7 +4,7 @@ title: 'Verify Permissions on SSH Server Private *_key Key Files'
 
 {{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name") %}}
 
-{{% if product in ["ol9", "rhcos4", "sle12", "sle15", "slmicro5", "slmicro6"] %}}
+{{% if product == "rhcos4" %}}
 {{# CoreOS is special - it is immutable, so it is more predictable, and it uses the dedicated group as key owner by default #}}
 {{% set perms = "-rw-r-----" %}}
 {{% set perms_num = "0640" %}}

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# remediation = none
+
+rm -f /etc/ssh/* || true # ignore error on deleting directories
+
+


### PR DESCRIPTION
#### Description:

This change restricts the 0640 permission exception to RHCOS4 only, requiring strict 0600 permissions for all other products including RHEL 8/9, Oracle Linux 9, and SUSE Linux Enterprise.

Background:
- October 2021: RHCOS4 exception added for 0640 (immutable system default)
- July 2022: Mistakenly extended to RHEL/OL/SLE products
- August 2024: RHEL 10 removed the exception ("it is root in RHEL 10")

The ssh_keys group exception was only meant for immutable systems where the default configuration cannot be changed. Regular RHEL systems ship with root:ssh_keys 0640 by default, but can and should be hardened to 0600 for DISA STIG compliance.

Impact:
- RHCOS4: Still accepts 0640 (immutable exception maintained)
- RHEL 8/9: Now requires 0600, will remediate from 0640 to 0600
- OL9: Same as RHEL
- SLE12/15, SLE Micro 5/6: Now requires 0600 instead of 0640
- Fixes DISA alignment issue where STIG requires strict 0600

The dedicated_ssh_keyowner group definitions remain in product.yml files - we still recognize and allow root:ssh_keys ownership, but require stricter permissions regardless of group.
#### Rationale:

- Fixes: #15012

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
