### PR TITLE
Remove untestable missing.pass.sh scenario for file_permissions_sshd_private_key

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing.pass.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# remediation = none
-
-rm -f /etc/ssh/* || true # ignore error on deleting directories
-
-


### PR DESCRIPTION
## Description

Removes the `missing.pass.sh` test scenario for `file_permissions_sshd_private_key`.

## Rationale

The scenario was included accidentally in #15015 and cannot be validated by Automatus on any backend:

- Every Automatus backend (libvirt **and** container) scans the target over SSH via `oscap-ssh`.
- The scenario's `rm -f /etc/ssh/*` deletes the SSH host keys that transport depends on.
- Modern OpenSSH re-execs a fresh `sshd` per connection and reloads host keys from disk, so the scan connection is reset (`kex_exchange_identification: read: Connection reset by peer`) before the rule can be evaluated.

It also carried a `# remediation = none` directive, which is invalid for a `.pass.sh` test and was flagged by the test-scenario linter:

```
FAIL file_permissions_sshd_private_key/missing.pass
(remediation=none doesn't make sense for a .pass.sh test)
```

The behavior the scenario aimed to cover — when no key files are present there are no offending keys, so the check passes — is already guaranteed by the OVAL `check_existence="none_exist"` semantics and needs no runtime scenario.

## Verification

Reproduced the SSH-transport failure on a rhel9 libvirt VM (initial scan reset before evaluation) and confirmed that even surgical `*_key`-only removal breaks new SSH connections, since sshd is the classic `sshd.service` (not socket-activated) yet OpenSSH still reloads host keys on each re-exec.