### PR TITLE
stabilization: Mark missing_auid tests as pass for lastlog/faillock audit rules

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/rhel9_missing_auid.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/rhel9_missing_auid.pass.sh
@@ -3,6 +3,6 @@
 # packages = audit
 # variables = var_accounts_passwords_pam_faillock_dir=/var/log/faillock
 
-# This test should fail because it's missing the auid filters
+# This test should pass because the auid filters are optional from the OVAL point of view
 echo "-a always,exit -F arch=b32 -F path=/var/log/faillock -F perm=wa -F key=logins" >> /etc/audit/rules.d/logins.rules
 echo "-a always,exit -F arch=b64 -F path=/var/log/faillock -F perm=wa -F key=logins" >> /etc/audit/rules.d/logins.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/rhel9_missing_auid.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/rhel9_missing_auid.pass.sh
@@ -2,6 +2,6 @@
 # platform = Red Hat Enterprise Linux 9
 # packages = audit
 
-# This test should fail because it's missing the auid filters
+# This test should pass because the auid filters are optional from the OVAL point of view
 echo "-a always,exit -F arch=b32 -F path=/var/log/lastlog -F perm=wa -k logins" >> /etc/audit/rules.d/logins.rules
 echo "-a always,exit -F arch=b64 -F path=/var/log/lastlog -F perm=wa -k logins" >> /etc/audit/rules.d/logins.rules


### PR DESCRIPTION
Backport of #15058