### PR TITLE
Require 0600 for group-owned SSH private keys in the OVAL check

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/oval/shared.xml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/oval/shared.xml
@@ -85,7 +85,11 @@
       {{# intentionally not considered: <unix:uwrite datatype="boolean">true</unix:uwrite> #}}
       <unix:uexec datatype="boolean">false</unix:uexec>
 
+      {{% if product == "rhcos4" -%}}
       {{# intentionally not considered: <unix:gread datatype="boolean">true</unix:gread> #}}
+      {{%- else %}}
+      <unix:gread datatype="boolean">false</unix:gread>
+      {{%- endif %}}
       <unix:gwrite datatype="boolean">false</unix:gwrite>
       <unix:gexec datatype="boolean">false</unix:gexec>
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/puppet/shared.pp
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/puppet/shared.pp
@@ -1,9 +1,14 @@
 # platform = multi_platform_all
+{{% if product == "rhcos4" %}}
+{{% set perms_num = "0640" %}}
+{{% else %}}
+{{% set perms_num = "0600" %}}
+{{% endif %}}
 include ssh_private_key_perms
 
 class ssh_private_key_perms {
   exec { 'sshd_priv_key':
-    command => "chmod 0640 /etc/ssh/*_key",
+    command => "chmod {{{ perms_num }}} /etc/ssh/*_key",
     path    => '/bin:/usr/bin'
   }
 }

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -16,8 +16,10 @@ title: 'Verify Permissions on SSH Server Private *_key Key Files'
 description: |-
     SSH server private keys - files that match the <code>/etc/ssh/*_key</code> glob, have to have restricted permissions.
     If those files are owned by the <code>root</code> user and the <code>root</code> group, they have to have the <code>{{{ perms_num }}}</code> permission or stricter.
-    {{% if dedicated_ssh_groupname -%}}
+    {{% if dedicated_ssh_groupname and perms_num == "0640" -%}}
     If they are owned by the <code>root</code> user, but by a dedicated group <code>{{{ dedicated_ssh_groupname }}}</code>, they can have the <code>0640</code> permission or stricter.
+    {{%- elif dedicated_ssh_groupname -%}}
+    If they are owned by the <code>root</code> user, but by a dedicated group <code>{{{ dedicated_ssh_groupname }}}</code>, they still have to have the <code>{{{ perms_num }}}</code> permission or stricter.
     {{%- endif %}}
 
 rationale: |-

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/dedicated_group_lenient.fail.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/dedicated_group_lenient.fail.sh
@@ -7,11 +7,8 @@ if ! grep -q "{{{ dedicated_ssh_groupname }}}" /etc/group; then
     groupadd "{{{ dedicated_ssh_groupname }}}"
 fi
 
-# The default host keys ship as root:{{{ dedicated_ssh_groupname }}} with mode 0640 on RHEL,
-# which is now a finding on non-immutable systems - harden them so the whole
-# system is compliant for this pass scenario.
-chmod 0600 /etc/ssh/*_key
-
+# Keys owned by root:{{{ dedicated_ssh_groupname }}} must still be 0600 or stricter on
+# non-immutable systems - the 0640 group-owned exception only applies to rhcos4.
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chown root:{{{ dedicated_ssh_groupname }}} "$FAKE_KEY"
-chmod 0600 "$FAKE_KEY"
+chmod 0640 "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/supercompliance.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/supercompliance.pass.sh
@@ -3,6 +3,11 @@
 
 {{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {"name": "root"}).get("name") %}}
 
+# The default host keys ship as root:{{{ dedicated_ssh_groupname }}} with mode 0640 on RHEL,
+# which is now a finding on non-immutable systems - harden them so the whole
+# system is compliant for this pass scenario.
+chmod 0600 /etc/ssh/*_key
+
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chown root:{{{ dedicated_ssh_groupname }}} "$FAKE_KEY"
 chmod 0400 "$FAKE_KEY"
@@ -10,4 +15,3 @@ chmod 0400 "$FAKE_KEY"
 FAKE_KEY_ROOT=$(mktemp -p /etc/ssh/ XXXX_key)
 chown root:root "$FAKE_KEY_ROOT"
 chmod 0400 "$FAKE_KEY_ROOT"
-


### PR DESCRIPTION
#### Description:

- Require mode `0600` for group-owned SSH private host keys in the OVAL check, so `root:<dedicated group>` (e.g. `root:ssh_keys`) keys at `0640` are now flagged as a finding on non-immutable systems. The `0640` group-readable exception now applies to `rhcos4` only.
- Align the rule description, the Puppet remediation (which hardcoded `0640`), and the test scenarios with this behavior.

#### Rationale:

- PR #15015 restricted the `0640` exception to `rhcos4`, but the exception is implemented **twice** in the OVAL check — once for `root:root` and once for `root:<dedicated group>`. Only the `root:root` state was gated, so `root:ssh_keys 0640` keys (the RHEL default) still passed even though the Bash/Ansible remediations already enforce `0600`.
- This caused SSG to report `pass` while DISA's SCAP content reported `fail` for `SV-230287` on stock RHEL. This change closes that gap and matches the DISA STIG.

#### Review Hints:

- The core fix is a single `gread` gate in `oval/shared.xml`; the built OVAL now sets `gread=false` for both the `root` and dedicated-group filter states.
- The default RHEL host keys ship as `root:ssh_keys 0640`, so the two whole-system pass scenarios (`supercompliance.pass.sh`, `altcorrect_permissions.pass.sh`) now harden pre-existing keys first. New `dedicated_group_lenient.fail.sh` covers the `root:<group> 0640` regression.
- Run automatus tests for the affected rule