### PR TITLE
Restore Hummingbird 65532 user exclusion in interactive users OVAL macro

### DIFF
--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1243,7 +1243,15 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 #}}
 {{%- macro create_interactive_users_list_object(object_id, include_root=False, rule_id=None) -%}}
+  {{%- if product == "hummingbird" -%}}
+  {{# Hummingbird distroless images ship a special "container user" named 65532 whose #}}
+  {{# passwd primary group is 0 while its home directory is group-owned by 65532. It is #}}
+  {{# not a real interactive user, so exclude it to avoid false positives in the #}}
+  {{# interactive-user home directory and dotfile checks. #}}
+  {{%- set ignored_users_list="(nobody|nfsnobody|65532)" %}}
+  {{%- else -%}}
   {{%- set ignored_users_list="(nobody|nfsnobody)" %}}
+  {{%- endif -%}}
 
   <unix:password_object id="{{{ object_id }}}" version="1">
     <set>


### PR DESCRIPTION
#### Description:

- PR #15008 migrated file_groupownership_home_directories (and the other interactive-user checks that share create_interactive_users_list_object) from the local /etc/passwd macro to the getpwent-based one, but the getpwent macro never carried the Hummingbird-specific carve-out that excludes the special "container user" named 65532.

On Hummingbird distroless images that account has UID 65532, primary group 0, and home /home/build (group-owned by 65532). Without the exclusion it is treated as a regular interactive user, so file_groupownership_home_directories now compares /home/build's group (65532) against the interactive users' primary GID set ({0}) and fails, producing a false positive that the previous content did not report.

Reintroduce the same product == "hummingbird" carve-out in create_interactive_users_list_object so the special user is ignored, restoring the prior behavior for all rules using this macro.

#### Rationale:

- Fixes #15065


