### PR TITLE
Fix remediations for file_permissions_audit_configuration_stig

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
@@ -67,7 +67,7 @@
 
     # IMPORTANT: this is necessary to ensure the dropin is loaded and the permissions for /etc/audit/ and /etc/audit/rules.d/ files are set correctly.
     - name: "{{{ rule_title }}} - Restart auditd.service"
-      ansible.builtin.shell: service auditd restart
+      ansible.builtin.command: service auditd restart
       when:
         - audit_config_perms.changed or rules_dir_perms.changed
 

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
@@ -66,9 +66,8 @@
         daemon_reload: true
 
     # IMPORTANT: this is necessary to ensure the dropin is loaded and the permissions for /etc/audit/ and /etc/audit/rules.d/ files are set correctly.
-    # Use systemctl kill + start instead of restart due to RefuseManualStart: https://access.redhat.com/solutions/2664811
     - name: "{{{ rule_title }}} - Restart auditd.service"
-      ansible.builtin.shell: systemctl kill auditd && systemctl start auditd
+      ansible.builtin.shell: service auditd restart
       when:
         - audit_config_perms.changed or rules_dir_perms.changed
 

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
@@ -10,7 +10,7 @@
 # Installs an auditd.service dropin to restore 0600 on audit.rules after augenrules
 # rewrites it to 0640 when /etc/audit/rules.d/ content changes (RHEL 8/9 only, not containers).
 
-- name: Set /etc/audit/audit.rules and /etc/audit/auditd.conf to 0600, owned by root
+- name: "{{{ rule_title }}} - Set /etc/audit/audit.rules and /etc/audit/auditd.conf to 0600, owned by root"
   ansible.builtin.file:
     path: "{{ item }}"
     mode: '0600'
@@ -21,8 +21,9 @@
     - /etc/audit/audit.rules
     - /etc/audit/auditd.conf
   failed_when: false
+  register: audit_config_perms
 
