### PR TITLE
CMP-4654: Update CIS Red Hat OpenShift Container Platform 4 Benchmark to v2.0.0

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -17,10 +17,10 @@ RUN find . -name "default\.profile" -exec sed -i 's/\(documentation_complete: \)
 RUN sed -i 's/\(documentation_complete: \).*/\1true/' \
     products/ocp4/profiles/cis-node.profile \
     products/ocp4/profiles/cis.profile \
-    products/ocp4/profiles/cis-node-1-7.profile \
-    products/ocp4/profiles/cis-1-7.profile \
     products/ocp4/profiles/cis-node-1-9.profile \
     products/ocp4/profiles/cis-1-9.profile \
+    products/ocp4/profiles/cis-node-2-0.profile \
+    products/ocp4/profiles/cis-2-0.profile \
     products/ocp4/profiles/moderate-node.profile \
     products/ocp4/profiles/moderate.profile \
     products/ocp4/profiles/moderate-node-rev-4.profile \

--- a/controls/cis_ocp_200.yml
+++ b/controls/cis_ocp_200.yml
@@ -1,10 +1,11 @@
 ---
 policy: CIS Red Hat OpenShift Container Platform 4 Benchmark
 title: CIS Red Hat OpenShift Container Platform 4 Benchmark
-id: cis_ocp_190
+id: cis_ocp_200
 source: https://www.cisecurity.org/benchmark/kubernetes
 product: ocp4
-version: '1.9.0'
+version: '2.0.0'
+reference_type: cis
 
 levels:
     - id: level_1

