### PR TITLE
Fix Packit propose_downstream jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,6 @@
 downstream_package_name: scap-security-guide
 upstream_package_name: scap-security-guide
+upstream_tag_template: v{version}
 specfile_path: scap-security-guide.spec
 
 actions:


### PR DESCRIPTION
Packit didn't create Fedora PRs after the 0.1.82 release.

The jobs failed with a "double v" error.
https://dashboard.packit.dev/jobs/propose-downstream/32603

```
2026-09-01 14:59:14.055 base_git.py       ERROR  Failed to download source from https://github.com/ComplianceAsCode/content/releases/download/vv0.1.82/scap-security-guide-v0.1.82.tar.bz2: HTTPError('404 Client Error: Not Found for url: https://github.com/ComplianceAsCode/content/releases/download/vv0.1.82/scap-security-guide-v0.1.82.tar.bz2')
2026-09-01 14:59:14.077 api.py            WARNING Please, check whether the `upstream_tag_template` needs to be configured.
```

Adding `upstream_tag_template` should resolve this issue, see the Packit docs:
https://packit.dev/docs/configuration#upstream_tag_template

