### PR TITLE
Fix HIPAA session timeout for OpenSSH >= 8.2

### DIFF
--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -382,6 +382,7 @@ controls:
           - sshd_enable_warning_banner
           - sshd_set_keepalive
           - sshd_set_keepalive_0
+          - logind_session_timeout
           - libreswan_approved_tunnels
           - dconf_gnome_remote_access_credential_prompt
           - dconf_gnome_remote_access_encryption
@@ -721,6 +722,7 @@ controls:
           - sshd_enable_warning_banner
           - sshd_set_keepalive
           - sshd_set_keepalive_0
+          - logind_session_timeout
           - sshd_use_priv_separation
           - libreswan_approved_tunnels
           - dconf_gnome_remote_access_credential_prompt
@@ -917,6 +919,7 @@ controls:
           - sshd_enable_warning_banner
           - sshd_set_keepalive
           - sshd_set_keepalive_0
+          - logind_session_timeout
           - sshd_use_priv_separation
           - coreos_disable_interactive_boot
           - disable_ctrlaltdel_burstaction
@@ -1699,6 +1702,7 @@ controls:
           - sshd_enable_warning_banner
           - sshd_set_keepalive
           - sshd_set_keepalive_0
+          - logind_session_timeout
           - sshd_use_approved_ciphers
           - sshd_use_approved_macs
           - sshd_use_priv_separation
@@ -1772,6 +1776,7 @@ controls:
           - sshd_enable_warning_banner
           - sshd_set_keepalive
           - sshd_set_keepalive_0
+          - logind_session_timeout
           - sshd_use_approved_ciphers
           - sshd_use_approved_macs
           - sshd_use_priv_separation

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -63,3 +63,4 @@ selections:
     - directory_group_ownership_var_log_audit
     - file_sshd_50_redhat_exists
     - journald_forward_to_syslog
+    - sshd_set_keepalive_0

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -66,3 +66,4 @@ selections:
     - '!service_rsh_disabled'
     - '!service_rexec_disabled'
     - '!configure_ssh_crypto_policy'
+    - '!sshd_set_keepalive_0'

--- a/products/rhel8/profiles/hipaa.profile
+++ b/products/rhel8/profiles/hipaa.profile
@@ -85,6 +85,7 @@ selections:
     - '!sshd_disable_rhosts_rsa'
     - '!sshd_disable_user_known_hosts'
     - '!sshd_set_keepalive'
+    - '!logind_session_timeout'
     - '!sshd_use_approved_ciphers'
     - '!sshd_use_approved_macs'
     - '!sshd_use_directory_configuration'

--- a/products/sle15/profiles/hipaa.profile
+++ b/products/sle15/profiles/hipaa.profile
@@ -84,6 +84,7 @@ selections:
     - '!sshd_disable_rhosts_rsa'
     - sshd_disable_user_known_hosts
     - sshd_set_keepalive
+    - '!sshd_set_keepalive_0'
     - sshd_use_approved_ciphers
     - sshd_use_approved_macs
     - '!sshd_use_directory_configuration'

--- a/products/sle16/profiles/hipaa.profile
+++ b/products/sle16/profiles/hipaa.profile
@@ -64,5 +64,6 @@ selections:
     - '!service_ypbind_disabled'
     - '!service_zebra_disabled'
     - '!sshd_disable_rhosts_rsa'
+    - '!sshd_set_keepalive_0'
     - '!sshd_use_approved_ciphers'
     - '!sshd_use_approved_macs'

--- a/tests/data/profile_stability/rhel10/hipaa.profile
+++ b/tests/data/profile_stability/rhel10/hipaa.profile
@@ -115,6 +115,7 @@ grub2_enable_selinux
 grub2_password
 kernel_module_usb-storage_disabled
 libreswan_approved_tunnels
+logind_session_timeout
 no_direct_root_logins
 no_empty_passwords
 package_audit_installed
@@ -155,7 +156,6 @@ sshd_do_not_permit_user_env
 sshd_enable_strictmodes
 sshd_enable_warning_banner
 sshd_set_keepalive
-sshd_set_keepalive_0
 sshd_use_directory_configuration
 sshd_use_priv_separation
 sysctl_fs_suid_dumpable

--- a/tests/data/profile_stability/rhel9/hipaa.profile
+++ b/tests/data/profile_stability/rhel9/hipaa.profile
@@ -89,6 +89,7 @@ grub2_enable_selinux
 grub2_password
 kernel_module_usb-storage_disabled
 libreswan_approved_tunnels
+logind_session_timeout
 no_direct_root_logins
 no_empty_passwords
 no_rsh_trust_files


### PR DESCRIPTION
Add logind_session_timeout to HIPAA controls to provide system-wide idle session termination via systemd-logind. Exclude sshd_set_keepalive_0 from RHEL10, SLE15, and SLE16 HIPAA profiles where it has broken behavior.

Update profile stability tests to reflect the changes.