--- a/controls/cis_ocp_200/section-1.yml
+++ b/controls/cis_ocp_200/section-1.yml
@@ -1,0 +1,506 @@
+---
+controls:
+    - id: '1'
+      title: Control Plane Components
+      status: pending
+      rules: []
+      controls:
+          - id: '1.1'
+            title: Master Node Configuration Files
+            status: automated
+            rules: []
+            controls:
+                - id: 1.1.1
+                  title: Ensure that the API server pod specification file permissions are set to 600
+                      or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_kube_apiserver
+                  levels:
+                      - level_1
+                - id: 1.1.2
+                  title: Ensure that the API server pod specification file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_kube_apiserver
+                      - file_groupowner_kube_apiserver
+                  levels:
+                      - level_1
+                - id: 1.1.3
+                  title: Ensure that the controller manager pod specification file permissions are set
+                      to 600 or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_kube_controller_manager
+                  levels:
+                      - level_1
+                - id: 1.1.4
+                  title: Ensure that the controller manager pod specification file ownership is set to
+                      root:root
+                  status: automated
+                  rules:
+                      - file_owner_kube_controller_manager
+                      - file_groupowner_kube_controller_manager
+                  levels:
+                      - level_1
+                - id: 1.1.5
+                  title: Ensure that the scheduler pod specification file permissions are set to 600
+                      or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_scheduler
+                  levels:
+                      - level_1
+                - id: 1.1.6
+                  title: Ensure that the scheduler pod specification file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_kube_scheduler
+                      - file_groupowner_kube_scheduler
+                  levels:
+                      - level_1
+                - id: 1.1.7
+                  title: Ensure that the etcd pod specification file permissions are set to 600 or more
+                      restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_etcd_member
+                  levels:
+                      - level_1
+                - id: 1.1.8
+                  title: Ensure that the etcd pod specification file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_groupowner_etcd_member
+                      - file_owner_etcd_member
+                  levels:
+                      - level_1
+                - id: 1.1.9
+                  title: Ensure that the Container Network Interface file permissions are set to 600
+                      or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_cni_conf
+                      - file_permissions_multus_conf
+                      - file_permissions_ip_allocations
+                      - file_perms_openshift_sdn_cniserver_config
+                      - file_permissions_ovs_pid
+                      - file_permissions_ovs_conf_db
+                      - file_permissions_ovs_sys_id_conf
+                      - file_permissions_ovs_conf_db_lock
+                      - file_permissions_ovs_vswitchd_pid
+                      - file_permissions_ovsdb_server_pid
+                      - file_permissions_ovn_cni_server_sock
+                      - file_permissions_ovn_db_files
+                  levels:
+                      - level_1
+                - id: 1.1.10
+                  title: Ensure that the Container Network Interface file ownership is set to openvswitch:openvswitch
+                  status: automated
+                  rules:
+                      - file_owner_cni_conf
+                      - file_groupowner_cni_conf
+                      - file_owner_multus_conf
+                      - file_groupowner_multus_conf
+                      - file_owner_ip_allocations
+                      - file_groupowner_ip_allocations
+                      - file_owner_openshift_sdn_cniserver_config
+                      - file_groupowner_openshift_sdn_cniserver_config
+                      - file_owner_ovs_pid
+                      - file_groupowner_ovs_pid
+                      - file_owner_ovs_conf_db
+                      - file_groupowner_ovs_conf_db_openvswitch
+                      - file_groupowner_ovs_conf_db_hugetlbfs
+                      - file_owner_ovs_sys_id_conf
+                      - file_groupowner_ovs_sys_id_conf_openvswitch
+                      - file_groupowner_ovs_sys_id_conf_hugetlbfs
+                      - file_owner_ovs_conf_db_lock
+                      - file_groupowner_ovs_conf_db_lock_openvswitch
+                      - file_groupowner_ovs_conf_db_lock_hugetlbfs
+                      - file_owner_ovs_vswitchd_pid
+                      - file_groupowner_ovs_vswitchd_pid
+                      - file_owner_ovsdb_server_pid
+                      - file_groupowner_ovsdb_server_pid
+                      - file_groupowner_ovn_cni_server_sock
+                      - file_owner_ovn_cni_server_sock
+                      - file_owner_ovn_db_files
+                      - file_groupowner_ovn_db_files
+                  levels:
+                      - level_1
+                - id: 1.1.11
+                  title: Ensure that the etcd data directory permissions are set to 700 or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_etcd_data_dir
+                      - file_permissions_etcd_data_files
+                  levels:
+                      - level_1
+                - id: 1.1.12
+                  title: Ensure that the etcd data directory ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_etcd_data_dir
+                      - file_groupowner_etcd_data_dir
+                      - file_owner_etcd_data_files
+                      - file_groupowner_etcd_data_files
+                  levels:
+                      - level_1
+                - id: 1.1.13
+                  title: Ensure that the kubeconfig file permissions are set to 600 or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_master_admin_kubeconfigs
+                  levels:
+                      - level_1
+                - id: 1.1.14
+                  title: Ensure that the kubeconfig file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_master_admin_kubeconfigs
+                      - file_groupowner_master_admin_kubeconfigs
+                  levels:
+                      - level_1
+                - id: 1.1.15
+                  title: Ensure that the Scheduler kubeconfig file permissions are set to 600 or more
+                      restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_scheduler_kubeconfig
+                  levels:
+                      - level_1
+                - id: 1.1.16
+                  title: Ensure that the Scheduler kubeconfig file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_scheduler_kubeconfig
+                      - file_groupowner_scheduler_kubeconfig
+                  levels:
+                      - level_1
+                - id: 1.1.17
+                  title: Ensure that the Controller Manager kubeconfig file permissions are set to 600
+                      or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_controller_manager_kubeconfig
+                  levels:
+                      - level_1
+                - id: 1.1.18
+                  title: Ensure that the Controller Manager kubeconfig file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_controller_manager_kubeconfig
+                      - file_groupowner_controller_manager_kubeconfig
+                  levels:
+                      - level_1
+                - id: 1.1.19
+                  title: Ensure that the OpenShift PKI directory and file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_openshift_pki_key_files
+                      - file_groupowner_openshift_pki_key_files
+                      - file_owner_openshift_pki_cert_files
+                      - file_groupowner_openshift_pki_cert_files
+                      - file_owner_etcd_pki_cert_files
+                      - file_groupowner_etcd_pki_cert_files
+                  levels:
+                      - level_1
+                - id: 1.1.20
+                  title: Ensure that the OpenShift PKI certificate file permissions are set to 600 or
+                      more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_openshift_pki_cert_files
+                      - file_permissions_etcd_pki_cert_files
+                  levels:
+                      - level_1
+                - id: 1.1.21
+                  title: Ensure that the OpenShift PKI key file permissions are set to 600
+                  status: automated
+                  rules:
+                      - file_permissions_openshift_pki_key_files
+                  levels:
+                      - level_1
+          - id: '1.2'
+            title: API Server
+            status: pending
+            rules: []
+            controls:
+                - id: 1.2.1
+                  title: Ensure that anonymous requests are authorized
+                  status: automated
+                  rules:
+                      - api_server_anonymous_auth
+                  levels:
+                      - level_1
+                - id: 1.2.2
+                  title: Use https for kubelet connections
+                  status: automated
+                  rules:
+                      - api_server_https_for_kubelet_conn
+                      - api_server_openshift_https_serving_cert
+                      - api_server_oauth_https_serving_cert
+                  levels:
+                      - level_1
+                - id: 1.2.3
+                  title: Ensure that the kubelet uses certificates to authenticate
+                  status: automated
+                  rules:
+                      - api_server_kubelet_client_cert
+                      - api_server_kubelet_client_key
+                  levels:
+                      - level_1
+                - id: 1.2.4
+                  title: Verify that the kubelet certificate authority is set as appropriate
+                  status: automated
+                  rules:
+                      - api_server_kubelet_certificate_authority
+                  levels:
+                      - level_1
+                - id: 1.2.5
+                  title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+                  status: automated
+                  rules:
+                      - api_server_auth_mode_no_aa
+                  levels:
+                      - level_1
+                - id: 1.2.6
+                  title: Verify that RBAC is enabled
+                  status: automated
+                  rules:
+                      - api_server_auth_mode_rbac
+                  levels:
+                      - level_1
+                - id: 1.2.7
+                  title: Ensure that the APIPriorityAndFairness feature gate is enabled
+                  status: inherently met
+                  rules: []
+                  levels:
+                      - level_1
+                - id: 1.2.8
+                  title: Ensure that the admission control plugin AlwaysAdmit is not set
+                  status: automated
+                  rules:
+                      - api_server_admission_control_plugin_alwaysadmit
+                  levels:
+                      - level_1
+                - id: 1.2.9
+                  title: Ensure that the admission control plugin AlwaysPullImages is not set
+                  status: automated
+                  rules:
+                      - api_server_admission_control_plugin_alwayspullimages
+                  levels:
+                      - level_1
+                - id: 1.2.10
+                  title: Ensure that the admission control plugin ServiceAccount is set
+                  status: automated
+                  rules:
+                      - api_server_admission_control_plugin_service_account
+                  levels:
+                      - level_1
+                - id: 1.2.11
+                  title: Ensure that the admission control plugin NamespaceLifecycle is set
+                  status: automated
+                  rules:
+                      - api_server_admission_control_plugin_namespacelifecycle
+                  levels:
+                      - level_1
+                - id: 1.2.12
+                  title: Ensure that the admission control plugin SecurityContextConstraint is set
+                  status: automated
+                  rules:
+                      - api_server_admission_control_plugin_scc
+                  levels:
+                      - level_1
+                - id: 1.2.13
+                  title: Ensure that the admission control plugin NodeRestriction is set
+                  status: automated
+                  rules:
+                      - api_server_admission_control_plugin_noderestriction
+                  levels:
+                      - level_1
+                - id: 1.2.14
+                  title: Ensure that the --insecure-bind-address argument is not set
+                  status: automated
+                  rules:
+                      - api_server_insecure_bind_address
+                  levels:
+                      - level_1
+                - id: 1.2.15
+                  title: Ensure that the --insecure-port argument is set to 0
+                  status: inherently met
+                  rules: []
+                  levels:
+                      - level_1
+                - id: 1.2.16
+                  title: Ensure that the --secure-port argument is not set to 0
+                  status: automated
+                  rules:
+                      - api_server_bind_address
+                  levels:
+                      - level_1
+                - id: 1.2.17
+                  title: Ensure that the healthz endpoint is protected by RBAC
+                  status: automated
+                  rules:
+                      - api_server_profiling_protected_by_rbac
+                  levels:
+                      - level_1
+                - id: 1.2.18
+                  title: Ensure that the --audit-log-path argument is set
+                  status: automated
+                  rules:
+                      - api_server_audit_log_path
+                      - openshift_api_server_audit_log_path
+                  levels:
+                      - level_1
+                - id: 1.2.19
+                  title: Ensure that the audit logs are forwarded off the cluster for retention
+                  status: automated
+                  rules:
+                      - audit_log_forwarding_enabled
+                      - audit_log_forwarding_webhook
+                  levels:
+                      - level_1
+                - id: 1.2.20
+                  title: Ensure that the maximumRetainedFiles argument is set to 10 or as appropriate
+                  status: automated
+                  rules:
+                      - api_server_audit_log_maxbackup
+                      - ocp_api_server_audit_log_maxbackup
+                  levels:
+                      - level_1
+                - id: 1.2.21
+                  title: Configure Kubernetes API Server Maximum Audit Log Size
+                  status: automated
+                  rules:
+                      - api_server_audit_log_maxsize
+                      - ocp_api_server_audit_log_maxsize
+                  levels:
+                      - level_1
+                - id: 1.2.22
+                  title: Ensure that the --request-timeout argument is set
+                  status: automated
+                  rules:
+                      - api_server_request_timeout
+                  levels:
+                      - level_1
+                - id: 1.2.23
+                  title: Ensure that the --service-account-lookup argument is set to true
+                  status: automated
+                  rules:
+                      - api_server_service_account_lookup
+                  levels:
+                      - level_1
+                - id: 1.2.24
+                  title: Ensure that the --service-account-key-file argument is set as appropriate
+                  status: automated
+                  rules:
+                      - api_server_service_account_public_key
+                  levels:
+                      - level_1
+                - id: 1.2.25
+                  title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
+                  status: automated
+                  rules:
+                      - api_server_etcd_cert
+                      - api_server_etcd_key
+                  levels:
+                      - level_1
+                - id: 1.2.26
+                  title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set
+                      as appropriate
+                  status: automated
+                  rules:
+                      - api_server_tls_cert
+                      - api_server_tls_private_key
+                  levels:
+                      - level_1
+                - id: 1.2.27
+                  title: Ensure that the --client-ca-file argument is set as appropriate
+                  status: automated
+                  rules:
+                      - api_server_client_ca
+                  levels:
+                      - level_1
+                - id: 1.2.28
+                  title: Ensure that the --etcd-cafile argument is set as appropriate
+                  status: automated
+                  rules:
+                      - api_server_etcd_ca
+                  levels:
+                      - level_1
+                - id: 1.2.29
+                  title: Ensure that encryption providers are appropriately configured
+                  status: automated
+                  rules:
+                      - api_server_encryption_provider_cipher
+                  levels:
+                      - level_1
+                - id: 1.2.30
+                  title: Ensure that the API Server only makes use of Strong Cryptographic Ciphers
+                  status: automated
+                  rules:
+                      - api_server_tls_security_profile_not_old
+                      - api_server_tls_security_profile_custom_min_tls_version
+                  levels:
+                      - level_1
+                - id: 1.2.31
+                  title: Ensure unsupported configuration overrides are not used
+                  status: pending
+                  rules:
+                      - api_server_no_unsupported_config_overrides
+                      - api_server_kube_no_unsupported_config_overrides
+                  levels:
+                      - level_1
+          - id: '1.3'
+            title: Controller Manager
+            status: pending
+            rules: []
+            controls:
+                - id: 1.3.1
+                  title: Ensure that controller manager healthz endpoints are protected by RBAC
+                  status: automated
+                  rules:
+                      - rbac_debug_role_protects_pprof
+                  levels:
+                      - level_1
+                - id: 1.3.2
+                  title: Ensure that the --use-service-account-credentials argument is set to true
+                  status: automated
+                  rules:
+                      - controller_use_service_account
+                  levels:
+                      - level_1
+                - id: 1.3.3
+                  title: Ensure that the --service-account-private-key-file argument is set as appropriate
+                  status: automated
+                  rules:
+                      - controller_service_account_private_key
+                  levels:
+                      - level_1
+                - id: 1.3.4
+                  title: Ensure that the --root-ca-file argument is set as appropriate
+                  status: automated
+                  rules:
+                      - controller_service_account_ca
+                  levels:
+                      - level_1
+          - id: '1.4'
+            title: Scheduler
+            status: automated
+            rules: []
+            controls:
+                - id: 1.4.1
+                  title: Ensure that the healthz endpoints for the scheduler are protected by RBAC
+                  status: automated
+                  rules:
+                      - scheduler_profiling_protected_by_rbac
+                  levels:
+                      - level_1
+                - id: 1.4.2
+                  title: Verify that the scheduler API service is protected by RBAC
+                  status: automated
+                  rules:
+                      - scheduler_service_protected_by_rbac
+                  levels:
+                      - level_1

