### PR TITLE
Remove `display_login_attempts` from Ubuntu 24.04's default profile

### DIFF
--- a/products/ubuntu2404/profiles/default.profile
+++ b/products/ubuntu2404/profiles/default.profile
@@ -206,7 +206,6 @@ selections:
     - disable_ctrlaltdel_reboot
     - disable_host_auth
     - disable_users_coredumps
-    - display_login_attempts
     - encrypt_partitions
     - ensure_pam_wheel_group_empty
     - ensure_root_access_controlled


### PR DESCRIPTION
#### Description:
Ubuntu 24.04 does not ship with `pam_lastlog` in its modules, and `pam_lastlog2` (its successor) is not available. #14666 was reported by another user with much better details and references the relevant changes, though the big issue is that applying `display_login_attempts`'s remediation to a 24.04 machine locks the user out from the tty console making it inaccessible in offline environments.

#### Rationale:
UBTU-24-300024 (V-270710) was removed in V1R5 STIG, and I do not see anything related to it for CIS, hence why it was removed from the default profile, though let me know if that's not the case. This was also removed in https://github.com/ansible-lockdown/UBUNTU24-STIG-Audit/commit/97ce781

This would close #14666

Thanks!
