### PR TITLE
Use symbolic file mode for /etc/audit/auditd.conf

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action_stig/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action_stig/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -12,4 +12,4 @@
         line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
         state: present
         create: yes
-        mode: 0640
+        mode: 'u-x,g-wx,o-rwx'

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*admin_space_left_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/ansible/shared.yml
@@ -12,4 +12,4 @@
     regexp: '^\s*admin_space_left\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
@@ -12,5 +12,5 @@
     line: "flush = {{ var_auditd_flush }}"
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -12,5 +12,5 @@
     line: "max_log_file = {{ var_auditd_max_log_file }}"
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*max_log_file_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*max_log_file_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*num_logs\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*space_left\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*space_left_action\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/ansible/shared.yml
@@ -12,5 +12,5 @@
     regexp: '^\s*space_left\s*=\s*.*$'
     state: present
     create: yes
-    mode: 0640
+    mode: 'u-x,g-wx,o-rwx'
   #notify: reload auditd

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_name_format/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_name_format/ansible/shared.yml
@@ -21,4 +21,5 @@
                   create=true,
                   separator=" = ",
                   separator_regex="\s*=\s*",
+                  mode="u-x,g-wx,o-rwx",
                   prefix_regex="(?i)^\s*", rule_title=rule_title) }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_overflow_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_overflow_action/ansible/shared.yml
@@ -16,4 +16,5 @@
                   create=true,
                   separator=" = ",
                   separator_regex="\s*=\s*",
+                  mode="u-x,g-wx,o-rwx",
                   prefix_regex="(?i)^\s*", rule_title=rule_title) }}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -363,7 +363,7 @@ value: :code:`Setting={{ varname1 }}`
 
 #}}
 {{%- macro ansible_auditd_set(msg='', parameter='', value='', rule_title=None) %}}
-{{{ ansible_set_config_file(msg, "/etc/audit/auditd.conf", parameter=parameter, value=value, create="yes", prefix_regex='(?i)^\s*', separator=" = ", separator_regex="\s*=\s*", mode="0640", rule_title=rule_title) }}}
+{{{ ansible_set_config_file(msg, "/etc/audit/auditd.conf", parameter=parameter, value=value, create="yes", prefix_regex='(?i)^\s*', separator=" = ", separator_regex="\s*=\s*", mode="u-x,g-wx,o-rwx", rule_title=rule_title) }}}
 {{%- endmacro %}}
 
 {{#


### PR DESCRIPTION
Keeps permissions intact if they are already stricter than expected. Also, avoids the implicit conversion of the file mode from octal number (0640) to decimal number (416).

Fixes: failing rule file_permissions_audit_configuration_stig in contest tests /hardening/ansible/stig, /hardening/host-os/ansible/stig on RHEL 8.10, 9.2 and 9.9.

