### PR TITLE
Fix offline privileged-command enumeration in remediation for `audit_rules_privileged_commands`

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -10,7 +10,7 @@
 
 - name: {{{ rule_title }}} - Search for Privileged Commands in Eligible Mount Points
   ansible.builtin.shell:
-    cmd: find {{ item }} -xdev -perm /6000 -type f 2>/dev/null
+    cmd: find {{ item }} -xdev -perm /6000 -type f -not -path "/var/tmp/dracut*" 2>/dev/null
   register: result_privileged_commands_search
   changed_when: false
   failed_when: false
@@ -21,6 +21,22 @@
     privileged_commands: "{{ privileged_commands | default([]) + item.stdout_lines }}"
   loop: "{{ result_privileged_commands_search.results }}"
   when: item is not skipped
+
+- name: {{{ rule_title }}} - Fallback search when mount enumeration found nothing
+  ansible.builtin.shell:
+    cmd: find / -xdev -perm /6000 -type f -not -path "/sysroot/*" -not -path "/var/tmp/dracut*" 2>/dev/null
+  register: result_privileged_commands_fallback
+  changed_when: false
+  failed_when: false
+  when: privileged_commands | default([]) | length == 0
+
+- name: {{{ rule_title }}} - Use fallback privileged command list
+  ansible.builtin.set_fact:
+    privileged_commands: "{{ result_privileged_commands_fallback.stdout_lines }}"
+  when:
+    - privileged_commands | default([]) | length == 0
+    - result_privileged_commands_fallback.stdout is defined
+    - result_privileged_commands_fallback.stdout | trim | length > 0
 
 {{% if product in ["fedora", "rhel10"] %}}
 - name: {{{ rule_title }}} - Set architecture for audit {{{ PATH }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
@@ -30,18 +30,27 @@ function add_audit_rule()
 
 }
 
+PRIV_CMD_DRACUT_EXCLUSION=(-not -path "/var/tmp/dracut*")
+PRIV_CMD_SYSROOT_EXCLUSION=(-not -path "/sysroot/*")
+
 if {{{ bash_bootc_build() }}} ; then
-  PRIV_CMDS=$(find / -perm /6000 -type f -not -path "/sysroot/*" 2>/dev/null)
-  for PRIV_CMD in $PRIV_CMDS; do
-    add_audit_rule $PRIV_CMD
-  done
+  priv_cmds=$(find / -xdev -perm /6000 -type f \
+    "${PRIV_CMD_SYSROOT_EXCLUSION[@]}" "${PRIV_CMD_DRACUT_EXCLUSION[@]}" 2>/dev/null)
 else
+  priv_cmds=""
   FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
   PARTITIONS=$(findmnt -n -l -k -it "$FILTER_NODEV" | grep -Pv "noexec|nosuid|/proc($|/.*$)" | awk '{ print $1 }')
   for PARTITION in $PARTITIONS; do
-    PRIV_CMDS=$(find "${PARTITION}" -xdev -perm /6000 -type f 2>/dev/null)
-    for PRIV_CMD in $PRIV_CMDS; do
-      add_audit_rule $PRIV_CMD
-    done
+    priv_cmds+=$'\n'"$(find "${PARTITION}" -xdev -perm /6000 -type f \
+      "${PRIV_CMD_DRACUT_EXCLUSION[@]}" 2>/dev/null)"
   done
+  # Offline/image-build fallback: the live mount table isn't the image's.
+  if [ -z "$(printf '%s' "$priv_cmds" | tr -d '[:space:]')" ]; then
+    priv_cmds=$(find / -xdev -perm /6000 -type f \
+      "${PRIV_CMD_SYSROOT_EXCLUSION[@]}" "${PRIV_CMD_DRACUT_EXCLUSION[@]}" 2>/dev/null)
+  fi
 fi
+
+for PRIV_CMD in $priv_cmds; do
+  [ -n "$PRIV_CMD" ] && add_audit_rule "$PRIV_CMD"
+done

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_offline_enumeration_fallback.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_offline_enumeration_fallback.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = audit
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+
+# Create a known setuid file that offline/fallback enumeration would discover.
+mkdir -p /usr/local/bin
+touch /usr/local/bin/test_priv_cmd
+chmod 4755 /usr/local/bin/test_priv_cmd
+
+# Generate rules using the same enumeration logic as remediation.
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules parity

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -3,7 +3,30 @@
 AUID=$1
 KEY=$2
 RULEPATH=$3
-for file in $(find / -not \( -fstype afs -o -fstype autofs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null); do
+MODE=${4:-}
+
+mkdir -p "$(dirname "$RULEPATH")"
+: > "$RULEPATH"
+
+if [ "$MODE" = "parity" ]; then
+    PRIV_CMD_DRACUT_EXCLUSION=(-not -path "/var/tmp/dracut*")
+    PRIV_CMD_SYSROOT_EXCLUSION=(-not -path "/sysroot/*")
+    PRIV_CMDS=""
+    FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+    PARTITIONS=$(findmnt -n -l -k -it "$FILTER_NODEV" | grep -Pv "noexec|nosuid|/proc($|/.*$)" | awk '{ print $1 }')
+    for PARTITION in $PARTITIONS; do
+        PRIV_CMDS+=$'\n'"$(find "${PARTITION}" -xdev -perm /6000 -type f \
+          "${PRIV_CMD_DRACUT_EXCLUSION[@]}" 2>/dev/null)"
+    done
+    if [ -z "$(printf '%s' "$PRIV_CMDS" | tr -d '[:space:]')" ]; then
+        PRIV_CMDS=$(find / -xdev -perm /6000 -type f \
+          "${PRIV_CMD_SYSROOT_EXCLUSION[@]}" "${PRIV_CMD_DRACUT_EXCLUSION[@]}" 2>/dev/null)
+    fi
+else
+    PRIV_CMDS=$(find / -not \( -fstype afs -o -fstype autofs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null)
+fi
+
+for file in $PRIV_CMDS; do
 {{% if product in ["fedora", "rhel10"] %}}
     [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
     for ARCH in "${RULE_ARCHS[@]}" ; do


### PR DESCRIPTION

#### Description:

Fall back to a tree scan when mount enumeration finds nothing during image builds, and align bash/ansible find exclusions with OVAL so generated audit rules match runtime checks.


#### Rationale:

Fixes #11565 
Fixes RHEL-220836
