### PR TITLE
Fix /etc/gshadow- group owner expectation on Debian 13

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -47,5 +47,6 @@ template:
         gid_or_name: '0'
         gid_or_name@debian11: '42'
         gid_or_name@debian12: '42'
+        gid_or_name@debian13: '42'
         gid_or_name@ubuntu2204: '42'
         gid_or_name@ubuntu2404: shadow


### PR DESCRIPTION
#### Description:

- `file_groupowner_backup_etc_gshadow` sets `gid_or_name@debian11`,  `@debian12` and `@ubuntu2204` to `42` (group `shadow`), but there is no `@debian13` override.
- Add `gid_or_name@debian13: '42'`.

#### Rationale:

- Without the override, Debian 13 falls back to the default `gid_or_name: '0'` and the rule expects group `root`.
- Debian keeps `/etc/gshadow-` as `root:shadow` (gid 42), the same as `/etc/gshadow` and `/etc/shadow-`, so the rule fails on a correctly configured Debian 13 system.
- `file_groupowner_backup_etc_shadow` already has the `@debian13` override; this brings `gshadow-` in line.

#### Review Hints:

- One-line change.
- `./build_product debian13 --datastream` and `ctest` pass; the generated OVAL now checks gid `42`.
