### PR TITLE
Stabilization: Fix platform of rule audit_rules_cron_execution

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_cron_execution/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_cron_execution/rule.yml
@@ -43,5 +43,3 @@ ocil: |-
     <pre>-a always,exit -F arch=b32 -S execve -F subj_type=crond_t -F auid&gt;={{{ uid_min }}} -F auid!=unset -k cron_exec</pre>
 
     If this command does not return the expected output, or the lines are commented out, this is a finding.
-
-platform: machine


### PR DESCRIPTION
The rule `audit_rules_cron_execution` shouldn't have the `machine` platform. Instead, it should be applicable to all systems with kernel, including bootable containers, which it will inherit from the group level platform in `linux_os/guide/auditing/group.yml`.

Fixes failing contest tests
- `/hardening/container/bootc-image-builder/stig`
- `/hardening/container/anaconda-ostree/stig`

This is a backport of the PR https://github.com/ComplianceAsCode/content/pull/15013 to the stabilization branch.