### PR TITLE
Set status of account_temp_expire_date rule to manual

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -2250,7 +2250,7 @@ controls:
       title: OL 9 must automatically expire temporary accounts within 72 hours.
       rules:
           - account_temp_expire_date
-      status: automated
+      status: manual
 
     - id: OL09-00-003005
       levels:

--- a/controls/stig_slmicro5.yml
+++ b/controls/stig_slmicro5.yml
@@ -830,7 +830,7 @@ controls:
     title: SLEM 5 must automatically expire temporary accounts within 72 hours.
     rules:
       - account_temp_expire_date
-    status: automated
+    status: manual
 
   - id: SLEM-05-411050
     levels:

--- a/controls/stig_ubuntu2204.yml
+++ b/controls/stig_ubuntu2204.yml
@@ -757,7 +757,7 @@ controls:
           - medium
       rules:
           - account_temp_expire_date
-      status: automated
+      status: manual
 
     - id: UBTU-22-411045
       title: Ubuntu 22.04 LTS must automatically lock an account until the locked account is released

--- a/products/rhel8/controls/stig_rhel8.yml
+++ b/products/rhel8/controls/stig_rhel8.yml
@@ -995,7 +995,7 @@ controls:
           less.
       rules:
           - account_temp_expire_date
-      status: automated
+      status: manual
 
     - id: RHEL-08-020010
       levels:
@@ -1320,7 +1320,7 @@ controls:
       title: RHEL 8 must automatically expire temporary accounts within 72 hours.
       rules:
           - account_temp_expire_date
-      status: automated
+      status: manual
 
     - id: RHEL-08-020280
       levels:

--- a/products/rhel9/controls/stig_rhel9.yml
+++ b/products/rhel9/controls/stig_rhel9.yml
@@ -2351,7 +2351,7 @@ controls:
       title: RHEL 9 must automatically expire temporary accounts within 72 hours.
       rules:
           - account_temp_expire_date
-      status: automated
+      status: manual
 
     - id: RHEL-09-411045
       levels:


### PR DESCRIPTION
#### Description:

- Set status of account_temp_expire_date rule to manual

#### Rationale:

- Rule account_temp_expire_date is empty, it has not check/remediation/template etc
- Note: Rule RHEL-08-020000 duplicates with RHEL-08-020270 in products/rhel8/controls/stig_rhel8.yml