### PR TITLE
Stabilization: Change scope of grub2_bootloader_argument templated tests

### DIFF
--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+{{% if not ARG_VALUE and not ARG_VARIABLE %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_fedora,multi_platform_rhel
+{{% endif %}}
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+{{% if not ARG_VALUE and not ARG_VARIABLE %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 
 {{%- if 'ubuntu' in product %}}
 # packages = grub2

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+{{% if not ARG_VALUE and not ARG_VARIABLE %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_ubuntu
+{{% endif %}}
 # packages = grub2
 
 {{%- if ARG_VARIABLE %}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+
+{{% if not ARG_VALUE and not ARG_VARIABLE %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}={{{ TEST_VALUE_PASS }}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+{{% if not ARG_VALUE and not ARG_VARIABLE %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
+{{% endif %}}
 # packages = grub2,grubby
 
 {{%- if ARG_VARIABLE %}}


### PR DESCRIPTION
Some test scenarios test correct handling of *values* of bootloader arguments. But, not all arguments have values, some arguments are value-less, for example `nousb`. For the value-less arguments it doesn't make sense to test the correct handling of values. Some tests that currently attempt to do this are broken.

We will fix it by disabling the test scenarios.
We will use the well-known "trick" of setting the `# platform` header to `Not Applicable` if the bootloader argument isn't supposed to have any value. These are rules where the template isn't given the `arg_value` or `arg_variable` parameter.

Fixes failing templated test scenario `wrong_value_entries.fail.sh` in rule `grub2_nousb_argument`.


This PR is a backport of the PR https://github.com/ComplianceAsCode/content/pull/15026 to the stabilization branch.
