### PR TITLE
Remove unused xinetd parameter from bash_service_command macro

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -697,17 +697,14 @@ Macro to enable or disable a particular service.
 
         bash_service_command("enable", "bluetooth")
         bash_service_command("disable", "bluetooth.service")
-        bash_service_command("disable", "rsh.socket", xinetd="rsh")
 
 :param service_state: Desired state of the service
 :type service_state: str
 :param service: The service to change
 :type service: str
-:param xinetd: Set the xinetd for the service. Defaults to empty string.
-:type xinetd: str
 
 #}}
-{{%- macro bash_service_command(service_state, service, xinetd="") -%}}
+{{%- macro bash_service_command(service_state, service) -%}}
 {{#
 # If systemctl is installed, use systemctl command; otherwise, use the
 # service/chkconfig commands
@@ -730,15 +727,6 @@ fi
 if /usr/bin/systemctl --failed | grep -q "{{{ service }}}"; then
     /usr/bin/systemctl reset-failed "{{{ service }}}"
 fi
-{{%- endif -%}}
-
-{{%- if xinetd != "" -%}}
-grep -qi disable "/etc/xinetd.d/$xinetd" && \
-    {{%- if service_state == "disable" -%}}
-sed -i "s/disable.*/disable         = no/gI" "/etc/xinetd.d/$xinetd"
-    {{%- else -%}}
-sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
-    {{%- endif -%}}
 {{%- endif -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
The xinetd parameter in bash_service_command has never been used in the codebase and contains inverted logic (a 7+ year old bug where disabling a service sets disable=no, enabling it).

Since:
- The parameter is not used anywhere in rules or templates
- A dedicated xinetd_service_disabled template exists with correct logic
- xinetd has been removed from RHEL 9, RHEL 10, and OL9
- xinetd is obsolete on modern systems

Remove the dead code rather than fixing the bug.

Changes:
- Remove xinetd parameter from bash_service_command signature
- Remove xinetd example from documentation
- Remove xinetd parameter documentation
- Remove buggy xinetd code block (lines 735-742)

This cleanup removes confusing, buggy, and unused code without any functional impact since the parameter was never actually utilized.