--- a/controls/cis_ocp_200/section-2.yml
+++ b/controls/cis_ocp_200/section-2.yml
@@ -1,0 +1,58 @@
+---
+controls:
+    - id: '2'
+      title: etcd
+      status: pending
+      rules: []
+      controls:
+          - id: '2.1'
+            title: Ensure that the --cert-file and --key-file arguments are set as appropriate
+            status: automated
+            rules:
+                - etcd_cert_file
+                - etcd_key_file
+            levels:
+                - level_1
+          - id: '2.2'
+            title: Ensure that the --client-cert-auth argument is set to true
+            status: automated
+            rules:
+                - etcd_client_cert_auth
+            levels:
+                - level_1
+          - id: '2.3'
+            title: Ensure that the --auto-tls argument is not set to true
+            status: automated
+            rules:
+                - etcd_auto_tls
+            levels:
+                - level_1
+          - id: '2.4'
+            title: Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate
+            status: automated
+            rules:
+                - etcd_peer_cert_file
+                - etcd_peer_key_file
+            levels:
+                - level_1
+          - id: '2.5'
+            title: Ensure that the --peer-client-cert-auth argument is set to true
+            status: automated
+            rules:
+                - etcd_peer_client_cert_auth
+            levels:
+                - level_1
+          - id: '2.6'
+            title: Ensure that the --peer-auto-tls argument is not set to true
+            status: automated
+            rules:
+                - etcd_peer_auto_tls
+            levels:
+                - level_1
+          - id: '2.7'
+            title: Ensure that a unique Certificate Authority is used for etcd
+            status: automated
+            rules:
+                - etcd_unique_ca
+            levels:
+                - level_2

