### PR TITLE
CMP-4521: Fix HyperShift Hosted Cluster detection using controlPlaneTopology

### DIFF
--- a/shared/applicability/oval/installed_app_is_ocp4.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4.xml
@@ -29,10 +29,6 @@
       <literal_component>/kubernetes-api-resources/hypershift/version</literal_component>
   </local_variable>
 
-  <local_variable id="ocp4_operator_deployment_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
-      <literal_component>/kubernetes-api-resources/api/v1/namespaces/openshift-compliance/pods/api-checks-pod</literal_component>
-  </local_variable>
-
   <unix:file_test id="test_file_for_ocp4" check="only one" comment="Find the actual file to be scanned." version="1">
       <unix:object object_ref="object_file_for_ocp4"/>
   </unix:file_test>
@@ -91,13 +87,13 @@
 
 
   <ind:yamlfilecontent_object id="object_hypershift_hosted" version="1">
-      <ind:filepath var_ref="ocp4_operator_deployment_dump_location"/>
-      <ind:yamlpath>.spec.containers[:].command[:]</ind:yamlpath>
+      <ind:filepath var_ref="ocp4_infra_dump_location"/>
+      <ind:yamlpath>.status.controlPlaneTopology</ind:yamlpath>
   </ind:yamlfilecontent_object>
 
   <ind:yamlfilecontent_state id="state_hypershift_hosted" version="1">
-      <ind:value datatype="record" entity_check="at least one">
-          <field name="#" datatype="string" operation="pattern match" entity_check="at least one">^--platform=HyperShift$</field>
+      <ind:value datatype="record">
+          <field name="#" datatype="string" operation="pattern match">^External$</field>
       </ind:value>
   </ind:yamlfilecontent_state>
 
@@ -270,7 +266,8 @@
       <description>The application installed on the system is OpenShift 4 on HyperShift Hosted Cluster.</description>
     </metadata>
     <criteria operator="AND">
-      <criterion comment="Make sure there is HyperShift in the Compliance Operator Command flag" test_ref="test_hypershift_hosted"/>
+      <criterion comment="Make sure controlPlaneTopology is External (HyperShift Hosted Cluster)" test_ref="test_hypershift_hosted"/>
+      <criterion comment="Make sure OCP4 infrastructure/cluster file is present" test_ref="test_file_for_ocp4_infra"/>
     </criteria>
   </definition>
 


### PR DESCRIPTION
#### Description:

This PR fixes the `ocp4-on-hypershift-hosted` CPE, which never fired. The
`object_hypershift_hosted` OVAL object matched `^--platform=HyperShift$` under
`.spec.containers[:].command[:]` of a hardcoded pod dump
(`/kubernetes-api-resources/api/v1/namespaces/openshift-compliance/pods/api-checks-pod`).
That path was wrong: the Compliance Operator names the pod `<scan-name>-api-checks-pod`,
and it places the `--platform=HyperShift` flag on the `api-resource-collector`
initContainer, not on a regular container. As a result the CPE was structurally
unreachable and never matched.

Instead of chasing the pod manifest, this PR detects HyperShift Hosted Clusters
from the `infrastructure.config.openshift.io/cluster` object, checking
`.status.controlPlaneTopology == "External"`. This is the canonical signal for a
cluster whose control plane runs externally in the management cluster, and it is
independent of Compliance Operator pod naming.

Changes to `shared/applicability/oval/installed_app_is_ocp4.xml`:
- Point `object_hypershift_hosted` at `ocp4_infra_dump_location` with yamlpath
  `.status.controlPlaneTopology`, matching `^External$`.
- Add a `test_file_for_ocp4_infra` criterion to the `ocp4-on-hypershift-hosted`
  definition so it only evaluates when the infrastructure/cluster file is present.
- Remove the now-unused `ocp4_operator_deployment_dump_location` variable.

#### Rationale:

Every rule gated `platform: not ocp4-on-hypershift-hosted` (46 in ocp4-cis,
54 in ocp4-high, 4 in ocp4-stig) was executing inside hosted clusters against
control-plane namespaces that do not exist there (openshift-kube-apiserver,
openshift-etcd, ...), producing false FAILs (e.g. `master_taint_noschedule`).
With this fix those rules are correctly reported as NOT-APPLICABLE on HyperShift
Hosted Clusters.

Jira: https://issues.redhat.com/browse/CMP-4521

#### Review Hints:

To confirm the detection signal on a cluster:

    oc get infrastructure cluster -o jsonpath='{.status.controlPlaneTopology}'

- `External` -> HyperShift Hosted Cluster (control plane external)
- `HighlyAvailable` / `SingleReplica` -> traditional OCP (control plane local)
