### PR TITLE
Mark missing_auid tests as pass for lastlog/faillock audit rules

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/rhel9_missing_auid.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/rhel9_missing_auid.pass.sh
@@ -3,6 +3,6 @@
 # packages = audit
 # variables = var_accounts_passwords_pam_faillock_dir=/var/log/faillock
 
-# This test should fail because it's missing the auid filters
+# This test should pass because the auid filters are optional from the OVAL point of view
 echo "-a always,exit -F arch=b32 -F path=/var/log/faillock -F perm=wa -F key=logins" >> /etc/audit/rules.d/logins.rules
 echo "-a always,exit -F arch=b64 -F path=/var/log/faillock -F perm=wa -F key=logins" >> /etc/audit/rules.d/logins.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/rhel9_missing_auid.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/rhel9_missing_auid.pass.sh
@@ -2,6 +2,6 @@
 # platform = Red Hat Enterprise Linux 9
 # packages = audit
 
-# This test should fail because it's missing the auid filters
+# This test should pass because the auid filters are optional from the OVAL point of view
 echo "-a always,exit -F arch=b32 -F path=/var/log/lastlog -F perm=wa -k logins" >> /etc/audit/rules.d/logins.rules
 echo "-a always,exit -F arch=b64 -F path=/var/log/lastlog -F perm=wa -k logins" >> /etc/audit/rules.d/logins.rules


### PR DESCRIPTION
#### Description:

- Convert the `rhel9_missing_auid` Automatus scenarios of the
  `audit_rules_login_events_lastlog` and `audit_rules_login_events_faillock`
  rules from `.fail` tests to `.pass` tests. On rhel9 (which uses the `modern`
  audit watch style), the OVAL check accepts audit rules with or without the
  `auid` filters (`-F auid>=1000 -F auid!=unset`), so an audit rule that omits
  them must pass the scan.

#### Rationale:

- Both rules use the `audit_rules_watch` template, which generates a pattern
  ending in `-F perm=wa.*$` for the `-a always,exit` rule form. The trailing
  `.*$` makes the `auid` filters optional, so a rule like
  `-a always,exit -F arch=b32 -F path=<watched_path> -F perm=wa -F key=logins`
  matches and the scan passes. The scenarios were previously classified as
  failures, which contradicts each rule's own `warnings:` note stating the OVAL
  accepts audit rules with or without the `auid` filters. This mismatch caused a
  false test expectation.

#### Review Hints:

- The behavior can be confirmed from each rule's `warnings:` block in its
  `rule.yml` and from the generated regex in
  `shared/templates/audit_rules_watch/oval.template`.
- To verify with Automatus:
  `python tests/automatus.py rule --libvirt qemu:///system <VM> audit_rules_login_events_lastlog audit_rules_login_events_faillock`
- Each change is a single-file rename (`.fail.sh` → `.pass.sh`) plus a one-line
  comment update; the `-master` and `-stabilization` branches are identical.