--- a/controls/cis_ocp_200/section-3.yml
+++ b/controls/cis_ocp_200/section-3.yml
@@ -1,0 +1,39 @@
+---
+controls:
+    - id: '3'
+      title: Control Plane Configuration
+      status: pending
+      rules: []
+      controls:
+          - id: '3.1'
+            title: Authentication and Authorization
+            status: automated
+            rules: []
+            controls:
+                - id: 3.1.1
+                  title: Client certificate authentication should not be used for users
+                  status: automated
+                  rules:
+                      - idp_is_configured
+                      - kubeadmin_removed
+                  levels:
+                      - level_2
+          - id: '3.2'
+            title: Logging
+            status: automated
+            rules: []
+            controls:
+                - id: 3.2.1
+                  title: Ensure that a minimal audit policy is created
+                  status: automated
+                  rules:
+                      - audit_logging_enabled
+                  levels:
+                      - level_1
+                - id: 3.2.2
+                  title: Ensure that the audit policy covers key security concerns
+                  status: automated
+                  rules:
+                      - audit_profile_set
+                  levels:
+                      - level_2

--- a/controls/cis_ocp_200/section-4.yml
+++ b/controls/cis_ocp_200/section-4.yml
@@ -1,0 +1,191 @@
+---
+controls:
+    - id: '4'
+      title: Worker Nodes
+      status: pending
+      rules: []
+      controls:
+          - id: '4.1'
+            title: Worker Node Configuration Files
+            status: pending
+            rules: []
+            controls:
+                - id: 4.1.1
+                  title: Ensure that the kubelet service file permissions are set to 644 or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_worker_service
+                  levels:
+                      - level_1
+                - id: 4.1.2
+                  title: Ensure that the kubelet service file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_worker_service
+                      - file_groupowner_worker_service
+                  levels:
+                      - level_1
+                - id: 4.1.3
+                  title: If proxy kube proxy configuration file exists ensure permissions are set to
+                      644 or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_proxy_kubeconfig
+                  levels:
+                      - level_1
+                - id: 4.1.4
+                  title: If proxy kubeconfig file exists ensure ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_proxy_kubeconfig
+                      - file_groupowner_proxy_kubeconfig
+                  levels:
+                      - level_1
+                - id: 4.1.5
+                  title: Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or
+                      more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_kubelet_conf
+                  levels:
+                      - level_1
+                - id: 4.1.6
+                  title: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_groupowner_kubelet_conf
+                      - file_owner_kubelet_conf
+        #- file_groupowner_kubelet
+                      - file_owner_kubelet
+                  levels:
+                      - level_1
+                - id: 4.1.7
+                  title: Ensure that the certificate authorities file permissions are set to 644 or more
+                      restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_worker_ca
+                  levels:
+                      - level_1
+                - id: 4.1.8
+                  title: Ensure that the client certificate authorities file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_worker_ca
+                      - file_groupowner_worker_ca
+                  levels:
+                      - level_1
+                - id: 4.1.9
+                  title: Ensure that the kubelet --config configuration file has permissions set to 600
+                      or more restrictive
+                  status: automated
+                  rules:
+                      - file_permissions_worker_kubeconfig
+                  levels:
+                      - level_1
+                - id: 4.1.10
+                  title: Ensure that the kubelet configuration file ownership is set to root:root
+                  status: automated
+                  rules:
+                      - file_owner_worker_kubeconfig
+                      - file_groupowner_worker_kubeconfig
+                  levels:
+                      - level_1
+          - id: '4.2'
+            title: Kubelet
+            status: pending
+            rules: []
+            controls:
+                - id: 4.2.1
+                  title: Activate Garbage collection in OpenShift Container Platform 4, as appropriate
+                  status: automated
+                  rules:
+                      - kubelet_eviction_thresholds_set_hard_memory_available
+                      - kubelet_eviction_thresholds_set_hard_nodefs_available
+                      - kubelet_eviction_thresholds_set_hard_nodefs_inodesfree
+                      - kubelet_eviction_thresholds_set_hard_imagefs_available
+                  levels:
+                      - level_1
+                - id: 4.2.2
+                  title: Ensure that the --anonymous-auth argument is set to false
+                  status: automated
+                  rules:
+                      - kubelet_anonymous_auth
+                  levels:
+                      - level_1
+                - id: 4.2.3
+                  title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+                  status: automated
+                  rules:
+                      - kubelet_authorization_mode
+                  levels:
+                      - level_1
+                - id: 4.2.4
+                  title: Ensure that the --client-ca-file argument is set as appropriate
+                  status: automated
+                  rules:
+                      - kubelet_configure_client_ca
+                  levels:
+                      - level_1
+                - id: 4.2.5
+                  title: Verify that the read only port is not used or is set to 0
+                  status: automated
+                  rules:
+                      - kubelet_disable_readonly_port
+                  levels:
+                      - level_1
+                - id: 4.2.6
+                  title: Ensure that the --streaming-connection-idle-timeout argument is not set to 0
+                  status: automated
+                  rules:
+                      - kubelet_enable_streaming_connections
+                  levels:
+                      - level_1
+                - id: 4.2.7
+                  title: Ensure that the --make-iptables-util-chains argument is set to true
+                  status: automated
+                  rules:
+                      - kubelet_enable_iptables_util_chains
+                  levels:
+                      - level_1
+                - id: 4.2.8
+                  title: Ensure that the kubeAPIQPS [--event-qps] argument is set to a level which
+                      ensures appropriate event capture
+                  status: automated
+                  rules:
+                      - kubelet_configure_event_creation
+                      - var_event_record_qps=50
+                  levels:
+                      - level_2
+                - id: 4.2.9
+                  title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set
+                      as appropriate
+                  status: automated
+                  rules:
+                      - kubelet_configure_tls_cert
+                      - kubelet_configure_tls_key
+                  levels:
+                      - level_1
+                - id: 4.2.10
+                  title: Ensure that the --rotate-certificates argument is not set to false
+                  status: automated
+                  rules:
+                      - kubelet_enable_client_cert_rotation
+                      - kubelet_enable_cert_rotation
+                  levels:
+                      - level_1
+                - id: 4.2.11
+                  title: Verify that the RotateKubeletServerCertificate argument is set to true
+                  status: automated
+                  rules:
+                      - kubelet_enable_server_cert_rotation
+                  levels:
+                      - level_1
+                - id: 4.2.12
+                  title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+                  status: automated
+                  rules:
+                      - kubelet_configure_tls_cipher_suites
+                      - ingress_controller_tls_cipher_suites
+                  levels:
+                      - level_1

