### PR TITLE
authselect remediation macro removed sudo rights

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -2156,9 +2156,9 @@ Part of the grub2_bootloader_argument_absent template.
     - authselect_current_profile is not match("custom/")
     - authselect_custom_profile is not match(authselect_current_profile)
 
-- name: '{{{ rule_title }}} - Ensure the authselect custom profile is selected'
+- name: '{{{ rule_title }}} - Ensure the authselect custom profile and features are selected'
   ansible.builtin.command:
-    cmd: authselect select {{ authselect_custom_profile }}
+    cmd: authselect select {{ authselect_custom_profile }} {{ result_authselect_features.stdout_lines | join(' ') }}
   register: result_pam_authselect_select_profile
   when:
     - result_authselect_check_cmd is success
@@ -2166,21 +2166,10 @@ Part of the grub2_bootloader_argument_absent template.
     - authselect_current_profile is not match("custom/")
     - authselect_custom_profile is not match(authselect_current_profile)
 
-- name: '{{{ rule_title }}} - Restore the authselect features in the custom profile'
-  ansible.builtin.command:
-    cmd: authselect enable-feature {{ item }}
-  loop: "{{ result_authselect_features.stdout_lines }}"
-  register: result_pam_authselect_restore_features
-  when:
-    - result_authselect_profile is not skipped
-    - result_authselect_features is not skipped
-    - result_pam_authselect_select_profile is not skipped
-
 {{{ ansible_apply_authselect_changes('after-hardening-custom-profile', rule_title=rule_title) }}}
   when:
     - result_authselect_check_cmd is success
     - result_authselect_profile is not skipped
-    - result_pam_authselect_restore_features is not skipped
 {{%- endmacro %}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2587,10 +2587,7 @@ if [[ ! $CURRENT_PROFILE == custom/* ]]; then
     authselect create-profile hardening -b $CURRENT_PROFILE
     CURRENT_PROFILE="custom/hardening"
     {{{ bash_apply_authselect_changes('before-hardening-custom-profile') | indent(4) }}}
-    authselect select $CURRENT_PROFILE
-    for feature in $ENABLED_FEATURES; do
-        authselect enable-feature $feature;
-    done
+    authselect select $CURRENT_PROFILE $ENABLED_FEATURES
     {{{ bash_apply_authselect_changes('after-hardening-custom-profile') | indent(4) }}}
 fi
 {{%- endmacro %}}


### PR DESCRIPTION
We use Red Hat IdM as our authentication backend and rely on centralised sudo management.
Following the integration of the system with ipa-client-install, the authselect configuration appears as follows:

```
# authselect current
Profile ID: sssd
Enabled features:
- with-mkhomedir
- with-sudo
```


In the old implementation, configuring the custom profile (custom/hardening) and enabling features was split into several Ansible tasks.

1. Read current authselect profile
2. Read the current enabled features
3. Create a new profile
4. Activate the profile
5. Re-enable previous features

When I run the remediation process using my personal account via sudo, I receive an error message at step 5 because, after activating step 4, authselect/pam loses access to the centralised Red Hat IdM sudo environment.
Fortunately, the authselect command can be used to configure the profile and features in a single command:

```
# authselect select custom/hardening with-sudo with-mkhomedir.
```

The pull request updates the Ansible and bash macros accordingly.