### PR TITLE
CMP-4648: Fix the content image profile-enable list (virt profiles on all arches, un-break the enable chain)

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -19,6 +19,8 @@ RUN sed -i 's/\(documentation_complete: \).*/\1true/' \
     products/ocp4/profiles/cis.profile \
     products/ocp4/profiles/cis-node-1-7.profile \
     products/ocp4/profiles/cis-1-7.profile \
+    products/ocp4/profiles/cis-node-1-9.profile \
+    products/ocp4/profiles/cis-1-9.profile \
     products/ocp4/profiles/moderate-node.profile \
     products/ocp4/profiles/moderate.profile \
     products/ocp4/profiles/moderate-node-rev-4.profile \
@@ -28,7 +30,9 @@ RUN sed -i 's/\(documentation_complete: \).*/\1true/' \
     products/ocp4/profiles/pci-dss-node-4-0.profile \
     products/ocp4/profiles/pci-dss-4-0.profile \
     products/ocp4/profiles/pci-dss-node-3-2.profile \
-    products/ocp4/profiles/pci-dss-3-2.profile
+    products/ocp4/profiles/pci-dss-3-2.profile \
+    products/ocp4/profiles/cis-vm-extension.profile \
+    products/ocp4/profiles/cis-vm-extension-node.profile
 
 # Enable the FedRAMP Moderate profile on ARM64.
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
@@ -59,16 +63,14 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/bsi-node.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/bsi-2022.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/bsi-node-2022.profile &&  \
-    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-v2r2.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-v2r3.profile && \
-    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r2.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r3.profile && \
-    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/cis-vm-extension.profile && \
-    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/cis-vm-extension-node.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-v2r6.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r6.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/bsi.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/bsi-2022.profile && \
-    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r2.profile; \
-    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r3.profile; \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r3.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r6.profile; \
     fi
 
 # Enable the DISA-STIG profiles for ppc64le


### PR DESCRIPTION
#### Description:

Fixes [CMP-4648](https://issues.redhat.com/browse/CMP-4648). Four fixes to the Konflux Containerfile's profile enable list, found during the CMP-4506 joint testing on a mixed-architecture CNV cluster:

1. **Virt profiles were x86_64-only.** `cis-vm-extension` / `cis-vm-extension-node` (added in #14989) sat in the x86_64 block, so the aarch64 datastream shipped without them: ARM worker nodes fail with `No profile matching suffix` and `strictNodeScan` turns the whole worker pool ERROR. Verified by extracting the arm64 variant of `content-dev:master` (14 profiles, no virt) and by per-node scanner exit codes on the test cluster (the two ARM nodes exit 1, all 19 x86_64 workers exit 2). Moved to the all-architecture enable block.

2. **The x86_64 enable chain has been silently broken since #15042** (STIG V2R2 removal): the list still `sed -i`'ed the three deleted `stig-v2r2` files; the failing sed short-circuits the `&&` chain and skips every later enable - **stig-v2r3, stig-node-v2r3, both virt profiles, and the rhcos4 bsi enables are all missing from current `content-dev:master`** (verified by extracting the amd64 datastream). The failure was masked by a trailing `;` keeping the RUN exit 0. Removed the dead seds; the block is now one `&&` chain so a missing file fails the build loudly.

3. **`cis-1-9` / `cis-node-1-9` enabled**: `cis`/`cis-node` extend them and profile resolution fails when the parent is not enabled (reproduced on a clean local build of the enable set).

4. **STIG V2R6 enabled with the same architecture support as V2R3** (`stig-v2r6`, `stig-node-v2r6`, rhcos4 `stig-v2r6` in the x86_64 block): `stig`/`stig-node`/rhcos4 `stig` now extend v2r6 - same resolution requirement as (3) - and without this x86_64 would ship only the older snapshot while ppc64le picks v2r6 up via its `find *stig*` glob. The CEL `stig-vm-extension` profiles are deliberately untouched (they ship via the CEL bundle; see comments).

Validated:
- Simulated the aarch64 enable path per this Containerfile, built the datastream, and ran it end-to-end through Compliance Operator 1.9.1 on a live cluster: PB VALID, `cis-vm-extension-node` Profile CR created, master+worker node scans DONE with all five rules evaluated - the exact scenario that ERRORs today.
- Simulated the full x86_64 enable path (executing this file's sed lines verbatim) and built ocp4+rhcos4: both datastreams now carry stig/stig-v2r3/stig-v2r6 (+node variants) and cis-vm-extension-node; all extends chains resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CMP-4648]: https://redhat.atlassian.net/browse/CMP-4648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