### PR TITLE
Systemd timer template enable masked timers

### DIFF
--- a/shared/templates/timer_enabled/ansible.template
+++ b/shared/templates/timer_enabled/ansible.template
@@ -14,6 +14,6 @@
       name: "{{{ TIMERNAME }}}.timer"
       enabled: "yes"
       state: "started"
+      masked: "no"
     when:
     - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'
-

--- a/shared/templates/timer_enabled/ansible.template
+++ b/shared/templates/timer_enabled/ansible.template
@@ -14,6 +14,6 @@
       name: "{{{ TIMERNAME }}}.timer"
       enabled: "yes"
       state: "started"
-      masked: "no"
+      masked: "false"
     when:
     - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'

--- a/shared/templates/timer_enabled/bash.template
+++ b/shared/templates/timer_enabled/bash.template
@@ -5,6 +5,7 @@
 # disruption = low
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ TIMERNAME }}}.timer'
 if [[ $("$SYSTEMCTL_EXEC" is-system-running) != "offline" ]]; then
   "$SYSTEMCTL_EXEC" start '{{{ TIMERNAME }}}.timer'
 fi

--- a/shared/templates/timer_enabled/tests/timer_masked.fail.sh
+++ b/shared/templates/timer_enabled/tests/timer_masked.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = {{{ PACKAGENAME }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop '{{{ TIMERNAME }}}.timer'
+"$SYSTEMCTL_EXEC" mask '{{{ TIMERNAME }}}.timer'


### PR DESCRIPTION
#### Description:

- In case the timer we must enable is masked the template should cover that case also

#### Rationale:

- Make sure ansible and bash remediations unmask the timer that should be enabled
- Add a small fail test when timer is masked
