### PR TITLE
CMP-4337: Fix OVS file group-owner rules for ppc64le architecture

### DIFF
--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -19,7 +19,7 @@ severity: medium
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/origin/openvswitch/.*", group="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_hugetlbfs/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_hugetlbfs/rule.yml
@@ -1,12 +1,12 @@
 documentation_complete: true
 
-platform: ocp4-node and x86_64_arch
+platform: ocp4-node and (x86_64_arch or ppc64le_arch)
 
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database is hugetlbfs'
 
 description: |-
     Check if the group owner of <code>/etc/openvswitch/conf.db</code> is
-    <code>hugetlbfs</code> for <code>x86_64</code>.
+    <code>hugetlbfs</code> for <code>x86_64</code> and <code>ppc64le</code>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_hugetlbfs/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_hugetlbfs/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: ocp4-node and x86_64_arch
+platform: ocp4-node and (x86_64_arch or ppc64le_arch)
 
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock is hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_hugetlbfs/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_hugetlbfs/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: ocp4-node and x86_64_arch
+platform: ocp4-node and (x86_64_arch or ppc64le_arch)
 
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID is hugetlbfs'
 


### PR DESCRIPTION
## Description

Adds `ppc64le` architecture support to the OpenVSwitch (OVS) hugetlbfs group-owner rules used by CIS OpenShift control **1.1.10**, and fixes an OCIL file-path typo.

On RHCOS the group ownership of files under `/etc/openvswitch` is architecture-dependent:
- **x86_64** and **ppc64le** → group `hugetlbfs` (DPDK / hugepages)
- **aarch64** and **s390x** → group `openvswitch`

The hugetlbfs OVS group-owner rules were gated to `x86_64_arch` only, so on ppc64le nodes neither the `hugetlbfs` nor the `openvswitch` group-owner variant was applicable — leaving a coverage gap for 1.1.10. This adds
`ppc64le_arch` to the platform expression of the three hugetlbfs rules:

- `file_groupowner_ovs_conf_db_hugetlbfs`
- `file_groupowner_ovs_conf_db_lock_hugetlbfs`
- `file_groupowner_ovs_sys_id_conf_hugetlbfs`

x86_64 behaviour is unchanged; aarch64/s390x continue to use the `_openvswitch` variants.

Also corrects an OCIL file-path typo in `file_groupowner_openvswitch` (`/etc/origin/openvswitch` → `/etc/openvswitch`).

## Rationale

Cross-architecture verification on all four supported OCP architectures confirmed OVS files are owned by `openvswitch` (uid 800) with group `hugetlbfs` on x86_64/ppc64le and `openvswitch` on aarch64/s390x, enforced
by systemd (`ovsdb-server.service` / `ovs-vswitchd.service`) on every boot.

## Note for reviewers

The three generic OVS rules `file_owner_openvswitch`, `file_groupowner_openvswitch`, and `file_permissions_openvswitch` are **not selected by any profile or control** (effectively dead) and assume
`root:root`, which does not match actual OVS ownership. They are left in place here (only the OCIL typo is fixed), but could be removed...