-- name: Find /etc/audit/rules.d/*.rules files
+- name: "{{{ rule_title }}} - Find /etc/audit/rules.d/*.rules files"
   ansible.builtin.find:
     paths: /etc/audit/rules.d/
     depth: 1
@@ -30,7 +31,7 @@
     patterns: '*.rules'
   register: rules_files
 
-- name: Set /etc/audit/rules.d/*.rules files to 0600, owned by root
+- name: "{{{ rule_title }}} - Set /etc/audit/rules.d/*.rules files to 0600, owned by root"
   ansible.builtin.file:
     path: "{{ item.path }}"
     mode: '0600'
@@ -38,16 +39,17 @@
     group: root
     state: file
   loop: "{{ rules_files.files }}"
+  register: rules_dir_perms
 
-- name: Install ExecStartPost dropin on auditd.service
+- name: "{{{ rule_title }}} - Install ExecStartPost dropin on auditd.service"
   block:
-    - name: Create dropin directory /etc/systemd/system/auditd.service.d
+    - name: "{{{ rule_title }}} - Create dropin directory /etc/systemd/system/auditd.service.d"
       ansible.builtin.file:
         path: /etc/systemd/system/auditd.service.d
         state: directory
         mode: '0755'
 
-    - name: Install /etc/systemd/system/auditd.service.d/permissions.conf
+    - name: "{{{ rule_title }}} - Install /etc/systemd/system/auditd.service.d/permissions.conf"
       ansible.builtin.copy:
         dest: /etc/systemd/system/auditd.service.d/permissions.conf
         content: |
@@ -55,18 +57,20 @@
           ExecStartPost=/usr/bin/chmod 0600 /etc/audit/audit.rules
         mode: '0644'
 
-    - name: Restore SELinux context on /etc/systemd/system/auditd.service.d/permissions.conf
+    - name: "{{{ rule_title }}} - Restore SELinux context on /etc/systemd/system/auditd.service.d/permissions.conf"
       ansible.builtin.command: restorecon /etc/systemd/system/auditd.service.d/permissions.conf
       changed_when: false
 
-    - name: Reload systemd daemon to pick up permissions.conf
+    - name: "{{{ rule_title }}} - Reload systemd daemon to pick up permissions.conf"
       ansible.builtin.systemd:
         daemon_reload: true
 
     # IMPORTANT: this is necessary to ensure the dropin is loaded and the permissions for /etc/audit/ and /etc/audit/rules.d/ files are set correctly.
     # Use systemctl kill + start instead of restart due to RefuseManualStart: https://access.redhat.com/solutions/2664811
-    - name: Restart auditd.service
+    - name: "{{{ rule_title }}} - Restart auditd.service"
       ansible.builtin.shell: systemctl kill auditd && systemctl start auditd
+      when:
+        - audit_config_perms.changed or rules_dir_perms.changed
 
   when:
     - '"audit" in ansible_facts.packages'

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/ansible/shared.yml
@@ -1,0 +1,73 @@
+# platform = multi_platform_rhel
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+# Copied and modified from `file_permissions/ansible.yml` template
+#
+# Sets mode 0600 and ownership root:root on all audit config files.
+# Installs an auditd.service dropin to restore 0600 on audit.rules after augenrules
+# rewrites it to 0640 when /etc/audit/rules.d/ content changes (RHEL 8/9 only, not containers).
+
+- name: Set /etc/audit/audit.rules and /etc/audit/auditd.conf to 0600, owned by root
+  ansible.builtin.file:
+    path: "{{ item }}"
+    mode: '0600'
+    owner: root
+    group: root
+    state: file
+  loop:
+    - /etc/audit/audit.rules
+    - /etc/audit/auditd.conf
+  failed_when: false
+
+- name: Find /etc/audit/rules.d/*.rules files
+  ansible.builtin.find:
+    paths: /etc/audit/rules.d/
+    depth: 1
+    file_type: file
+    patterns: '*.rules'
+  register: rules_files
+
+- name: Set /etc/audit/rules.d/*.rules files to 0600, owned by root
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    mode: '0600'
+    owner: root
+    group: root
+    state: file
+  loop: "{{ rules_files.files }}"
+
+- name: Install ExecStartPost dropin on auditd.service
+  block:
+    - name: Create dropin directory /etc/systemd/system/auditd.service.d
+      ansible.builtin.file:
+        path: /etc/systemd/system/auditd.service.d
+        state: directory
+        mode: '0755'
+
+    - name: Install /etc/systemd/system/auditd.service.d/permissions.conf
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/auditd.service.d/permissions.conf
+        content: |
+          [Service]
+          ExecStartPost=/usr/bin/chmod 0600 /etc/audit/audit.rules
+        mode: '0644'
+
+    - name: Restore SELinux context on /etc/systemd/system/auditd.service.d/permissions.conf
+      ansible.builtin.command: restorecon /etc/systemd/system/auditd.service.d/permissions.conf
+      changed_when: false
+
+    - name: Reload systemd daemon to pick up permissions.conf
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+    # IMPORTANT: this is necessary to ensure the dropin is loaded and the permissions for /etc/audit/ and /etc/audit/rules.d/ files are set correctly.
+    # Use systemctl kill + start instead of restart due to RefuseManualStart: https://access.redhat.com/solutions/2664811
+    - name: Restart auditd.service
+      ansible.builtin.shell: systemctl kill auditd && systemctl start auditd
+
+  when:
+    - '"audit" in ansible_facts.packages'
+    - '"kernel-core" in ansible_facts.packages'

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/bash/shared.sh
@@ -1,0 +1,42 @@
+# platform = multi_platform_rhel
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+# Copied and modified from `file_permissions/bash.template` template
+#
+# Sets mode 0600 and ownership root:root on all audit config files.
+# Installs an auditd.service dropin to restore 0600 on audit.rules after augenrules
+# rewrites it to 0640 when /etc/audit/rules.d/ content changes (RHEL 8/9 only, not containers).
+
+find /etc/audit/ -maxdepth 1 -type f \
+    -regextype posix-extended -regex '^.*audit(\.rules|d\.conf)$' \
+    -exec chmod 0600 {} \; \
+    -exec chown root:root {} \;
+
+find /etc/audit/rules.d/ -maxdepth 1 -type f -name '*.rules' \
+    -exec chmod 0600 {} \; \
+    -exec chown root:root {} \;
+
+if rpm --quiet -q audit && rpm --quiet -q kernel-core; then
+
+# Generate the dropin file content to restore 0600 on audit.rules after augenrules rewrites it to 0640 when /etc/audit/rules.d/ content changes (RHEL 8/9 only, not containers).
+
+mkdir -p /etc/systemd/system/auditd.service.d
+chmod 0755 /etc/systemd/system/auditd.service.d
+
+cat > /etc/systemd/system/auditd.service.d/permissions.conf << 'EOF'
+[Service]
+ExecStartPost=/usr/bin/chmod 0600 /etc/audit/audit.rules
+EOF
+chmod 0644 /etc/systemd/system/auditd.service.d/permissions.conf
+restorecon /etc/systemd/system/auditd.service.d/permissions.conf
+
+systemctl daemon-reload
+# IMPORTANT: this is necessary to ensure the dropin is loaded and the permissions for /etc/audit/ and /etc/audit/rules.d/ files are set correctly.
+# Use systemctl kill + start instead of restart due to RefuseManualStart: https://access.redhat.com/solutions/2664811
+systemctl kill auditd
+systemctl start auditd
+
+fi

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/bash/shared.sh
@@ -35,8 +35,6 @@ restorecon /etc/systemd/system/auditd.service.d/permissions.conf
 
 systemctl daemon-reload
 # IMPORTANT: this is necessary to ensure the dropin is loaded and the permissions for /etc/audit/ and /etc/audit/rules.d/ files are set correctly.
-# Use systemctl kill + start instead of restart due to RefuseManualStart: https://access.redhat.com/solutions/2664811
-systemctl kill auditd
-systemctl start auditd
+service auditd restart
 
 fi

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/rule.yml
@@ -29,6 +29,10 @@ ocil: |-
     {{{ describe_file_permissions(file="/etc/audit/", perms="0600") }}}
     {{{ describe_file_permissions(file="/etc/audit/rules.d/", perms="0600") }}}
 
+warnings:
+    - general: |-
+        <tt>augenrules --load</tt> resets permissions of <tt>/etc/audit/audit.rules</tt> to <tt>0640</tt>, undoing remediation (<tt>0600</tt>). Fix: A systemd dropin for <tt>audit</tt> service is installed at <tt>/etc/systemd/system/auditd.service.d/permissions.conf</tt>with <tt>ExecStartPost=/usr/bin/chmod 0600 /etc/audit/audit.rules</tt>. This dropin is necessary to restore <tt>0600</tt> permissions after <tt>augenrules</tt> runs and rewrites the <tt>/etc/audit/audit.rules</tt> file. systemd runs both commands in order, restoring <tt>0600</tt>. Use <tt>service auditd restart</tt> to reload and apply the drop-in when remediating manually.
+
 template:
     name: file_permissions
     vars:

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/correct_permissions.pass.sh
@@ -3,9 +3,9 @@
 
 rm -rf /etc/audit/*
 mkdir -p /etc/audit/rules.d/
-export TESTFILE=/etc/audit/rules.d/test_rule.rules
-export AUDITFILE=/etc/audit/auditd.conf
-touch $TESTFILE
-touch $AUDITFILE
-chmod 0600 $TESTFILE
-chmod 0600 $AUDITFILE
+touch /etc/audit/auditd.conf
+echo '-a always,exit -F arch=b64 -S getuid -k test_execstartpost_2' > /etc/audit/rules.d/test_rule.rules
+augenrules --load
+chmod 0600 /etc/audit/audit.rules
+chmod 0600 /etc/audit/auditd.conf
+chmod 0600 /etc/audit/rules.d/test_rule.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/lenient_permissions.fail.sh
@@ -3,9 +3,9 @@
 
 rm -rf /etc/audit/*
 mkdir -p /etc/audit/rules.d/
-export TESTFILE=/etc/audit/rules.d/test_rule.rules
-export AUDITFILE=/etc/audit/auditd.conf
-touch $TESTFILE
-touch $AUDITFILE
-chmod 0640 $TESTFILE
-chmod 0640 $AUDITFILE
+touch /etc/audit/auditd.conf
+echo '-a always,exit -F arch=b64 -S getuid -k test_execstartpost_2' > /etc/audit/rules.d/test_rule.rules
+augenrules --load
+chmod 0640 /etc/audit/audit.rules
+chmod 0640 /etc/audit/auditd.conf
+chmod 0640 /etc/audit/rules.d/test_rule.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/stricter_permisions.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/stricter_permisions.pass.sh
@@ -3,9 +3,9 @@
 
 rm -rf /etc/audit/*
 mkdir -p /etc/audit/rules.d/
-export TESTFILE=/etc/audit/rules.d/test_rule.rules
-export AUDITFILE=/etc/audit/auditd.conf
-touch $TESTFILE
-touch $AUDITFILE
-chmod 0400 $TESTFILE
-chmod 0400 $AUDITFILE
+touch /etc/audit/auditd.conf
+echo '-a always,exit -F arch=b64 -S getuid -k test_execstartpost_2' > /etc/audit/rules.d/test_rule.rules
+augenrules --load
+chmod 0400 /etc/audit/audit.rules
+chmod 0400 /etc/audit/auditd.conf
+chmod 0400 /etc/audit/rules.d/test_rule.rules


### PR DESCRIPTION
#### Description:

- Fix the Ansible and Bash remediations for `file_permissions_audit_configuration_stig` so that `/etc/audit/audit.rules` and the other audit configuration files stay `0600` even after `augenrules --load` rewrites `audit.rules` back to `0640`. A systemd dropin (`ExecStartPost=/usr/bin/chmod 0600 /etc/audit/audit.rules` on `auditd.service`) is installed to restore the permission after every `augenrules` run.

#### Rationale:

- The previous remediation only ran a one-time `chmod` on the audit config files. `augenrules` resets `/etc/audit/audit.rules` to `0640` on every reload triggered by changes under `/etc/audit/rules.d/`, silently undoing the fix and leaving the system out of compliance again. The dropin makes the `0600` permission durable across reloads, and a matching warning was added to `rule.yml` to document the behavior.

#### Review Hints:

- Build: `./build_product rhel9`
- Test with Automatus: `python3 tests/automatus.py rule --libvirt qemu:///system <vm_name> file_permissions_audit_configuration_stig`