--- a/controls/cis_ocp_200/section-5.yml
+++ b/controls/cis_ocp_200/section-5.yml
@@ -1,0 +1,216 @@
+---
+controls:
+    - id: '5'
+      title: Policies
+      status: partial
+      rules: []
+      controls:
+          - id: '5.1'
+            title: RBAC and Service Accounts
+            status: manual
+            rules: []
+            controls:
+                - id: 5.1.1
+                  title: Ensure that the cluster-admin role is only used where required
+                  status: manual
+                  rules:
+                      - rbac_limit_cluster_admin
+                  levels:
+                      - level_1
+                - id: 5.1.2
+                  title: Minimize access to secrets
+                  status: manual
+                  rules:
+                      - rbac_limit_secrets_access
+                  levels:
+                      - level_1
+                - id: 5.1.3
+                  title: Minimize wildcard use in Roles and ClusterRoles
+                  status: manual
+                  rules:
+                      - rbac_wildcard_use
+                  levels:
+                      - level_1
+                - id: 5.1.4
+                  title: Minimize access to create pods
+                  status: manual
+                  rules:
+                      - rbac_pod_creation_access
+                  levels:
+                      - level_1
+                - id: 5.1.5
+                  title: Ensure that default service accounts are not actively used.
+                  status: manual
+                  rules:
+                      - accounts_unique_service_account
+                  levels:
+                      - level_1
+                - id: 5.1.6
+                  title: Ensure that Service Account Tokens are only mounted where necessary
+                  status: manual
+                  rules:
+                      - accounts_restrict_service_account_tokens
+                  levels:
+                      - level_1
+          - id: '5.2'
+            title: Security Context Constraints
+            status: partial
+            rules: []
+            controls:
+                - id: 5.2.1
+                  title: Minimize the admission of privileged containers
+                  status: manual
+                  rules:
+                      - scc_limit_privileged_containers
+                  levels:
+                      - level_1
+                - id: 5.2.2
+                  title: Minimize the admission of containers wishing to share the host process ID namespace
+                  status: manual
+                  rules:
+                      - scc_limit_process_id_namespace
+                  levels:
+                      - level_1
+                - id: 5.2.3
+                  title: Minimize the admission of containers wishing to share the host IPC namespace
+                  status: manual
+                  rules:
+                      - scc_limit_ipc_namespace
+                  levels:
+                      - level_1
+                - id: 5.2.4
+                  title: Minimize the admission of containers wishing to share the host network namespace
+                  status: manual
+                  rules:
+                      - scc_limit_network_namespace
+                  levels:
+                      - level_1
+                - id: 5.2.5
+                  title: Minimize the admission of containers with allowPrivilegeEscalation
+                  status: manual
+                  rules:
+                      - scc_limit_privilege_escalation
+                  levels:
+                      - level_1
+                - id: 5.2.6
+                  title: Minimize the admission of root containers
+                  status: manual
+                  rules:
+                      - scc_limit_root_containers
+                  levels:
+                      - level_2
+                - id: 5.2.7
+                  title: Minimize the admission of containers with the NET_RAW capability
+                  status: manual
+                  rules:
+                      - scc_limit_net_raw_capability
+                  levels:
+                      - level_1
+                - id: 5.2.8
+                  title: Minimize the admission of containers with added capabilities
+                  status: automated
+                  rules:
+                      - scc_limit_container_allowed_capabilities
+                  levels:
+                      - level_1
+                - id: 5.2.9
+                  title: Minimize the admission of containers with capabilities assigned
+                  status: manual
+                  rules:
+                      - scc_drop_container_capabilities
+                  levels:
+                      - level_2
+                - id: 5.2.10
+                  title: Minimize access to privileged Security Context Constraints
+                  status: manual
+                  rules:
+                      - rbac_least_privilege
+                  levels:
+                      - level_2
+          - id: '5.3'
+            title: Network Policies and CNI
+            status: partial
+            rules: []
+            controls:
+                - id: 5.3.1
+                  title: Ensure that the CNI in use supports Network Policies
+                  status: automated
+                  rules:
+                      - configure_network_policies
+                  levels:
+                      - level_1
+                - id: 5.3.2
+                  title: Ensure that all Namespaces have Network Policies defined
+                  status: partial
+                  rules:
+                      - configure_network_policies_namespaces
+                      - configure_network_policies_hypershift_hosted
+                  levels:
+                      - level_2
+          - id: '5.4'
+            title: Secrets Management
+            status: manual
+            rules: []
+            controls:
+                - id: 5.4.1
+                  title: Prefer using secrets as files over secrets as environment variables
+                  status: manual
+                  rules:
+                      - secrets_no_environment_variables
+                  levels:
+                      - level_1
+                - id: 5.4.2
+                  title: Consider external secret storage
+                  status: manual
+                  rules:
+                      - secrets_consider_external_storage
+                  levels:
+                      - level_2
+          - id: '5.5'
+            title: Extensible Admission Control
+            status: automated
+            rules: []
+            controls:
+                - id: 5.5.1
+                  title: Configure Image Provenance using image controller configuration parameters
+                  status: automated
+                  rules:
+                      - ocp_allowed_registries
+                      - ocp_allowed_registries_for_import
+                      - ocp_insecure_registries
+                      - ocp_insecure_allowed_registries_for_import
+                  levels:
+                      - level_2
+          - id: '5.7'
+            title: General Policies
+            status: manual
+            rules: []
+            controls:
+                - id: 5.7.1
+                  title: Create administrative boundaries between resources using namespaces
+                  status: manual
+                  rules:
+                      - general_namespaces_in_use
+                  levels:
+                      - level_1
+                - id: 5.7.2
+                  title: Ensure that the seccomp profile is set to docker/default in your pod definitions
+                  status: manual
+                  rules:
+                      - general_default_seccomp_profile
+                  levels:
+                      - level_2
+                - id: 5.7.3
+                  title: Apply Security Context to Your Pods and Containers
+                  status: manual
+                  rules:
+                      - general_apply_scc
+                  levels:
+                      - level_2
+                - id: 5.7.4
+                  title: The default namespace should not be used
+                  status: manual
+                  rules:
+                      - general_default_namespace_use
+                  levels:
+                      - level_2

