### PR TITLE
Allow file_ownership_var_log_audit_stig to check effective log files

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 
 - name: "{{{ rule_title }}} - Get audit log file from /etc/audit/auditd.conf"
-  ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
+  ansible.builtin.command: grep -iE '^[[:space:]]*log_file\b' /etc/audit/auditd.conf
   check_mode: False
   failed_when: false
   changed_when: false

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/bash/shared.sh
@@ -1,8 +1,8 @@
 # platform = multi_platform_all
 
-if LC_ALL=C grep -iw log_file /etc/audit/auditd.conf; then
-    FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
-    chown root $FILE*
-else
-    chown root /var/log/audit/audit.log*
+if LC_ALL=C grep -iqE '^[[:space:]]*log_file\b' /etc/audit/auditd.conf; then
+    FILE=$(awk -F "=" '/^[[:space:]]*log_file[[:space:]]*=/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
 fi
+
+FILE=${FILE:-/var/log/audit/audit.log}
+chown root "$(dirname "$FILE")"/*

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/oval/shared.xml
@@ -6,7 +6,7 @@
         <extend_definition comment="log_file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criterion comment="audit log files are root owned" test_ref="test_user_ownership_audit_log_files" />
       </criteria>
-      {{% if "ol" in families or "rhel" in product %}}
+      {{% if "ol" in families or "rhel" in product or "ubuntu" in product %}}
       <criteria operator="AND" comment="log_file not set">
         <extend_definition comment="log_file not set in auditd.conf"
           definition_ref="auditd_conf_log_file_not_set"/>
@@ -18,17 +18,31 @@
       {{% endif %}}
     </criteria>
   </definition>
-  
+
   <unix:file_test check="all" check_existence="none_exist" comment="audit log files uid root" id="test_user_ownership_audit_log_files" version="1">
     <unix:object object_ref="object_user_ownership_audit_log_files" />
   </unix:file_test>
 
   <unix:file_object comment="audit log files" id="object_user_ownership_audit_log_files" version="1">
+    {{% if "ubuntu" in product %}}
+    <unix:filepath operation="pattern match" var_ref="audit_log_file_path_regex" />
+    {{% else %}}
     <unix:filepath operation="pattern match" var_ref="audit_log_file_path" />
+    {{% endif %}}
     <filter action="include">state_owner_not_root_var_log_audit</filter>
   </unix:file_object>
-  
-  {{% if "ol" in families or "rhel" in product %}}
+
+    <local_variable id="audit_log_file_path_regex" datatype="string" version="1" comment="regex matching base audit log path and rotated files">
+    <concat>
+        <literal_component>^</literal_component>
+        <escape_regex>
+        <variable_component var_ref="audit_log_file_path" />
+        </escape_regex>
+        <literal_component>.*$</literal_component>
+    </concat>
+    </local_variable>
+
+  {{% if "ol" in families or "rhel" in product or "ubuntu" in product %}}
   <unix:file_test check="all" check_existence="none_exist"
       comment="var/log/audit/audit.log file uid root"
       id="test_user_ownership_audit_default_log_files" version="1">
@@ -37,7 +51,12 @@
 
   <unix:file_object comment="audit log files" id="object_user_ownership_audit_default_log_files"
       version="1">
+    {{% if "ol" in families or "rhel" in product %}}
     <unix:filepath operation="equals">/var/log/audit/audit.log</unix:filepath>
+    {{% else %}}
+    <unix:path>/var/log/audit</unix:path>
+    <unix:filename operation="pattern match">^audit\.log.*$</unix:filename>
+    {{% endif %}}
     <filter action="include">state_owner_not_root_var_log_audit</filter>
   </unix:file_object>
   {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
@@ -4,17 +4,11 @@
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_file = /var/log/audit/audit2.log" >> /etc/audit/auditd.conf
 
-if LC_ALL=C grep -iqE '^[[:space:]]*log_file\b' /etc/audit/auditd.conf; then
-    FILE=$(awk -F "=" '/^[[:space:]]*log_file[[:space:]]*=/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
-fi
-
-FILE=${FILE:-/var/log/audit/audit.log}
-
 useradd testuser_123
-touch "/var/log/audit/audit2.log"
-touch "/var/log/audit/audit.log"
+mkdir -p /var/log/audit
+touch /var/log/audit/audit2.log
+touch /var/log/audit/audit2.log.1
+touch /var/log/audit/audit.log
 
-for f in $FILE; do
-    chown root "${f}"*
-done
-chown testuser_123 "/var/log/audit/audit.log"
+chown root /var/log/audit/audit2.log*
+chown testuser_123 /var/log/audit/audit.log

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
@@ -4,15 +4,17 @@
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_file = /var/log/audit/audit2.log" >> /etc/audit/auditd.conf
 
-if grep -iwq "log_file" /etc/audit/auditd.conf; then
-    FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
-else
-    FILE="/var/log/audit/audit.log"
+if LC_ALL=C grep -iqE '^[[:space:]]*log_file\b' /etc/audit/auditd.conf; then
+    FILE=$(awk -F "=" '/^[[:space:]]*log_file[[:space:]]*=/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
 fi
+
+FILE=${FILE:-/var/log/audit/audit.log}
 
 useradd testuser_123
 touch "/var/log/audit/audit2.log"
 touch "/var/log/audit/audit.log"
 
-chown root $FILE*
+for f in $FILE; do
+    chown root "${f}"*
+done
 chown testuser_123 "/var/log/audit/audit.log"

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # packages = audit
 
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
@@ -3,8 +3,12 @@
 # packages = audit
 
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
+
 useradd testuser_123
+mkdir -p /var/log/audit
+touch /var/log/audit/audit.log
+touch /var/log/audit/audit.log.1
 touch "/var/log/audit/audit2.log"
 
-chown root "/var/log/audit/audit.log"
-chown testuser_123 "/var/log/audit/audit2.log"
+chown root /var/log/audit/audit.log*
+chown testuser_123 /var/log/audit/audit2.log

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # packages = audit
 
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
@@ -4,25 +4,17 @@
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_file = /var/log/audit/audit2.log" >> /etc/audit/auditd.conf
 
-if LC_ALL=C grep -iqE '^[[:space:]]*log_file\b' /etc/audit/auditd.conf; then
-    FILE=$(awk -F "=" '/^[[:space:]]*log_file[[:space:]]*=/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
-fi
-
-FILE=${FILE:-/var/log/audit/audit.log}
+FILE="/var/log/audit/audit2.log"
 
 useradd testuser_123
+mkdir -p /var/log/audit
 
 touch "/var/log/audit/audit.log"
 chown root "/var/log/audit/audit.log"
 
-{{% if product in ["ol8", "rhel8"] %}}
-for f in $FILE; do
-    touch "$f"
-    chown testuser_123 "$f"
-done
-{{% else %}}
-for f in $FILE; do
-    touch "${f}.1"
-    chown testuser_123 "${f}.1"
-done
+touch "$FILE"
+chown testuser_123 "$FILE"
+{{% if product not in ["ol8", "rhel8"] %}}
+touch "$FILE.1"
+chown testuser_123 "$FILE.1"
 {{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
@@ -4,11 +4,11 @@
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_file = /var/log/audit/audit2.log" >> /etc/audit/auditd.conf
 
-if grep -iwq "log_file" /etc/audit/auditd.conf; then
-    FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
-else
-    FILE="/var/log/audit/audit.log"
+if LC_ALL=C grep -iqE '^[[:space:]]*log_file\b' /etc/audit/auditd.conf; then
+    FILE=$(awk -F "=" '/^[[:space:]]*log_file[[:space:]]*=/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
 fi
+
+FILE=${FILE:-/var/log/audit/audit.log}
 
 useradd testuser_123
 
@@ -16,9 +16,13 @@ touch "/var/log/audit/audit.log"
 chown root "/var/log/audit/audit.log"
 
 {{% if product in ["ol8", "rhel8"] %}}
-touch $FILE
-chown testuser_123 $FILE
+for f in $FILE; do
+    touch "$f"
+    chown testuser_123 "$f"
+done
 {{% else %}}
-touch $FILE.1
-chown testuser_123 $FILE.1
+for f in $FILE; do
+    touch "${f}.1"
+    chown testuser_123 "${f}.1"
+done
 {{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
@@ -3,7 +3,9 @@
 # packages = audit
 
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
+
 useradd testuser_123
+mkdir -p /var/log/audit
 touch "/var/log/audit/audit2.log"
 touch "/var/log/audit/audit.log"
 

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # packages = audit
 
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf

--- a/shared/checks/oval/auditd_conf_log_file_not_set.xml
+++ b/shared/checks/oval/auditd_conf_log_file_not_set.xml
@@ -20,12 +20,12 @@
 
   <ind:textfilecontent54_object id="object_auditd_conf_log_file" version="1">
     <ind:filepath operation="equals">/etc/audit/auditd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^(log_file\s*=\s*.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*(log_file\s*=\s*.*)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <local_variable id="audit_log_file_path" datatype="string" version="1" comment="path to audit log files">
-    <regex_capture pattern="^log_file\s*=\s*(.*)">
+    <regex_capture pattern="^\s*log_file\s*=\s*(.*)">
       <object_component item_field="subexpression" object_ref="object_auditd_conf_log_file" />
     </regex_capture>
   </local_variable>


### PR DESCRIPTION
#### Description:

- Allow space-starting entries in audit.conf
- Check effective log file in oval for Ubuntu
- Simplfy test scripts
- Enable test scripts for ubuntu

#### Rationale:

- Test result on Ubuntu
```
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/alan.moore@canonical.com/dev/cac/content/logs/rule-custom-2026-09-10-1652/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_file_ownership_var_log_audit_stig
INFO - Script correct_value_default_file.pass.sh using profile (all) OK
INFO - Script wrong_value_default_file.fail.sh using profile (all) OK
INFO - Script correct_value.pass.sh using profile (all) OK
INFO - Script wrong_value.fail.sh using profile (all) OK
```