### PR TITLE
Stabilization: Clean up environment in test scenarios

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/correct_permissions.pass.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # packages = audit
 
+rm -rf /etc/audit/*
+mkdir -p /etc/audit/rules.d/
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 export AUDITFILE=/etc/audit/auditd.conf
 touch $TESTFILE

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/lenient_permissions.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # packages = audit
 
+rm -rf /etc/audit/*
+mkdir -p /etc/audit/rules.d/
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 export AUDITFILE=/etc/audit/auditd.conf
 touch $TESTFILE

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/stricter_permisions.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration_stig/tests/stricter_permisions.pass.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # packages = audit
 
+rm -rf /etc/audit/*
+mkdir -p /etc/audit/rules.d/
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 export AUDITFILE=/etc/audit/auditd.conf
 touch $TESTFILE


### PR DESCRIPTION
Remove pre-existing files before creating test files in test scenarios for rule `file_permissions_audit_configuration_stig`. Pre-existing files can cause unexpected test results, because the rule checks all files in the `/etc/audit/` directory.

This is a backport of https://github.com/ComplianceAsCode/content/pull/15011 to the stabilization branch.
