### PR TITLE
CMP-4609: Fix file_permissions_scheduler rule to check for 0600 per CIS Benchmark

### DIFF
--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'Verify Permissions on the Kubernetes Scheduler Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="0600") }}}
 
 rationale: |-
     If the Kubernetes specification file is writable by a group-owner or the
@@ -22,10 +22,10 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-------") }}}
 
 platform: ocp4-master-node
 
@@ -39,5 +39,5 @@ template:
     name: file_permissions
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
-        filemode: '0644'
+        filemode: '0600'
         filepath_is_regex: "true"


### PR DESCRIPTION
## Problem

The rule `file_permissions_scheduler` (CIS Benchmark control 1.1.5) checks the permissions of `/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml` on master nodes.

The rule was configured with `filemode: 0644`, but the **CIS Benchmark requires `0600`**. On OCP clusters, these files already ship with the correct `0600` permissions (`-rw-------`).

This caused two issues:

1. **Misleading remediation guidance**: The rule description told users to run `chmod 0644`, which would **weaken** the existing `0600` permissions by adding group-read and other-read access.
2. **Incorrect OVAL check**: The OVAL state only checked for bits more permissive than `0644` (suid, sgid, sticky, uexec, gwrite, gexec, owrite, oexec). It did not flag `gread` or `oread` as violations, meaning a file with `0644` would incorrectly pass when it should fail per CIS requirements.

## Fix

Changed the `filemode` template parameter from `0644` to `0600` in `applications/openshift/master/file_permissions_scheduler/rule.yml`.

This produces four changes in the generated content:
- **Description**: `chmod 0644` → `chmod 0600`
- **Instructions**: `-rw-r--r--` → `-rw-------`
- **OVAL state**: Adds `gread` and `oread` to the list of prohibited permission bits (matching the existing pattern used by 10 other rules like `etcd_data_files`, `master_admin_kubeconfigs`, `openshift_pki_key_files`)
- **OVAL state ID**: `mode_not_0644` → `mode_not_0600`

## How to Reproduce / Verify

### Reproduce the bug (before the fix)

1. Install the compliance operator on an OCP 4.x cluster
2. Run a CIS-node scan: `oc get rules.compliance -n openshift-compliance ocp4-file-permissions-scheduler -o yaml`
3. Observe the description says `chmod 0644` and instructions say `-rw-r--r--`
4. Check actual permissions on a master node:
   ```bash
   oc debug node/<master> -- chroot /host bash -c \
     'stat -c "%a %n" /etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml'
   ```
5. Actual permissions are `600` (`-rw-------`), not `644`

### Verify the fix

1. Build the content with this fix: `./build_product ocp4 --datastream`
2. Build a content image: `podman build -f Dockerfiles/compliance_operator_content.Dockerfile -t <registry>/content:fix .`
3. Push and patch the ProfileBundle: `oc patch profilebundle ocp4 -n openshift-compliance --type merge -p '{"spec":{"contentImage":"<registry>/content:fix"}}'`
4. Check the rule description now says `chmod 0600` and `-rw-------`
5. Run a targeted scan — result should be **PASS** since actual files have `0600`

### Verified on

- OCP 4.22.0 nightly (2026-08-11) cluster with 3 master nodes
- All scheduler pod spec files confirmed at `0600`
- Scan result: **PASS** with the fixed content
