### PR TITLE
Avoid duplicate YAML keys in sshd private key ansible remediation (yamllint issue)

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml
@@ -25,12 +25,10 @@
     - "{{ root_owned_keys.stdout_lines }}"
 
 {{% if dedicated_ssh_groupname -%}}
+{{% set dedicated_find_permissions = 'u+xs,g+xws,o+xwrt' if product == "rhcos4" else 'u+xs,g+xwrs,o+xwrt' %}}
+{{% set dedicated_permissions_mode = 'u-xs,g-xws,o-xwrt' if product == "rhcos4" else 'u-xs,g-xwrs,o-xwrt' %}}
 - name: Find root:{{{ dedicated_ssh_groupname }}}-owned keys
-{{% if product == "rhcos4" %}}
-  ansible.builtin.command: '{{{ find_command_base }}} -group {{{ dedicated_ssh_groupname }}} -perm /u+xs,g+xws,o+xwrt'
-{{% else %}}
-  ansible.builtin.command: '{{{ find_command_base }}} -group {{{ dedicated_ssh_groupname }}} -perm /u+xs,g+xwrs,o+xwrt'
-{{% endif %}}
+  ansible.builtin.command: '{{{ find_command_base }}} -group {{{ dedicated_ssh_groupname }}} -perm /{{{ dedicated_find_permissions }}}'
   register: dedicated_group_owned_keys
   changed_when: False
   failed_when: False
@@ -39,11 +37,7 @@
 - name: Set permissions for root:{{{ dedicated_ssh_groupname }}}-owned keys
   ansible.builtin.file:
     path: "{{ item }}"
-{{% if product == "rhcos4" %}}
-    mode: "u-xs,g-xws,o-xwrt"
-{{% else %}}
-    mode: "u-xs,g-xwrs,o-xwrt"
-{{% endif %}}
+    mode: "{{{ dedicated_permissions_mode }}}"
     state: file
   with_items:
     - "{{ dedicated_group_owned_keys.stdout_lines }}"


### PR DESCRIPTION
Fixes the ansible lint issues because of jinja macros definitions:

```
Running yamllint on linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml...
stdin
  Warning: 11:1 [empty-lines] too many blank lines (6 > 2)
  Error: 32:3 [key-duplicates] duplication of key "ansible.builtin.command" in mapping
  Error: 45:5 [key-duplicates] duplication of key "mode" in mapping
  Warning: 50:1 [empty-lines] too many blank lines (1 > 0)
Running yamllint on linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml...
stdin
  Warning: 15:1 [empty-lines] too many blank lines (12 > 2)
```

No need to backport this since it doesn't change any code behavior.