### PR TITLE
Remove hmac-ripemd160 from RHEL OpenSCAP SSH MAC value selectors

### DIFF
--- a/linux_os/guide/services/ssh/sshd_strong_macs.var
+++ b/linux_os/guide/services/ssh/sshd_strong_macs.var
@@ -11,10 +11,10 @@ operator: equals
 interactive: false
 
 options:
-    default: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
-    cis_rhel8: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
-    cis_rhel9: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
-    cis_rhel10: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
+    default: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+    cis_rhel8: -hmac-md5,hmac-md5-96,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
+    cis_rhel9: -hmac-md5,hmac-md5-96,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
+    cis_rhel10: -hmac-md5,hmac-md5-96,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
     cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_tencentos4: hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com


### PR DESCRIPTION
#### Description:

- Remove `hmac-ripemd160` from the `sshd_strong_macs` default allow-list.
- Remove `hmac-ripemd160` and `hmac-ripemd160-etm@openssh.com` from
  `cis_rhel8`, `cis_rhel9`, and `cis_rhel10` deny-lists.

#### Rationale:

- Resolves: [RHEL-250374](https://redhat.atlassian.net/browse/RHEL-250374)

- On RHEL 8, `ssh -Q mac` does not list it. Remediation that uses the default selector writes:

  `MACs hmac-sha2-512-etm@openssh.com,...,hmac-sha2-256,hmac-ripemd160` 

  sshd then fails with `Bad SSH2 mac spec` and does not start.
  
- `cis_rhel8/9/10` stay deny-lists (leading `-`). Only unimplemented
  ripemd names are removed. This is not an allow-list conversion.
- #14447 fixed SLE only (`cis_sle12`). RHEL `default` was left unchanged.
- #14460 attempted a default-value fix but was closed unmerged.



#### Review Hints:

- One file: `linux_os/guide/services/ssh/sshd_strong_macs.var`
- On RHEL 8: `sshd -t` succeeds with the new default and new cis_rhel8 list
- The generated remediation for the RHEL profiles should not contain
  `hmac-ripemd160` in the affected selectors.

[RHEL-250374]: https://redhat.atlassian.net/browse/RHEL-250374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