### PR TITLE
Fix wireless_disable_interface remediations to work multiple interfaces

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/ubuntu.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/ubuntu.yml
@@ -10,6 +10,7 @@
     file_type: directory
     patterns: "wireless"
     recurse: yes
+    follow: true
   register: wireless_paths
 
 - name: "{{{ rule_title }}} - Extract interface names from directory paths"

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
@@ -8,7 +8,7 @@ fi
 
 if command -v wicked >/dev/null 2>&1 && systemctl is-active wickedd >/dev/null 2>&1; then
   if [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
-    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless | xargs -0 dirname | xargs basename)
+    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless -print0 | xargs -0 dirname | xargs basename)
     for iface in $interfaces; do
       wicked ifdown $iface
       sed -i 's/STARTMODE=.*/STARTMODE=off/' /etc/sysconfig/network/ifcfg-$iface

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
@@ -8,7 +8,7 @@ fi
 
 if command -v wicked >/dev/null 2>&1 && systemctl is-active wickedd >/dev/null 2>&1; then
   if [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
-    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless -print0 | xargs -0 dirname | xargs basename)
+    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless -print0 | xargs -0 -n1 dirname | xargs -n1 basename)
     for iface in $interfaces; do
       wicked ifdown $iface
       sed -i 's/STARTMODE=.*/STARTMODE=off/' /etc/sysconfig/network/ifcfg-$iface

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/ubuntu.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/ubuntu.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_ubuntu
 
 if [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
-    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless | xargs -0 dirname | xargs basename)
+    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless -print0 | xargs -0 dirname | xargs basename)
 
     for i in $interfaces; do
         ip link set dev "$i" down


### PR DESCRIPTION
#### Description:

- Fix find to work with xargs -0
- Follow symlink in ansible

#### Rationale:

- The bash remediation mis-parses the interface list when more than one wireless interface is present, because it pipes newline-separated find output into xargs -0.
- The paths defined there are symlinks