--- a/products/ocp4/profiles/cis-1-9.profile
+++ b/products/ocp4/profiles/cis-1-9.profile
@@ -5,6 +5,8 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4
 
+status: deprecated
+
 metadata:
     SMEs:
         - rhmdnd

--- a/products/ocp4/profiles/cis-2-0.profile
+++ b/products/ocp4/profiles/cis-2-0.profile
@@ -10,6 +10,7 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
+        - abushkin-redhat
     version: 2.0.0
 
 description: |-

--- a/products/ocp4/profiles/cis-2-0.profile
+++ b/products/ocp4/profiles/cis-2-0.profile
@@ -5,18 +5,16 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4
 
-status: deprecated
-
 metadata:
     SMEs:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.7.0
+    version: 2.0.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V1.7.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V2.0.0.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
@@ -30,7 +28,7 @@ filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platfor
     not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
-    - cis_ocp:all
+    - cis_ocp_200:all
     ### Variables
     - var_openshift_audit_profile=WriteRequestBodies
     ### Helper Rules

--- a/products/ocp4/profiles/cis-node-1-9.profile
+++ b/products/ocp4/profiles/cis-node-1-9.profile
@@ -5,6 +5,8 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4-node
 
+status: deprecated
+
 metadata:
     SMEs:
         - rhmdnd

