### PR TITLE
Fix chronyd_server_directive

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_server_directive/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/oval/shared.xml
@@ -29,7 +29,7 @@
   <ind:textfilecontent54_object comment="Matches pool entries in Chrony conf files"
   id="object_chronyd_no_pool_directive" version="1">
     <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]+pool.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*pool.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/mixed.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/mixed.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = chrony
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+
+echo "pool 0.pool.ntp.org" > {{{ chrony_conf_path }}}
+echo "server 0.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/mixed.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/mixed.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # packages = chrony
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# remediation = none
 
 echo "pool 0.pool.ntp.org" > {{{ chrony_conf_path }}}
 echo "server 0.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/multiple_servers.pass.sh
@@ -2,6 +2,6 @@
 # packages = chrony
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
-sed -i "^pool.*" {{{ chrony_conf_path }}}
+sed -i '/^pool.*/d' {{{ chrony_conf_path }}}
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}
 echo "server 1.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_pool.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_pool.fail.sh
@@ -3,7 +3,7 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # remediation = none
 
-sed -i "^server.*" {{{ chrony_conf_path }}}
+sed -i '/^server.*/d' {{{ chrony_conf_path }}}
 if ! grep "^pool.*" {{{ chrony_conf_path }}}; then
     echo "pool 0.pool.ntp.org" > {{{ chrony_conf_path }}}
 fi

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_server.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_server.pass.sh
@@ -2,5 +2,5 @@
 # packages = chrony
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
-sed -i "^pool.*" {{{ chrony_conf_path }}}
+sed -i '/^pool.*/d' {{{ chrony_conf_path }}}
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}


### PR DESCRIPTION
#### Description:

- Fix sed in chronyd_server_directive tests/
- Add mixed pool and server entries test case for chronyd_server_directive
- Fix oval regex

#### Rationale:

- sed contains a syntax error
- Only entries starting with `\s*server` is allowed