### PR TITLE
Add an Ubuntu/Debian override to platform: package[openssh-client]

### DIFF
--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -98,7 +98,11 @@ args:
   openssh:
     pkgname: openssh
   openssh-clients:
+    {{% if pkg_system == "dpkg" %}}
+    pkgname: openssh-client
+    {{% else %}}
     pkgname: openssh-clients
+    {{% endif %}}
   openssh-server:
     pkgname: openssh-server
   openssl:


### PR DESCRIPTION
#### Description:

- Add an Ubuntu/Debian override to platform: package[openssh-client]

#### Rationale:

- [Debain](https://packages.debian.org/trixie/openssh-client) and [Ubuntu](https://packages.ubuntu.com/resolute/openssh-client) name this package as openssh-client