### PR TITLE
Change path of rule to realpath as per stig

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/ansible/shared.yml
@@ -4,5 +4,5 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_audit_augenrules_add_watch_rule(path='/sbin/fdisk', permissions='x', key='modules', rule_title=rule_title) }}}
-{{{ ansible_audit_auditctl_add_watch_rule(path='/sbin/fdisk', permissions='x', key='modules', rule_title=rule_title) }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/usr/sbin/fdisk', permissions='x', key='modules', rule_title=rule_title) }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/usr/sbin/fdisk', permissions='x', key='modules', rule_title=rule_title) }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_ubuntu
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-{{{ bash_fix_audit_watch_rule("auditctl", "/sbin/fdisk", "x", "modules") }}}
-{{{ bash_fix_audit_watch_rule("augenrules", "/sbin/fdisk", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/usr/sbin/fdisk", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/usr/sbin/fdisk", "x", "modules") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/oval/shared.xml
@@ -23,7 +23,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_fdisk_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x([\s]+-k[\s]+[\S]+)?[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/sbin/fdisk[\s]+-p[\s]+x([\s]+-k[\s]+[\S]+)?[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -32,7 +32,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_fdisk_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x([\s]+-k[\s]+[\S]+)?[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/sbin/fdisk[\s]+-p[\s]+x([\s]+-k[\s]+[\S]+)?[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
@@ -27,7 +27,7 @@ ocil: |-
     following command:
 
     <pre>$ sudo auditctl -l | grep fdisk
-    -w /sbin/fdisk -p x -k fdisk </pre>
+    -w /usr/sbin/fdisk -p x -k fdisk </pre>
 
     If the command does not return a line, or the line is commented out, this
     is a finding.


### PR DESCRIPTION
#### Description:

- Change path of rule to realpath as per stig

#### Rationale:

- auditctl skips symlink's real target
- stig benchmark says:
```
$ sudo auditctl -l | grep fdisk
-w /usr/sbin/fdisk -p x -k fdisk
```