### PR TITLE
Refer xccdf value in ssh_use_approved_macs_ordered_stig

### DIFF
--- a/linux_os/guide/services/ssh/ssh_client/ssh_use_approved_macs_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_use_approved_macs_ordered_stig/rule.yml
@@ -9,7 +9,7 @@ description: |-
     The following line in <tt>{{{ sshc_main_config }}}</tt>
     demonstrates use of FIPS-approved MACs:
 
-    <pre>MACs {{{ ssh_approved_macs }}}</pre>
+    <pre>MACs {{{ xccdf_value("ssh_approved_macs") }}}</pre>
     If this line does not contain these MACs in exact order,
     is commented out, or is missing, this is a finding.
 


### PR DESCRIPTION
#### Description:

- Refer xccdf value in ssh_use_approved_macs_ordered_stig