### PR TITLE
Stabilization: bump /usr partition to 6800 MB for anssi_bp28 tests in rhel8

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
@@ -97,7 +97,7 @@ volgroup VolGroup pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=root --vgname=VolGroup --size=1024 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=6667 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=6800 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
 logvol /opt --fstype=xfs --name=opt --vgname=VolGroup --size=128 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -101,7 +101,7 @@ volgroup VolGroup pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=root --vgname=VolGroup --size=1024 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=6667 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=6800 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
 logvol /opt --fstype=xfs --name=opt --vgname=VolGroup --size=128 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
@@ -98,7 +98,7 @@ volgroup VolGroup pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=root --vgname=VolGroup --size=1024 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=6667 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=6800 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
 logvol /opt --fstype=xfs --name=opt --vgname=VolGroup --size=128 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition


### PR DESCRIPTION
#### Description:

- This is a backport of https://github.com/ComplianceAsCode/content/pull/15025