--- a/products/ocp4/profiles/cis-node-2-0.profile
+++ b/products/ocp4/profiles/cis-node-2-0.profile
@@ -10,6 +10,7 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
+        - abushkin-redhat
     version: 2.0.0
 
 description: |-

--- a/products/ocp4/profiles/cis-node-2-0.profile
+++ b/products/ocp4/profiles/cis-node-2-0.profile
@@ -5,18 +5,16 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4-node
 
-status: deprecated
-
 metadata:
     SMEs:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.7.0
+    version: 2.0.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V1.7.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V2.0.0.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
@@ -30,4 +28,4 @@ filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp
     or "ocp4-node-on-ovn" in platform'
 
 selections:
-    - cis_ocp:all
+    - cis_ocp_200:all

--- a/products/ocp4/profiles/cis-node.profile
+++ b/products/ocp4/profiles/cis-node.profile
@@ -10,11 +10,11 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.9.0
+    version: 2.0.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V1.9.0.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V2.0.0.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
@@ -24,4 +24,4 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-node-1-9
+extends: cis-node-2-0

--- a/products/ocp4/profiles/cis-node.profile
+++ b/products/ocp4/profiles/cis-node.profile
@@ -10,6 +10,7 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
+        - abushkin-redhat
     version: 2.0.0
 
 description: |-

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -10,6 +10,7 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
+        - abushkin-redhat
     version: 2.0.0
 
 description: |-

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -10,11 +10,11 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.9.0
+    version: 2.0.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V1.9.0.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V2.0.0.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
@@ -24,4 +24,4 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-1-9
+extends: cis-2-0


