### PR TITLE
CMP-4619: Fix-OpenSCAP rules for /etc/shadow return ERROR on RHCOS 10

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/oval/shared.xml
@@ -6,14 +6,16 @@
       test_ref="test_no_empty_passwords_etc_shadow" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+  <unix:shadow_test check="all" check_existence="none_exist" version="1"
   id="test_no_empty_passwords_etc_shadow"
   comment="make sure there aren't blank or null passwords in /etc/shadow">
-    <ind:object object_ref="obj_no_empty_passwords_etc_shadow" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_no_empty_passwords_etc_shadow" version="1">
-    <ind:filepath>/etc/shadow</ind:filepath>
-    <ind:pattern operation="pattern match">^[^:]+::.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+    <unix:object object_ref="obj_no_empty_passwords_etc_shadow" />
+  </unix:shadow_test>
+  <unix:shadow_object id="obj_no_empty_passwords_etc_shadow" version="1">
+    <unix:username operation="pattern match">.*</unix:username>
+    <filter action="exclude">state_no_empty_passwords_etc_shadow_nonempty</filter>
+  </unix:shadow_object>
+  <unix:shadow_state id="state_no_empty_passwords_etc_shadow_nonempty" version="1">
+    <unix:password operation="pattern match">.+</unix:password>
+  </unix:shadow_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/oval/shared.xml
@@ -6,17 +6,16 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="check for existence of lines starting with +" id="test_no_legacy_plus_entries_etc_shadow"
+  <unix:shadow_test check="all" check_existence="none_exist"
+  comment="check for existence of shadow entries with username starting with +"
+  id="test_no_legacy_plus_entries_etc_shadow"
   version="1">
-    <ind:object object_ref="object_no_legacy_plus_entries_etc_shadow" />
-  </ind:textfilecontent54_test>
+    <unix:object object_ref="object_no_legacy_plus_entries_etc_shadow" />
+  </unix:shadow_test>
 
-  <ind:textfilecontent54_object comment="lines starting with +"
+  <unix:shadow_object comment="shadow entries with username starting with +"
   id="object_no_legacy_plus_entries_etc_shadow" version="1">
-    <ind:filepath>/etc/shadow</ind:filepath>
-    <ind:pattern operation="pattern match">^\+.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+    <unix:username operation="pattern match">^\+.*$</unix:username>
+  </unix:shadow_object>
 
 </def-group>


### PR DESCRIPTION
#### Description:

- Two OVAL rules (`no_empty_passwords_etc_shadow`, `no_legacy_plus_entries_etc_shadow`) that check `/etc/shadow` return ERROR on RHCOS 10 because the `textfilecontent54` probe cannot read the file —` /etc/shadow` has 0000 permissions on RHEL 10.
- This PR switches both rules from` ind:textfilecontent54` (direct file I/O) to unix:shadow (C library shadow API via `getspent()`), which does not require direct file read access.
- This pattern is already used by other shadow rules in this repo (`no_password_auth_for_systemaccounts`, `accounts_password_all_shadowed_sha512`, `accounts_password_last_change_is_in_past`).
- Backwards compatible — `unix:shadow` probe is available on all supported platforms (RHEL 8/9/10).


#### Rationale:

- On RHEL 10 / RHCOS 10, /etc/shadow has 0000 permissions. The OpenSCAP textfilecontent54 probe opens the file directly and fails with "No space left on device" when it cannot access it, returning ERROR instead of evaluating the rule.
- 
- The unix:shadow probe reads shadow entries through the getspent() C library API, bypassing file permissions entirely. It is the correct way to access shadow data and is already used by other rules in the same profile.
- 
- Fixes CMP-4619


#### Review Hints:

Verified on OCP 5.0.0-0.nightly-2026-08-21-033959 (RHCOS 10.2, 3 masters + 3 workers) with CO 1.9.2. 

To verify manually on a node: `oc debug node/<name> -- chroot /host bash -c 'awk -F: "!length(\$2) {print \$1}" /etc/shadow && grep "^\+" /etc/shadow'` — empty output confirms compliance.

Co-authored with Claude