### PR TITLE
Fix chronyd_specify_remote_server remediation

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
@@ -8,4 +8,4 @@ if [[ ! -f $config_file ]]; then
     touch "$config_file"
 fi
 
-{{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") | indent(2) }}}
+{{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
@@ -4,6 +4,8 @@
 
 config_file="{{{ chrony_conf_path }}}"
 
-if ! grep -q '^[[:space:]]*\(server\|pool\)[[:space:]]\+[[:graph:]]\+' "$config_file" ; then
-  {{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") | indent(2) }}}
+if [[ ! -f $config_file ]]; then
+    touch "$config_file"
 fi
+
+{{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") | indent(2) }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/confdir.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/confdir.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
 
 # Test: server directive in confdir .conf file
 CONF_DIR="/etc/chrony/conf.d"

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/escape_dot.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/escape_dot.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = chrony
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# variables = var_multiple_time_servers=0.pool.ntp.org,1.pool.ntp.org
+
+rm -rf /etc/chrony/conf.d
+rm -rf /etc/chrony/sources.d
+
+echo "server 0xpool-ntp-org" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/escape_dot.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/escape_dot.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # variables = var_multiple_time_servers=0.pool.ntp.org,1.pool.ntp.org
 
 rm -rf /etc/chrony/conf.d

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_sourcedir.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_sourcedir.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
 
 # Test: Multiple sourcedir declarations, server in second directory
 SOURCES_DIR1="/etc/chrony/sources1.d"

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/sourcedir.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/sourcedir.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
 
 # Test: server directive in sourcedir .sources file
 SOURCES_DIR="/etc/chrony/sources.d"

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -743,7 +743,8 @@ fi
 {{%- macro bash_ensure_there_are_servers_in_ntp_compatible_config_file(config_file, servers_list) -%}}
 IFS="," read -a SERVERS <<< {{{ servers_list }}}
 for server in "${SERVERS[@]}" ; do
-    if ! grep -q "^[[:space:]]*server[[:space:]]\+${server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then
+    escaped_server="${server//./\\.}"
+    if ! grep -q "^[[:space:]]*server[[:space:]]\+${escaped_server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then
         printf '\nserver %s' "$server" >> "{{{ config_file }}}"
     fi
 done

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -742,6 +742,21 @@ fi
 #}}
 {{%- macro bash_ensure_there_are_servers_in_ntp_compatible_config_file(config_file, servers_list) -%}}
 IFS="," read -r -a SERVERS <<< "{{{ servers_list }}}"
+
+valid_pattern=""
+for server in "${SERVERS[@]}"; do
+    escaped_server="${server//./\\.}"
+    if [ -z "$valid_pattern" ]; then
+        valid_pattern="${escaped_server}"
+    else
+        valid_pattern="${valid_pattern}|${escaped_server}"
+    fi
+done
+
+if [ -n "$valid_pattern" ]; then
+    sed -i -E "/^[[:space:]]*server[[:space:]]/ { /^[[:space:]]*server[[:space:]]+(${valid_pattern})([[:space:]]|$)/! s/^[[:space:]]*server/# server/ }" "{{{ config_file }}}"
+fi
+
 for server in "${SERVERS[@]}" ; do
     escaped_server="${server//./\\.}"
     if ! grep -q "^[[:space:]]*server[[:space:]]\+${escaped_server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -741,13 +741,12 @@ fi
 
 #}}
 {{%- macro bash_ensure_there_are_servers_in_ntp_compatible_config_file(config_file, servers_list) -%}}
-if ! grep -q '#[[:space:]]*server' "{{{ config_file }}}" ; then
-  for server in $(echo "{{{ servers_list }}}" | tr ',' '\n') ; do
-    printf '\nserver %s' "$server" >> "{{{ config_file }}}"
-  done
-else
-  sed -i 's/#[ \t]*server/server/g' "{{{ config_file }}}"
-fi
+IFS="," read -a SERVERS <<< {{{ servers_list }}}
+for server in "${SERVERS[@]}" ; do
+    if ! grep -qs "^[[:space:]]*server[[:space:]]\+${server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then
+        printf '\nserver %s' "$server" >> "{{{ config_file }}}"
+    fi
+done
 {{{ bash_ensure_nl_at_eof(config_file) }}}
 {{%- endmacro -%}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -743,7 +743,7 @@ fi
 {{%- macro bash_ensure_there_are_servers_in_ntp_compatible_config_file(config_file, servers_list) -%}}
 IFS="," read -a SERVERS <<< {{{ servers_list }}}
 for server in "${SERVERS[@]}" ; do
-    if ! grep -qs "^[[:space:]]*server[[:space:]]\+${server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then
+    if ! grep -q "^[[:space:]]*server[[:space:]]\+${server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then
         printf '\nserver %s' "$server" >> "{{{ config_file }}}"
     fi
 done

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -741,7 +741,7 @@ fi
 
 #}}
 {{%- macro bash_ensure_there_are_servers_in_ntp_compatible_config_file(config_file, servers_list) -%}}
-IFS="," read -a SERVERS <<< {{{ servers_list }}}
+IFS="," read -r -a SERVERS <<< "{{{ servers_list }}}"
 for server in "${SERVERS[@]}" ; do
     escaped_server="${server//./\\.}"
     if ! grep -q "^[[:space:]]*server[[:space:]]\+${escaped_server}\([[:space:]]\|$\)" "{{{ config_file }}}" ; then


### PR DESCRIPTION
#### Description:

- Move the logic of checking existance inside for loop for bash_ensure_there_are_servers_in_ntp_compatible_config_file
- Change the primary remediation logic to append if not exist
- Skip chronyd conf dir tests on Ubuntu

#### Rationale:

- Current remediation logic is "if `server|pool [[:graph:]]+` not exists: run the macro, else: do nothing.
- The macro logic is also weird: "if `# server` doesn't exist: append urls, else uncomment those lines. Its regex only matching `#[[:space:]]*server` instead of targeting server like `#\s*server\s+0.pool.ntp.org`