### PR DESCRIPTION
#### Description:

- Add CIS Red Hat OpenShift Container Platform 4 Benchmark **v2.0.0** content and profiles,
  and deprecate v1.9.0.
- Overall nature of the change: Primarily cosmetic, mainly a reference update moving from v1.9 to v2.0.

**Structural changes**
- New control: `controls/cis_ocp_200.yml` + `controls/cis_ocp_200/section-*.yml`.
- New profiles: `products/ocp4/profiles/cis-2-0.profile` (platform) and `cis-node-2-0.profile` (node), selecting `cis_ocp_200:all`.
- Deprecated v1.9.0 profiles (`cis-1-9` / `cis-node-1-9`) via `status: deprecated` — still shipped for users pinned to that version.
- Moved the `cis` reference ownership to the current version: dropped `reference_type: cis` from `controls/cis_ocp_190.yml` (now deprecated) so only `controls/cis_ocp_200.yml` carries it. Two active control files sharing a reference type would double-list every rule's control reference; this matches the existing precedent where the superseded `cis_ocp` (1.7.0) control carries no `reference_type`.
- Removed the previously-deprecated v1.7.0 profiles (`cis-1-7` / `cis-node-1-7`) per the ticket's acceptance criteria (older deprecated profiles are dropped when a new version lands). Nothing referenced these profiles (no tests, no data). Note: the `controls/cis_ocp` (1.7.0) control file is **intentionally retained** — it is not orphaned; the PCI-DSS 4.0 profile depends on it via `cis_ocp:all:level_2` in `controls/pcidss_4_ocp4.yml`. Only the profiles are removed.
- Repointed the unversioned "latest" profiles (`cis` / `cis-node`) to extend the new v2.0.0 profiles.
- Updated `Dockerfiles/compliance-operator-content-konflux.Containerfile`: added the new v2.0.0 pair (`cis-2-0` / `cis-node-2-0`) to the shipped `documentation_complete` list and removed the v1.7.0 pair (the deprecated v1.9.0 pair stays, as it did while it was current).

**Rule-level changes** (0)
- None — no rule content changed for our profiles.

**Control-file title updates** (1)
- `1.1.10` (`controls/cis_ocp_200/section-1.yml`): "Ensure that the Container Network Interface file ownership is set to root:root" → "Ensure that the Container Network Interface file ownership is set to openvswitch:openvswitch"

**Recommendation scope**
- No renumbering: recommendation numbers are unchanged between v1.9.0 and v2.0.0.


#### Rationale:

- CIS Red Hat OpenShift Container Platform 4 Benchmark v2.0.0 was released August 1st, 2026.
- CMP-4654 — https://issues.redhat.com/browse/CMP-4654
