### PR TITLE
Fix noschedule rules for HyperShift Hosted Control Plane

### DIFF
--- a/applications/openshift/high-availability/control_plane_nodes_in_three_zones/rule.yml
+++ b/applications/openshift/high-availability/control_plane_nodes_in_three_zones/rule.yml
@@ -26,6 +26,8 @@ identifiers:
 
 severity: medium
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'Kubernetes control plane not distributed across three failure zones'
 
 ocil: |-

--- a/applications/openshift/master/master_taint_noschedule/rule.yml
+++ b/applications/openshift/master/master_taint_noschedule/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 title: Verify that Control Plane Nodes are not schedulable for workloads
 
+{{% set jqfilter = '[ .items[] | select(.spec.taints[]?.key == "node-role.kubernetes.io/master" and .spec.taints[]?.effect == "NoSchedule") | .metadata.name ]' %}}
+
 description: -|
     <p>
     User workloads should not be colocated with control plane workloads. To ensure that the scheduler won't
@@ -25,22 +27,22 @@ rationale: -|
     In some setups it might be necessary to make the control plane schedulable for workloads i.e.
     Single Node Openshift (SNO) or Compact Cluster (Three Node Cluster) setups.
 
-{{% set jqfilter = '.items[] | select(.metadata.labels."node-role.kubernetes.io/master" == "" or .metadata.labels."node-role.kubernetes.io/control-plane" == "" ) | .spec.taints[] | select(.key == "node-role.kubernetes.io/master" and .effect == "NoSchedule")' %}}
-
 identifiers:
     cce@ocp4: CCE-88731-5
 
 severity: medium
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'Control Plane is schedulable'
 
 ocil: |-
     Run the following command to see if control planes are schedulable
-    <pre>$oc get --raw /api/v1/nodes | jq '.items[] | select(.metadata.labels."node-role.kubernetes.io/master" == "" or .metadata.labels."node-role.kubernetes.io/control-plane" == "" ) | .spec.taints[] | select(.key == "node-role.kubernetes.io/master" and .effect == "NoSchedule" )'</pre>
-    for each master node, there should be an output of a key with the NoSchedule effect.
+    <pre>$oc get --raw /api/v1/nodes | jq '[ .items[] | select(.spec.taints[]?.key == "node-role.kubernetes.io/master" and .spec.taints[]?.effect == "NoSchedule") | .metadata.name ]'</pre>
+    for each non-schedulable master node, there should be the name in the output.
 
-    By editing the cluster scheduler you can centrally configure the masters as schedulable or not
-    by setting .spec.mastersSchedulable to true.
+    By editing the cluster scheduler you can centrally configure the masters as not schedulable
+    by setting .spec.mastersSchedulable to false.
     Use <pre>$oc edit schedulers.config.openshift.io cluster</pre> to configure the scheduling.
 
 warnings:
@@ -53,9 +55,9 @@ template:
         ocp_data: "true"
         filepath: |-
             {{{ openshift_filtered_path('/api/v1/nodes', jqfilter) }}}
-        yamlpath: ".effect"
+        yamlpath: "[:]"
         check_existence: "at_least_one_exists"
         entity_check: "at least one"
         values:
-            - value: "NoSchedule"
+            - value: "(.*?)"
               operation: "pattern match"


### PR DESCRIPTION
#### Description:

This re-opens the work from #13699 (closed for inactivity) by cherry-picking
@sluetze's commit. It makes two control-plane rules behave correctly on
HyperShift Hosted Control Plane (HCP) clusters:

- **`master_taint_noschedule`**: the previous `jqfilter` iterated
  `.spec.taints[]` unconditionally, so on hosted clusters — where worker nodes
  have no taints — the api-checks resource filtering errored out
  (`couldn't filter '{"kind":"NodeList",...}'`) and aborted the whole scan. The
  filter is rewritten to use `.spec.taints[]?` and collect the names of tainted
  master nodes into a list, which evaluates safely on both HCP and regular
  clusters. The rule is also gated with `platform: not ocp4-on-hypershift-hosted`.
- **`control_plane_nodes_in_three_zones`**: gated with
  `platform: not ocp4-on-hypershift-hosted`, since a hosted cluster's control
  plane runs in the management cluster and this check does not apply.

#### Rationale:

On HCP clusters these control-plane rules either crashed the scan
(`master_taint_noschedule`) or produced meaningless results. This makes them
HCP-safe and marks them not-applicable on hosted clusters.

#### Related:

- Complements #15085 (CMP-4521); not a hard dependency. The
  `master_taint_noschedule` crash fix works independently of it, and the
  `platform: not ocp4-on-hypershift-hosted` gates added here are inert no-ops
  until that PR lands. #15085 fixes the `ocp4-on-hypershift-hosted` CPE, which
  was structurally unreachable and never fired — as @sluetze documented in
  #13699, none of the `platform: not ocp4-on-hypershift-hosted` rules returned
  NOT-APPLICABLE on HCP before that fix. Once #15085 merges, the gates here begin
  marking these rules NOT-APPLICABLE on hosted clusters. Either PR can merge
  first.
- Same class as CMP-4521's sibling bug
  [CMP-4491](https://issues.redhat.com/browse/CMP-4491) (jq `Cannot iterate over
  null` from strict array traversal, fixed by adding `?` optional operators),
  which was addressed for the `audit_error_alert_exists` rule by another PR. The
  `master_taint_noschedule` change here applies the same optional-traversal fix
  pattern to node taints.

Original PR: #13699
Original author: @sluetze


[CMP-4491]: https://redhat.atlassian.net/browse/CMP-4491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