### PR TITLE
Only enable oval for check_ufw_active for debian

### DIFF
--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("Verify ufw is active", rule_title=rule_title) }}}
+    {{{ oval_metadata("Verify ufw is active", affected_platforms=["multi_platform_debian"], rule_title=rule_title) }}}
     <criteria>
       <criterion comment="ufw is enabled in /etc/ufw/ufw.conf"
         test_ref="{{{ rule_id }}}_test_ufw_enabled" />


### PR DESCRIPTION
#### Description:

- Only enable oval for check_ufw_active for debian.


#### Rationale:

- ubuntu stig doesn't check conf, it's runtime-only check. So #14773 is irrelevant to Ubuntu

cc @israel-villar

