### PR TITLE
Fix for sshd_lineinfile template to comply with newer ansible versions

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -954,7 +954,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- if ver -%}}
 {{# For RPM packages, Ansible splits the package version into "epoch", "version" and "release" keys. For DEB packages, Ansible provides only "version" key. We don't take the "release" part into account. #}}
 {{%- if pkg_system == "rpm" -%}}
-"{{{ package }}}" in ansible_facts.packages and (((((ansible_facts.packages["{{{ package }}}"] | last)["epoch"]) != None) | ternary((ansible_facts.packages["{{{ package }}}"] | last)["epoch"] ~ ":", "0:")) + ((ansible_facts.packages["{{{ package }}}"] | last)["version"] | split("-") | first)) is version("{{{ ver }}}", "{{{ op }}}")
+"{{{ package }}}" in ansible_facts.packages and (((((ansible_facts.packages["{{{ package }}}"] | last)["epoch"]) | default(0) | int) | ternary((ansible_facts.packages["{{{ package }}}"] | last)["epoch"] ~ ":", "0:")) + ((ansible_facts.packages["{{{ package }}}"] | last)["version"] | split("-") | first)) is version("{{{ ver }}}", "{{{ op }}}")
 {{%- else -%}}
 "{{{ package }}}" in ansible_facts.packages and ((ansible_facts.packages["{{{ package }}}"] | last)["version"] | split("-") | first) is version("{{{ ver }}}", "{{{ op }}}")
 {{%- endif -%}}


### PR DESCRIPTION
#### Description:

-  In Ansible code use explicitely default value of integer 0 for epoch part of package version


#### Rationale:

- New ansible versions are more strict to comparing integers to strings. Package versions ending up as strings cannot be compared to integers in the ansible version function. Therefore ansible code in remediation fails, in cases like in sshd_lineinfile template.


